### PR TITLE
fix(opencode-plugin): close TOCTOU race in deliverPendingToIdle

### DIFF
--- a/src/opencode_plugin/hcom.ts
+++ b/src/opencode_plugin/hcom.ts
@@ -84,8 +84,7 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
   //     next wake event.
   //   pendingAckId — set after messages are read, cleared by transform.
   //     Prevents re-delivery while a prior injection is still being processed.
-  //     If promptAsync throws synchronously after pendingAckId is set, the id
-  //     remains until the next transform fires or the session resets.
+  //     If promptAsync fails to queue, pendingAckId is cleared immediately.
   async function deliverPendingToIdle(sid: string): Promise<boolean> {
     if (permissionPending) {
       log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "permission_pending" })
@@ -125,10 +124,29 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
       // the loop is actually processing the message. This keeps messages
       // unread until delivery is confirmed.
       pendingAckId = maxId
-      client.session.promptAsync({
-        path: { id: sid },
-        body: { parts: [{ type: "text", text: formatted }] },
-      } as any)
+      try {
+        const promptAsyncResult = client.session.promptAsync({
+          path: { id: sid },
+          body: { parts: [{ type: "text", text: formatted }] },
+        } as any)
+        if (promptAsyncResult && typeof (promptAsyncResult as Promise<unknown>).then === "function") {
+          void (promptAsyncResult as Promise<unknown>).catch((e) => {
+            if (pendingAckId === maxId) pendingAckId = null
+            log("ERROR", "plugin.delivery_prompt_failed", instanceName, {
+              error: String(e),
+              pending_ack: maxId,
+            })
+          })
+        }
+      } catch (e) {
+        pendingAckId = null
+        log("ERROR", "plugin.delivery_prompt_failed", instanceName, {
+          error: String(e),
+          pending_ack: maxId,
+          sync_throw: true,
+        })
+        return false
+      }
       log("INFO", "plugin.delivery_pending", instanceName, {
         msg: `promptAsync, ack deferred to transform (maxId=${maxId})`,
         count: rawMessages.length,
@@ -328,6 +346,7 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
             bindingPromise = null
             lastReportedStatus = null
             pendingAckId = null
+            deliveryInFlight = false
             permissionPending = false
             break
           case "file.edited": {

--- a/src/opencode_plugin/hcom.ts
+++ b/src/opencode_plugin/hcom.ts
@@ -34,6 +34,7 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
   let notifyServer: ReturnType<typeof Bun.listen> | null = null  // TCP notify server for instant message wake
   let lastReportedStatus: string | null = null  // Skip redundant status updates
   let pendingAckId: number | null = null        // Deferred ack: set by deliverPendingToIdle, acked by transform
+  let deliveryInFlight = false                  // Delivery guard flag: rejects concurrent callers (not a queuing mutex)
   let permissionPending = false                  // Exact permission gate from OpenCode events
 
   // SAFE-02: Lazy PATH detection on first hook callback
@@ -74,49 +75,69 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
 
   // Deliver pending messages via promptAsync. Ack is deferred to transform
   // (fires on the loop iteration that actually processes the user message).
+  //
+  // Two-layer serialization:
+  //   deliveryInFlight — guard flag set synchronously before the first await.
+  //     Closes the TOCTOU window where TCP notify and idle-status wake paths
+  //     could both pass a null check before either one set the value.
+  //     Concurrent callers are rejected (not queued); they will retry on the
+  //     next wake event.
+  //   pendingAckId — set after messages are read, cleared by transform.
+  //     Prevents re-delivery while a prior injection is still being processed.
+  //     If promptAsync throws synchronously after pendingAckId is set, the id
+  //     remains until the next transform fires or the session resets.
   async function deliverPendingToIdle(sid: string): Promise<boolean> {
     if (permissionPending) {
       log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "permission_pending" })
       return false
     }
     if (!instanceName) return false
+    if (deliveryInFlight) {
+      log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "delivery_in_flight" })
+      return false
+    }
     if (pendingAckId !== null) {
       log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "pending_ack_in_flight", pending_ack: pendingAckId })
       return false
     }
-    const msgResult = await $.nothrow()`hcom opencode-read --name ${instanceName}`.quiet()
-    if (msgResult.exitCode !== 0) {
-      log("WARN", "plugin.delivery_read_failed", instanceName, { exit_code: msgResult.exitCode, stderr: msgResult.stderr.toString().slice(0, 200) })
-      return false
-    }
-    let rawMessages: any[] = []
-    try { rawMessages = JSON.parse(msgResult.text()) } catch (e) {
-      log("WARN", "plugin.delivery_parse_failed", instanceName, { error: String(e), raw: msgResult.text().slice(0, 200) })
-      return false
-    }
-    if (!Array.isArray(rawMessages) || rawMessages.length === 0) {
-      log("DEBUG", "plugin.delivery_no_messages", instanceName)
-      return false
-    }
+    deliveryInFlight = true
+    try {
+      const msgResult = await $.nothrow()`hcom opencode-read --name ${instanceName}`.quiet()
+      if (msgResult.exitCode !== 0) {
+        log("WARN", "plugin.delivery_read_failed", instanceName, { exit_code: msgResult.exitCode, stderr: msgResult.stderr.toString().slice(0, 200) })
+        return false
+      }
+      let rawMessages: any[] = []
+      try { rawMessages = JSON.parse(msgResult.text()) } catch (e) {
+        log("WARN", "plugin.delivery_parse_failed", instanceName, { error: String(e), raw: msgResult.text().slice(0, 200) })
+        return false
+      }
+      if (!Array.isArray(rawMessages) || rawMessages.length === 0) {
+        log("DEBUG", "plugin.delivery_no_messages", instanceName)
+        return false
+      }
 
-    const maxId = Math.max(...rawMessages.map((m: any) => m.event_id || 0))
-    if (maxId === 0) return false
+      const maxId = Math.max(...rawMessages.map((m: any) => m.event_id || 0))
+      if (maxId === 0) return false
 
-    const formatted = formatMessagesForInjection(rawMessages, instanceName)
-    // Don't ack here — defer to transform so cursor advances only when
-    // the loop is actually processing the message. This keeps messages
-    // unread until delivery is confirmed.
-    pendingAckId = maxId
-    client.session.promptAsync({
-      path: { id: sid },
-      body: { parts: [{ type: "text", text: formatted }] },
-    } as any)
-    log("INFO", "plugin.delivery_pending", instanceName, {
-      msg: `promptAsync, ack deferred to transform (maxId=${maxId})`,
-      count: rawMessages.length,
-      pending_ack: maxId,
-    })
-    return true
+      const formatted = formatMessagesForInjection(rawMessages, instanceName)
+      // Don't ack here — defer to transform so cursor advances only when
+      // the loop is actually processing the message. This keeps messages
+      // unread until delivery is confirmed.
+      pendingAckId = maxId
+      client.session.promptAsync({
+        path: { id: sid },
+        body: { parts: [{ type: "text", text: formatted }] },
+      } as any)
+      log("INFO", "plugin.delivery_pending", instanceName, {
+        msg: `promptAsync, ack deferred to transform (maxId=${maxId})`,
+        count: rawMessages.length,
+        pending_ack: maxId,
+      })
+      return true
+    } finally {
+      deliveryInFlight = false
+    }
   }
 
   // Periodic status sync: polls session status API as a retry mechanism


### PR DESCRIPTION
## Summary
This fixes duplicate injected hcom turns in the OpenCode plugin by closing a TOCTOU race in `deliverPendingToIdle()`.

The issue became reproducible under multi-agent orchestration, where wake events happen frequently and near-simultaneously.

## Root cause
`deliverPendingToIdle()` can be entered from two independent wake paths:
- TCP notify wake
- idle-status wake (`session.status` -> `idle`)

Both paths could pass the `pendingAckId === null` check before either caller set it (first `await` boundary), causing duplicate `opencode-read`/`promptAsync` delivery of the same payload.

## Fix
- Add synchronous `deliveryInFlight` guard flag checked/set before the first `await`
- Early-return concurrent callers when a delivery is already running
- Reset guard in `finally`

`pendingAckId` remains in place as the second serialization layer between injection and transform-hook ack.

## Validation
- Reproduced prior duplicate-delivery behavior under frequent wake conditions
- Two-turn injection tests (`FIRST_OK` / `SECOND_OK`) now show single delivery per message
- Real OpenCode usage confirms duplicate turn injection is no longer present
- Repository test suite passes (`cargo test -q`)

## Notes
This PR is intentionally scoped to the delivery race fix only. The agent/model persistence follow-up is prepared as a separate stacked branch/PR.