### PR TITLE
fix(opencode-plugin): persist agent/model context across injected turns

### DIFF
--- a/src/hooks/opencode.rs
+++ b/src/hooks/opencode.rs
@@ -10,8 +10,8 @@ use crate::instance_binding;
 use crate::instance_lifecycle as lifecycle;
 use crate::instances;
 use crate::log::{log_error, log_info};
-use crate::shared::ST_LISTENING;
 use crate::shared::context::HcomContext;
+use crate::shared::ST_LISTENING;
 
 use super::common;
 use super::common::finalize_session;
@@ -27,6 +27,58 @@ fn parse_flag(argv: &[String], flag: &str) -> Option<String> {
 /// Check if a bare flag exists in argv (no value).
 fn has_flag(argv: &[String], flag: &str) -> bool {
     argv.iter().any(|a| a == flag)
+}
+
+/// Extract `--flag value` or `--flag=value` from argv.
+fn parse_value_arg(argv: &[String], flags: &[&str]) -> Option<String> {
+    for (idx, token) in argv.iter().enumerate() {
+        for flag in flags {
+            if token == flag {
+                return argv.get(idx + 1).cloned();
+            }
+            let prefix = format!("{flag}=");
+            if let Some(value) = token.strip_prefix(&prefix) {
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn parse_launch_model(raw: &str) -> Option<Value> {
+    let (provider_id, model_id) = raw.split_once('/')?;
+    if provider_id.is_empty() || model_id.is_empty() {
+        return None;
+    }
+    Some(serde_json::json!({
+        "providerID": provider_id,
+        "modelID": model_id,
+    }))
+}
+
+fn launch_agent_and_model_from_args(launch_args: Option<&str>) -> (Option<String>, Option<Value>) {
+    let Some(raw_args) = launch_args.filter(|value| !value.is_empty()) else {
+        return (None, None);
+    };
+    let argv: Vec<String> = match serde_json::from_str(raw_args) {
+        Ok(args) => args,
+        Err(_) => return (None, None),
+    };
+
+    let agent = parse_value_arg(&argv, &["--agent"]);
+    let model =
+        parse_value_arg(&argv, &["--model", "-m"]).and_then(|value| parse_launch_model(&value));
+    (agent, model)
+}
+
+fn launch_agent_and_model(db: &HcomDb, instance_name: &str) -> (Option<String>, Option<Value>) {
+    db.get_instance_full(instance_name)
+        .ok()
+        .flatten()
+        .map(|instance| launch_agent_and_model_from_args(instance.launch_args.as_deref()))
+        .unwrap_or((None, None))
 }
 
 /// Upsert plugin notify endpoint in DB.
@@ -132,11 +184,18 @@ fn handle_start(ctx: &HcomContext, db: &HcomDb, argv: &[String]) -> (i32, String
             &format!("instance={} session_id={}", existing_name, session_id),
         );
 
+        let (launch_agent, launch_model) = launch_agent_and_model(db, &existing_name);
         let mut result = serde_json::json!({
             "name": existing_name,
             "session_id": session_id,
         });
         result["bootstrap"] = Value::String(bootstrap_text);
+        if let Some(agent) = launch_agent {
+            result["agent"] = Value::String(agent);
+        }
+        if let Some(model) = launch_model {
+            result["model"] = model;
+        }
         return (0, serde_json::to_string(&result).unwrap_or_default());
     }
 
@@ -242,11 +301,18 @@ fn handle_start(ctx: &HcomContext, db: &HcomDb, argv: &[String]) -> (i32, String
     // Auto-spawn relay-worker now that an instance is active
     crate::relay::worker::ensure_worker(true);
 
+    let (launch_agent, launch_model) = launch_agent_and_model(db, &instance_name);
     let mut response = serde_json::json!({
         "name": instance_name,
         "session_id": session_id,
     });
     response["bootstrap"] = Value::String(bootstrap_text);
+    if let Some(agent) = launch_agent {
+        response["agent"] = Value::String(agent);
+    }
+    if let Some(model) = launch_model {
+        response["model"] = model;
+    }
     (0, serde_json::to_string(&response).unwrap_or_default())
 }
 
@@ -689,6 +755,105 @@ mod tests {
         assert!(!has_flag(&argv, "--ack"));
     }
 
+    #[test]
+    fn test_parse_value_arg_supports_split_and_equals_forms() {
+        let split = sv(&["--agent", "reviewer", "-m", "openai/gpt-5.4"]);
+        assert_eq!(
+            parse_value_arg(&split, &["--agent"]),
+            Some("reviewer".to_string())
+        );
+        assert_eq!(
+            parse_value_arg(&split, &["--model", "-m"]),
+            Some("openai/gpt-5.4".to_string())
+        );
+
+        let equals = sv(&["--agent=planner", "--model=anthropic/claude-sonnet-4-6"]);
+        assert_eq!(
+            parse_value_arg(&equals, &["--agent"]),
+            Some("planner".to_string())
+        );
+        assert_eq!(
+            parse_value_arg(&equals, &["--model", "-m"]),
+            Some("anthropic/claude-sonnet-4-6".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_launch_model_validates_provider_and_model() {
+        assert_eq!(
+            parse_launch_model("openai/gpt-5.4"),
+            Some(serde_json::json!({
+                "providerID": "openai",
+                "modelID": "gpt-5.4",
+            }))
+        );
+        assert_eq!(parse_launch_model("openai"), None);
+        assert_eq!(parse_launch_model("/gpt-5.4"), None);
+        assert_eq!(parse_launch_model("openai/"), None);
+    }
+
+    #[test]
+    fn test_launch_agent_and_model_from_args_parses_stored_launch_args() {
+        let launch_args =
+            serde_json::to_string(&sv(&["--agent=planner", "--model", "openai/gpt-5.4"])).unwrap();
+
+        let (agent, model) = launch_agent_and_model_from_args(Some(&launch_args));
+        assert_eq!(agent.as_deref(), Some("planner"));
+        assert_eq!(
+            model,
+            Some(serde_json::json!({
+                "providerID": "openai",
+                "modelID": "gpt-5.4",
+            }))
+        );
+    }
+
+    #[test]
+    fn test_launch_agent_and_model_from_args_supports_short_model_flag() {
+        let launch_args = serde_json::to_string(&sv(&[
+            "--agent",
+            "reviewer",
+            "-m",
+            "anthropic/claude-opus-4",
+        ]))
+        .unwrap();
+
+        let (agent, model) = launch_agent_and_model_from_args(Some(&launch_args));
+        assert_eq!(agent.as_deref(), Some("reviewer"));
+        assert_eq!(
+            model,
+            Some(serde_json::json!({
+                "providerID": "anthropic",
+                "modelID": "claude-opus-4",
+            }))
+        );
+    }
+
+    #[test]
+    fn test_launch_agent_and_model_reads_instance_launch_args() {
+        let (_dir, db) = test_db();
+        let launch_args =
+            serde_json::to_string(&sv(&["--agent", "reviewer", "--model", "openai/gpt-5.4"]))
+                .unwrap();
+        db.conn()
+            .execute(
+                "INSERT INTO instances (name, tool, status, created_at, launch_args)
+                 VALUES (?1, 'opencode', 'active', 0, ?2)",
+                rusqlite::params!["luna", launch_args],
+            )
+            .unwrap();
+
+        let (agent, model) = launch_agent_and_model(&db, "luna");
+        assert_eq!(agent.as_deref(), Some("reviewer"));
+        assert_eq!(
+            model,
+            Some(serde_json::json!({
+                "providerID": "openai",
+                "modelID": "gpt-5.4",
+            }))
+        );
+    }
+
     // ── Plugin management ──
 
     #[test]
@@ -843,6 +1008,52 @@ mod tests {
         let (code, output) = handle_start(&ctx, &db, &argv);
         assert_eq!(code, 0);
         assert!(output.contains("Missing --session-id"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_handle_start_rebind_includes_launch_identity() {
+        crate::config::Config::init();
+        let (_env_dir, hcom_dir, test_home, _guard) =
+            crate::hooks::test_helpers::isolated_test_env();
+        let (_db_dir, db) = test_db();
+        let launch_args =
+            serde_json::to_string(&sv(&["--agent", "reviewer", "--model", "openai/gpt-5.4"]))
+                .unwrap();
+        db.conn()
+            .execute(
+                "INSERT INTO instances (name, tool, status, created_at, launch_args)
+                 VALUES (?1, 'opencode', 'active', 0, ?2)",
+                rusqlite::params!["luna", launch_args],
+            )
+            .unwrap();
+        db.set_session_binding("sess-1", "luna").unwrap();
+
+        let env = std::collections::HashMap::from([
+            (
+                "HCOM_DIR".to_string(),
+                hcom_dir.to_string_lossy().to_string(),
+            ),
+            ("HOME".to_string(), test_home.to_string_lossy().to_string()),
+            ("HCOM_PROCESS_ID".to_string(), "pid-123".to_string()),
+        ]);
+        let ctx = HcomContext::from_env(&env, std::path::PathBuf::from("/tmp"));
+
+        let (code, output) = handle_start(&ctx, &db, &sv(&["--session-id", "sess-1"]));
+        assert_eq!(code, 0);
+
+        let payload: Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(payload["name"], "luna");
+        assert_eq!(payload["session_id"], "sess-1");
+        assert_eq!(payload["agent"], "reviewer");
+        assert_eq!(
+            payload["model"],
+            serde_json::json!({
+                "providerID": "openai",
+                "modelID": "gpt-5.4",
+            })
+        );
+        assert!(payload["bootstrap"].as_str().is_some());
     }
 
     #[test]

--- a/src/opencode_plugin/hcom.ts
+++ b/src/opencode_plugin/hcom.ts
@@ -427,9 +427,17 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
         if (input.sessionID && !instanceName) {
           await bindIdentity(input.sessionID)
         }
-        if (input.agent) currentAgent = input.agent
-        const resolvedModel = normalizePromptModel(input.model)
-        if (resolvedModel) currentModel = resolvedModel
+        const isBoundSession = !input.sessionID || !sessionId || input.sessionID === sessionId
+        if (isBoundSession) {
+          if (input.agent) currentAgent = input.agent
+          const resolvedModel = normalizePromptModel(input.model)
+          if (resolvedModel) currentModel = resolvedModel
+        } else {
+          log("DEBUG", "plugin.chat_message_ignored_foreign_session", instanceName, {
+            session_id: input.sessionID,
+            bound_session_id: sessionId,
+          })
+        }
         log("DEBUG", "plugin.chat_message", instanceName, {
           session_id: input.sessionID,
           agent: input.agent,

--- a/src/opencode_plugin/hcom.ts
+++ b/src/opencode_plugin/hcom.ts
@@ -6,6 +6,42 @@ import { homedir } from "os"
 const HCOM_DIR = process.env.HCOM_DIR || `${homedir()}/.hcom`
 const LOG_PATH = `${HCOM_DIR}/.tmp/logs/hcom.log`
 
+// NOTE: parseCliArgValue / parseCliModelArg always return null in practice.
+// hcom launches OpenCode via a PTY wrapper (launcher.rs); the plugin process
+// inherits the OpenCode binary argv, not the outer `hcom opencode --agent …`
+// invocation. currentAgent / currentModel are seeded to null here and
+// populated correctly by the chat.message hook on the first user turn.
+// Long-term fix: seed from the `opencode-start` hcom response payload.
+function parseCliArgValue(...flags: string[]): string | null {
+  for (let i = 0; i < process.argv.length; i++) {
+    const token = process.argv[i]
+    for (const flag of flags) {
+      if (token === flag) return process.argv[i + 1] ?? null
+      if (token.startsWith(`${flag}=`)) return token.slice(flag.length + 1)
+    }
+  }
+  return null
+}
+
+function parseCliModelArg() {
+  const raw = parseCliArgValue("--model", "-m")
+  if (!raw) return null
+  const slash = raw.indexOf("/")
+  if (slash <= 0 || slash === raw.length - 1) return null
+  return {
+    providerID: raw.slice(0, slash),
+    modelID: raw.slice(slash + 1),
+  }
+}
+
+function normalizePromptModel(model: unknown) {
+  if (!model || typeof model !== "object") return null
+  const providerID = (model as Record<string, unknown>).providerID
+  const modelID = (model as Record<string, unknown>).modelID
+  if (typeof providerID !== "string" || typeof modelID !== "string") return null
+  return { providerID, modelID }
+}
+
 function log(
   level: "DEBUG" | "INFO" | "WARN" | "ERROR",
   event: string,
@@ -31,11 +67,16 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
   let bootstrapText: string | null = null     // BOOT-01: cached from opencode-start
   let bindingPromise: Promise<void> | null = null  // Prevents duplicate binding
   let reconcileTimer: ReturnType<typeof setInterval> | null = null  // Periodic status sync + delivery fallback
+  let reconcileInFlight = false                 // Prevents concurrent reconcile calls from overlapping interval ticks
   let notifyServer: ReturnType<typeof Bun.listen> | null = null  // TCP notify server for instant message wake
   let lastReportedStatus: string | null = null  // Skip redundant status updates
   let pendingAckId: number | null = null        // Deferred ack: set by deliverPendingToIdle, acked by transform
   let deliveryInFlight = false                  // Delivery guard flag: rejects concurrent callers (not a queuing mutex)
   let permissionPending = false                  // Exact permission gate from OpenCode events
+  let launchedAgent: string | null = parseCliArgValue("--agent")
+  let launchedModel: { providerID: string; modelID: string } | null = parseCliModelArg()
+  let currentAgent: string | null = launchedAgent
+  let currentModel: { providerID: string; modelID: string } | null = launchedModel
 
   // SAFE-02: Lazy PATH detection on first hook callback
   function checkHcom(): boolean {
@@ -47,15 +88,6 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
       }
     }
     return hcomAvailable
-  }
-
-  function findLastUserMessage(
-    messages: Array<{ info: { id: string; sessionID: string; role: string }; parts: any[] }>
-  ) {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].info.role === "user") return messages[i]
-    }
-    return null
   }
 
   function formatMessagesForInjection(messages: any[], recipientName: string): string {
@@ -124,11 +156,22 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
       // the loop is actually processing the message. This keeps messages
       // unread until delivery is confirmed.
       pendingAckId = maxId
+      log("DEBUG", "plugin.delivery_payload", instanceName, {
+        session_id: sid,
+        current_agent: currentAgent,
+        current_model: currentModel?.modelID ?? null,
+      })
       try {
+        // Runtime contract note: OpenCode accepts agent/model in async prompt bodies,
+        // but current SDK typings omit them on promptAsync.
         const promptAsyncResult = client.session.promptAsync({
           path: { id: sid },
-          body: { parts: [{ type: "text", text: formatted }] },
-        } as any)
+          body: {
+            agent: currentAgent ?? undefined,
+            model: currentModel ?? undefined,
+            parts: [{ type: "text", text: formatted }],
+          },
+        } as any) // SDK types don't expose agent/model on the async variant; body shape matches the sync prompt endpoint
         if (promptAsyncResult && typeof (promptAsyncResult as Promise<unknown>).then === "function") {
           void (promptAsyncResult as Promise<unknown>).catch((e) => {
             if (pendingAckId === maxId) pendingAckId = null
@@ -163,8 +206,10 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
   // daemon down, etc. other made up scenario etc.). Does NOT deliver messages — that's handled by
   // TCP notify (on message arrival) and session.status events (on idle).
   async function reconcile(): Promise<void> {
+    if (reconcileInFlight) return
     if (permissionPending) return
     if (!instanceName || !sessionId) return
+    reconcileInFlight = true
     try {
       const statusResult = await client.session.status()
       if (!statusResult.data) return
@@ -178,6 +223,8 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
       }
     } catch (e) {
       log("ERROR", "plugin.reconcile_error", instanceName, { error: String(e) })
+    } finally {
+      reconcileInFlight = false
     }
   }
 
@@ -245,7 +292,13 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
         instanceName = json.name
         sessionId = json.session_id
         bootstrapText = json.bootstrap || null
-        log("INFO", "plugin.bound", instanceName, { session_id: sessionId, notify_port: notifyPort, bootstrap_len: bootstrapText?.length ?? 0 })
+        log("INFO", "plugin.bound", instanceName, {
+          session_id: sessionId,
+          notify_port: notifyPort,
+          bootstrap_len: bootstrapText?.length ?? 0,
+          launched_agent: launchedAgent,
+          launched_model: launchedModel?.modelID ?? null,
+        })
       } catch (e) {
         log("ERROR", "plugin.bind_error", null, { error: String(e) })
         stopNotifyServer()
@@ -281,7 +334,7 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
             }
             if (instanceName) {
               lastReportedStatus = "blocked"
-              await $.nothrow()`hcom opencode-status --name ${instanceName} --status blocked --context ${"approval"} --detail ${event.properties.permission}`.quiet()
+              await $.nothrow()`hcom opencode-status --name ${instanceName} --status blocked --context ${"approval"} --detail ${String(event.properties.permission ?? "")}`.quiet()
               log("INFO", "plugin.permission_asked", instanceName, { permission: event.properties.permission, request_id: event.properties.id })
             }
             break
@@ -348,11 +401,13 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
             pendingAckId = null
             deliveryInFlight = false
             permissionPending = false
+            currentAgent = launchedAgent
+            currentModel = launchedModel
             break
           case "file.edited": {
             const filePath = event.properties.file
             if (instanceName) {
-              await $.nothrow()`hcom opencode-status --name ${instanceName} --status active --context ${"tool:write"} --detail ${filePath}`.quiet()
+              await $.nothrow()`hcom opencode-status --name ${instanceName} --status active --context ${"tool:write"} --detail ${String(filePath ?? "")}`.quiet()
             }
             break
           }
@@ -372,6 +427,9 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
         if (input.sessionID && !instanceName) {
           await bindIdentity(input.sessionID)
         }
+        if (input.agent) currentAgent = input.agent
+        const resolvedModel = normalizePromptModel(input.model)
+        if (resolvedModel) currentModel = resolvedModel
         log("DEBUG", "plugin.chat_message", instanceName, {
           session_id: input.sessionID,
           agent: input.agent,
@@ -404,11 +462,12 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
               synthetic: true,
             })
             log("DEBUG", "plugin.transform_bootstrap", instanceName, { msg_count: msgCount, user_msgs: userMsgCount, bootstrap_len: bootstrapText.length })
+            bootstrapText = null
           } else {
             log("WARN", "plugin.transform_no_user_msg", instanceName, { msg_count: msgCount })
           }
         } else {
-          log("WARN", "plugin.transform_no_bootstrap", instanceName, { msg_count: msgCount, user_msgs: userMsgCount })
+          log("DEBUG", "plugin.transform_no_bootstrap", instanceName, { msg_count: msgCount, user_msgs: userMsgCount })
         }
 
         // Deferred ack: deliverPendingToIdle called promptAsync but didn't ack.

--- a/src/opencode_plugin/hcom.ts
+++ b/src/opencode_plugin/hcom.ts
@@ -478,11 +478,13 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
         if (!instanceName && sessionId) await bindIdentity(sessionId)
         if (!instanceName || !sessionId) return
 
-        // Inject bootstrap on first user message (ephemeral — clone discarded after each turn)
-        const msgCount = output.messages?.length ?? 0
-        const userMsgCount = output.messages?.filter((m: any) => m.info.role === "user").length ?? 0
+        // OpenCode transform mutations are prompt-local, not persisted to stored
+        // session history, so keep injecting the original bootstrap payload.
+        const messages = output.messages ?? []
+        const msgCount = messages.length
+        const userMsgCount = messages.filter((m: any) => m.info.role === "user").length
         if (bootstrapText) {
-          const firstUserMsg = output.messages.find((m: any) => m.info.role === "user")
+          const firstUserMsg = messages.find((m: any) => m.info.role === "user")
           if (firstUserMsg) {
             firstUserMsg.parts.push({
               id: crypto.randomUUID(),
@@ -493,7 +495,6 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
               synthetic: true,
             })
             log("DEBUG", "plugin.transform_bootstrap", instanceName, { msg_count: msgCount, user_msgs: userMsgCount, bootstrap_len: bootstrapText.length })
-            bootstrapText = null
           } else {
             log("WARN", "plugin.transform_no_user_msg", instanceName, { msg_count: msgCount })
           }

--- a/src/opencode_plugin/hcom.ts
+++ b/src/opencode_plugin/hcom.ts
@@ -6,12 +6,15 @@ import { homedir } from "os"
 const HCOM_DIR = process.env.HCOM_DIR || `${homedir()}/.hcom`
 const LOG_PATH = `${HCOM_DIR}/.tmp/logs/hcom.log`
 
-// NOTE: parseCliArgValue / parseCliModelArg always return null in practice.
-// hcom launches OpenCode via a PTY wrapper (launcher.rs); the plugin process
-// inherits the OpenCode binary argv, not the outer `hcom opencode --agent …`
-// invocation. currentAgent / currentModel are seeded to null here and
-// populated correctly by the chat.message hook on the first user turn.
-// Long-term fix: seed from the `opencode-start` hcom response payload.
+type PromptModel = {
+  providerID: string
+  modelID: string
+}
+
+// Best-effort fallback for non-hcom/manual plugin runs.
+// Normal hcom launches seed launch agent/model through the `opencode-start`
+// response payload, since the plugin process does not inherit the outer
+// `hcom opencode --agent/--model` argv in PTY-launched OpenCode.
 function parseCliArgValue(...flags: string[]): string | null {
   for (let i = 0; i < process.argv.length; i++) {
     const token = process.argv[i]
@@ -74,9 +77,9 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
   let deliveryInFlight = false                  // Delivery guard flag: rejects concurrent callers (not a queuing mutex)
   let permissionPending = false                  // Exact permission gate from OpenCode events
   let launchedAgent: string | null = parseCliArgValue("--agent")
-  let launchedModel: { providerID: string; modelID: string } | null = parseCliModelArg()
+  let launchedModel: PromptModel | null = parseCliModelArg()
   let currentAgent: string | null = launchedAgent
-  let currentModel: { providerID: string; modelID: string } | null = launchedModel
+  let currentModel: PromptModel | null = launchedModel
 
   // SAFE-02: Lazy PATH detection on first hook callback
   function checkHcom(): boolean {
@@ -88,6 +91,19 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
       }
     }
     return hcomAvailable
+  }
+
+  function isBoundSession(candidateSessionId?: string | null): boolean {
+    return !candidateSessionId || !sessionId || candidateSessionId === sessionId
+  }
+
+  function ignoreForeignSession(event: string, candidateSessionId?: string | null): boolean {
+    if (isBoundSession(candidateSessionId)) return false
+    log("DEBUG", event, instanceName, {
+      session_id: candidateSessionId,
+      bound_session_id: sessionId,
+    })
+    return true
   }
 
   function formatMessagesForInjection(messages: any[], recipientName: string): string {
@@ -123,6 +139,9 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
       return false
     }
     if (!instanceName) return false
+    if (ignoreForeignSession("plugin.delivery_ignored_foreign_session", sid)) {
+      return false
+    }
     if (deliveryInFlight) {
       log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "delivery_in_flight" })
       return false
@@ -162,8 +181,8 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
         current_model: currentModel?.modelID ?? null,
       })
       try {
-        // Runtime contract note: OpenCode accepts agent/model in async prompt bodies,
-        // but current SDK typings omit them on promptAsync.
+        // Runtime contract note: keep this cast until the plugin's bundled client
+        // typings are aligned across shipped OpenCode builds.
         const promptAsyncResult = client.session.promptAsync({
           path: { id: sid },
           body: {
@@ -289,9 +308,14 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
           stopNotifyServer()
           return
         }
+        const boundModel = normalizePromptModel(json.model)
+        if (typeof json.agent === "string") launchedAgent = json.agent
+        if (boundModel) launchedModel = boundModel
         instanceName = json.name
         sessionId = json.session_id
         bootstrapText = json.bootstrap || null
+        currentAgent = launchedAgent
+        currentModel = launchedModel
         log("INFO", "plugin.bound", instanceName, {
           session_id: sessionId,
           notify_port: notifyPort,
@@ -316,6 +340,9 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
         const eventSessionId = event.properties?.sessionID ?? event.properties?.info?.id
         if (eventSessionId && !sessionId) {
           sessionId = eventSessionId as string
+        }
+        if (instanceName && ignoreForeignSession("plugin.event_ignored_foreign_session", eventSessionId)) {
+          return
         }
         switch (event.type) {
           case "session.created": {
@@ -427,16 +454,12 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
         if (input.sessionID && !instanceName) {
           await bindIdentity(input.sessionID)
         }
-        const isBoundSession = !input.sessionID || !sessionId || input.sessionID === sessionId
-        if (isBoundSession) {
+        if (isBoundSession(input.sessionID)) {
           if (input.agent) currentAgent = input.agent
           const resolvedModel = normalizePromptModel(input.model)
           if (resolvedModel) currentModel = resolvedModel
         } else {
-          log("DEBUG", "plugin.chat_message_ignored_foreign_session", instanceName, {
-            session_id: input.sessionID,
-            bound_session_id: sessionId,
-          })
+          ignoreForeignSession("plugin.chat_message_ignored_foreign_session", input.sessionID)
         }
         log("DEBUG", "plugin.chat_message", instanceName, {
           session_id: input.sessionID,


### PR DESCRIPTION
## Summary
Follow-up to #23.

Workers launched with `hcom opencode --agent <name>` could run turn 1 on the intended agent/model, then drift on follow-up hcom-injected turns to OpenCode's default agent/model path. This surfaced during multi-agent orchestration, where frequent hook deliveries made fallback behavior visible in real usage.

## Root cause
`deliverPendingToIdle()` injected through `promptAsync` with only `body.parts`, omitting `body.agent` and `body.model`.

When those fields were absent, OpenCode resolved agent context through its default path (`defaultAgent()`), which could diverge from the launched worker agent/model on subsequent injected turns.

## Fix
- Track `currentAgent` and `currentModel` in plugin state and refresh on each `chat.message`
- Scope the currentAgent/currentModel writes behind an `isBoundSession` check so foreign-session `chat.message` events can't cross-contaminate the bound session's injection context
- Pass `agent` and `model` on every injected `promptAsync` call
- Preserve #23 delivery hardening in this branch (`promptAsync` failure handling and `deliveryInFlight` cleanup on session reset)
- Keep the original bootstrap payload available across transforms (OpenCode transform mutations are prompt-local and not persisted to stored session history)
- Add `reconcileInFlight` guard to prevent overlapping interval reconciles
- Remove dead helper code and normalize `--detail` shell args with `String(x ?? "")`
- Add an explicit runtime-contract comment near the `promptAsync` `as any` cast

## Known limitation: Tab-switch without submit
`currentAgent`/`currentModel` only update when the user submits a turn (`chat.message` fires). If the user Tab-switches the TUI agent but doesn't submit, an hcom message arriving in that window still runs on the previously-submitted agent. The plugin has no way to observe TUI-only state — the agent selection is client-side until submit. Fully closing this window requires an upstream OpenCode change (exposing the TUI's current agent selection to plugins).

## CLI parse limitation (known)
`parseCliArgValue` and `parseCliModelArg` are currently null in PTY-launched OpenCode because the plugin process sees OpenCode binary argv, not outer `hcom opencode --agent/--model` argv.

This PR documents that behavior. Effective turn-to-turn tracking still works through the `chat.message` hook. Long-term fix is to seed launch agent/model from the `opencode-start` payload.

## Validation
- `cargo test -q`
- `cargo build -q`
- Real OpenCode usage after patch: follow-up injected turns remain on the intended agent/model, with no observed default fallback drift