### PR TITLE
Fix headless PTY background launches on macOS

### DIFF
--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -135,6 +135,8 @@ pub fn run(argv: &[String], flags: &GlobalFlags) -> Result<i32> {
     let system_prompt = hcom_flags.system_prompt;
     let initial_prompt = hcom_flags.initial_prompt;
 
+    validate_claude_headless_launch(&tool, background, &merged_args, initial_prompt.as_deref())?;
+
     // Open DB
     let db = HcomDb::open()?;
 
@@ -221,6 +223,29 @@ pub(crate) fn prepare_launch_execution(
     }
 
     (merged_args, background, use_pty)
+}
+
+fn validate_claude_headless_launch(
+    tool: &str,
+    background: bool,
+    merged_args: &[String],
+    initial_prompt: Option<&str>,
+) -> Result<()> {
+    if tool != "claude" || !background {
+        return Ok(());
+    }
+
+    let spec = claude_args::resolve_claude_args(Some(merged_args), None);
+    let has_cli_prompt = spec.positional_tokens.iter().any(|t| !t.trim().is_empty());
+    let has_hcom_prompt = initial_prompt.is_some_and(|p| !p.trim().is_empty());
+
+    if has_cli_prompt || has_hcom_prompt {
+        return Ok(());
+    }
+
+    bail!(
+        "Claude headless mode requires a prompt/task. Try `hcom claude --headless --hcom-prompt 'say hi in hcom'` or `hcom claude -p 'say hi in hcom'`."
+    )
 }
 
 pub(crate) fn launch_result_to_json(result: &LaunchResult) -> serde_json::Value {
@@ -841,6 +866,31 @@ mod tests {
         let spec = crate::hooks::claude_args::resolve_claude_args(Some(&args), None);
         assert!(spec.has_flag(&["--output-format"], &["--output-format="]));
         assert!(spec.has_flag(&["--verbose"], &[]));
+    }
+
+    #[test]
+    fn test_validate_claude_headless_launch_requires_prompt() {
+        let err = validate_claude_headless_launch("claude", true, &[], None).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Claude headless mode requires a prompt/task"));
+    }
+
+    #[test]
+    fn test_validate_claude_headless_launch_accepts_cli_prompt() {
+        assert!(validate_claude_headless_launch(
+            "claude",
+            true,
+            &s(&["-p", "say hi in hcom"]),
+            None
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_validate_claude_headless_launch_accepts_hcom_prompt() {
+        assert!(validate_claude_headless_launch("claude", true, &[], Some("say hi in hcom"))
+            .is_ok());
     }
 
     #[test]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -299,6 +299,17 @@ fn tool_extra_env(tool: &str) -> HashMap<String, String> {
     m
 }
 
+fn background_runner_env(
+    tool: &str,
+    env: &HashMap<String, String>,
+    instance_name: &str,
+) -> HashMap<String, String> {
+    let mut runner_env = env.clone();
+    runner_env.insert("HCOM_INSTANCE_NAME".to_string(), instance_name.to_string());
+    runner_env.extend(tool_extra_env(tool));
+    runner_env
+}
+
 /// Create a bash script that runs a tool via the hcom native PTY wrapper.
 ///
 /// The script sets up the environment and calls `hcom pty <tool> [args...]`.
@@ -540,16 +551,17 @@ fn launch_background_runner(
             .unwrap_or(0),
         rand::random::<u16>() % 9000 + 1000
     );
-    instance_env.insert("HCOM_BACKGROUND".to_string(), log_filename);
+    let mut runner_env = background_runner_env(tool, instance_env, instance_name);
+    runner_env.insert("HCOM_BACKGROUND".to_string(), log_filename);
     let script_file =
-        create_runner_script(tool, cwd, instance_name, instance_env, tool_args, false)?;
+        create_runner_script(tool, cwd, instance_name, &runner_env, tool_args, false)?;
     let command = format!(
         "bash {}",
         crate::tools::args_common::shell_quote(&script_file)
     );
     let (launch_result, effective_preset) = terminal::launch_terminal(
         &command,
-        instance_env,
+        &runner_env,
         Some(cwd),
         true,
         false,
@@ -1337,5 +1349,39 @@ mod tests {
         let args = vec!["--prompt".to_string(), "fix all tests".to_string()];
         let cmd = build_claude_command(&args);
         assert!(cmd.contains("'fix all tests'"));
+    }
+
+    #[test]
+    fn test_background_runner_env_includes_instance_name() {
+        let mut env = HashMap::new();
+        env.insert("HCOM_PROCESS_ID".to_string(), "pid-123".to_string());
+
+        let runner_env = background_runner_env("codex", &env, "nita");
+
+        assert_eq!(
+            runner_env.get("HCOM_INSTANCE_NAME").map(String::as_str),
+            Some("nita")
+        );
+        assert_eq!(
+            runner_env.get("HCOM_PROCESS_ID").map(String::as_str),
+            Some("pid-123")
+        );
+        assert!(!runner_env.contains_key("HCOM_PTY_MODE"));
+    }
+
+    #[test]
+    fn test_background_runner_env_includes_claude_pty_mode() {
+        let env = HashMap::new();
+
+        let runner_env = background_runner_env("claude", &env, "hone");
+
+        assert_eq!(
+            runner_env.get("HCOM_INSTANCE_NAME").map(String::as_str),
+            Some("hone")
+        );
+        assert_eq!(
+            runner_env.get("HCOM_PTY_MODE").map(String::as_str),
+            Some("1")
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,7 @@ pub fn run_pty(args: &[String]) -> Result<()> {
             ready_pattern,
             instance_name,
             tool: tool_name,
+            env_vars: pty_child_env(),
         },
     )
     .context("Failed to spawn PTY")?;
@@ -136,6 +137,10 @@ pub fn run_pty(args: &[String]) -> Result<()> {
     drop(proxy);
 
     std::process::exit(exit_code);
+}
+
+fn pty_child_env() -> Vec<(String, String)> {
+    vec![("HCOM_LAUNCHED".to_string(), "1".to_string())]
 }
 
 #[cfg(test)]
@@ -184,6 +189,14 @@ mod tests {
             Action::Pty {
                 args: args(&["claude", "--arg1", "--arg2"])
             }
+        );
+    }
+
+    #[test]
+    fn test_pty_child_env_marks_launched() {
+        assert_eq!(
+            super::pty_child_env(),
+            vec![("HCOM_LAUNCHED".to_string(), "1".to_string())]
         );
     }
 }

--- a/src/pty/inject.rs
+++ b/src/pty/inject.rs
@@ -167,6 +167,8 @@ impl InjectServer {
 mod tests {
     use super::InjectServer;
     use std::net::TcpStream;
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn accept_returns_false_when_queue_is_empty() {
@@ -181,7 +183,18 @@ mod tests {
         let mut server = InjectServer::new().unwrap();
         let _client = TcpStream::connect(("127.0.0.1", server.port())).unwrap();
 
-        assert!(server.accept().unwrap());
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let accepted = loop {
+            if server.accept().unwrap() {
+                break true;
+            }
+            if Instant::now() >= deadline {
+                break false;
+            }
+            thread::sleep(Duration::from_millis(10));
+        };
+
+        assert!(accepted);
         assert_eq!(server.client_raw_fds().count(), 1);
     }
 }

--- a/src/pty/inject.rs
+++ b/src/pty/inject.rs
@@ -77,15 +77,20 @@ impl InjectServer {
         self.clients.iter().map(|(stream, _)| stream.as_raw_fd())
     }
 
-    /// Accept a new connection
-    pub fn accept(&mut self) -> Result<()> {
+    /// Accept a new connection.
+    ///
+    /// Returns `Ok(true)` if a connection was accepted, `Ok(false)` if the accept
+    /// queue was empty (WouldBlock). The caller uses this to apply backoff on
+    /// macOS, where a non-blocking listener can keep reporting POLLIN via poll()
+    /// even after the accept queue is drained.
+    pub fn accept(&mut self) -> Result<bool> {
         match self.listener.accept() {
             Ok((stream, _addr)) => {
                 stream.set_nonblocking(true)?;
                 self.clients.push((stream, Vec::new()));
-                Ok(())
+                Ok(true)
             }
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(()),
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(false),
             Err(e) => Err(e.into()),
         }
     }
@@ -155,5 +160,28 @@ impl InjectServer {
         }
 
         text
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InjectServer;
+    use std::net::TcpStream;
+
+    #[test]
+    fn accept_returns_false_when_queue_is_empty() {
+        let mut server = InjectServer::new().unwrap();
+
+        assert!(!server.accept().unwrap());
+        assert_eq!(server.client_raw_fds().count(), 0);
+    }
+
+    #[test]
+    fn accept_returns_true_when_connection_is_pending() {
+        let mut server = InjectServer::new().unwrap();
+        let _client = TcpStream::connect(("127.0.0.1", server.port())).unwrap();
+
+        assert!(server.accept().unwrap());
+        assert_eq!(server.client_raw_fds().count(), 1);
     }
 }

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -683,6 +683,14 @@ impl Proxy {
         // that reaches EOF (e.g. /dev/null in headless mode), to avoid busy-waiting.
         let mut poll_stdin = true;
 
+        // Whether to skip the inject listener in the next poll iteration.
+        // On macOS, a non-blocking TcpListener can keep reporting POLLIN via poll()
+        // after accept() drains the queue (kqueue quirk). When accept() returns
+        // WouldBlock, we exclude the listener from the next poll call so poll()
+        // can block on master_fd instead of spinning. It is re-included the
+        // iteration after, so at most one poll cycle of latency for new connections.
+        let mut listener_backoff = false;
+
         // For Claude in accept-edits mode, ready pattern may be hidden.
         // Start delivery after timeout if ready pattern not seen.
         use crate::tool::Tool;
@@ -740,8 +748,17 @@ impl Proxy {
                 poll_fds.push(PollFd::new(stdin_borrowed, PollFlags::POLLIN));
             }
 
-            let inject_listener_idx = poll_fds.len();
-            poll_fds.push(PollFd::new(inject_listener_fd, PollFlags::POLLIN));
+            // Include the inject listener unless we're in backoff (macOS spurious POLLIN).
+            // Reset backoff here so it applies for exactly one iteration.
+            let include_listener = !listener_backoff;
+            listener_backoff = false;
+            let inject_listener_idx: Option<usize> = if include_listener {
+                let idx = poll_fds.len();
+                poll_fds.push(PollFd::new(inject_listener_fd, PollFlags::POLLIN));
+                Some(idx)
+            } else {
+                None
+            };
 
             // Add inject client fds
             let client_raw_fds: Vec<i32> = self.inject_server.client_raw_fds().collect();
@@ -793,7 +810,9 @@ impl Proxy {
                     }
                     continue;
                 }
-                Err(e) => bail!("poll failed: {}", e),
+                Err(e) => {
+                    bail!("poll failed: {}", e)
+                }
             }
 
             // Handle PTY output — drain all available data before writing to stdout.
@@ -926,6 +945,12 @@ impl Proxy {
             // Handle stdin (only if we're still polling it)
             if poll_stdin {
                 if let Some(revents) = poll_fds[1].revents() {
+                    if revents.contains(PollFlags::POLLNVAL) {
+                        // Some headless launch paths can inherit a stdin fd that poll()
+                        // reports as invalid instead of readable EOF. Drop it from the
+                        // poll set to avoid an immediate-return busy loop.
+                        poll_stdin = false;
+                    }
                     if revents.contains(PollFlags::POLLHUP) {
                         // Terminal disconnected - exit cleanly
                         break;
@@ -960,15 +985,28 @@ impl Proxy {
             }
 
             // Handle inject server accept
-            if let Some(revents) = poll_fds[inject_listener_idx].revents() {
-                if revents.contains(PollFlags::POLLIN) {
-                    self.inject_server.accept()?;
+            if let Some(idx) = inject_listener_idx {
+                if let Some(revents) = poll_fds[idx].revents() {
+                    if revents.contains(PollFlags::POLLIN) {
+                        // If accept() returns WouldBlock (false), skip the listener next
+                        // iteration to break the macOS spurious-POLLIN busy-loop.
+                        if !self.inject_server.accept()? {
+                            listener_backoff = true;
+                        }
+                    }
                 }
             }
 
             // Handle inject client data (process in reverse to handle removals)
+            // Clients are pushed immediately after the listener (or immediately after
+            // stdin when listener is in backoff), so their base index shifts by one
+            // depending on whether the listener is present this iteration.
+            let clients_base = inject_listener_idx.map_or_else(
+                || poll_fds.len() - client_raw_fds.len(),
+                |idx| idx + 1,
+            );
             for i in (0..client_raw_fds.len()).rev() {
-                let poll_idx = inject_listener_idx + 1 + i;
+                let poll_idx = clients_base + i;
                 if let Some(revents) = poll_fds[poll_idx].revents() {
                     if revents.contains(PollFlags::POLLIN) || revents.contains(PollFlags::POLLHUP) {
                         match self.inject_server.read_client(i)? {

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -950,12 +950,17 @@ impl Proxy {
                         // reports as invalid instead of readable EOF. Drop it from the
                         // poll set to avoid an immediate-return busy loop.
                         poll_stdin = false;
-                    }
-                    if revents.contains(PollFlags::POLLHUP) {
+                    } else if revents.contains(PollFlags::POLLHUP) {
                         // Terminal disconnected - exit cleanly
-                        break;
-                    }
-                    if revents.contains(PollFlags::POLLIN) {
+                        if nix::unistd::isatty(unsafe { BorrowedFd::borrow_raw(stdin_raw) })
+                            .unwrap_or(false)
+                        {
+                            break;
+                        }
+                        // Non-TTY stdin (e.g. /dev/null or a closed pipe) is not a
+                        // terminal-disconnect signal for headless PTY launches.
+                        poll_stdin = false;
+                    } else if revents.contains(PollFlags::POLLIN) {
                         match nix_read(&stdin_fd, &mut buf) {
                             Ok(0) => {
                                 // stdin EOF: only treat as terminal disconnect if stdin is a real TTY.

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -484,6 +484,8 @@ pub struct ProxyConfig {
     pub instance_name: Option<String>,
     /// Tool name (claude, gemini, codex)
     pub tool: String,
+    /// Extra environment variables to set in the child process
+    pub env_vars: Vec<(String, String)>,
 }
 
 impl Default for ProxyConfig {
@@ -492,6 +494,7 @@ impl Default for ProxyConfig {
             ready_pattern: b"? for shortcuts".to_vec(),
             instance_name: None,
             tool: "claude".to_string(),
+            env_vars: vec![],
         }
     }
 }
@@ -542,6 +545,7 @@ impl Proxy {
         let child = unsafe {
             Command::new(command)
                 .args(args)
+                .envs(config.env_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())))
                 .pre_exec(move || {
                     // Create new session
                     if libc::setsid() == -1 {

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -675,6 +675,10 @@ impl Proxy {
         // with any incomplete escape sequence (CSI, OSC, UTF-8, etc.).
         let mut had_pty_output: bool;
 
+        // Whether to include stdin in the poll set. Set to false when stdin is a non-TTY
+        // that reaches EOF (e.g. /dev/null in headless mode), to avoid busy-waiting.
+        let mut poll_stdin = true;
+
         // For Claude in accept-edits mode, ready pattern may be hidden.
         // Start delivery after timeout if ready pattern not seen.
         use crate::tool::Tool;
@@ -720,7 +724,7 @@ impl Proxy {
 
             let mut poll_fds = vec![
                 PollFd::new(master_fd, PollFlags::POLLIN),
-                PollFd::new(stdin_borrowed, PollFlags::POLLIN),
+                PollFd::new(stdin_borrowed, if poll_stdin { PollFlags::POLLIN } else { PollFlags::empty() }),
                 PollFd::new(inject_listener_fd, PollFlags::POLLIN),
             ];
 
@@ -764,13 +768,6 @@ impl Proxy {
                         self.inject_server.port(),
                         "Periodic dump (main loop)",
                     );
-                    // Detect lost terminal (e.g. terminal window closed, stdin redirected to /dev/null)
-                    // SAFETY: stdin_raw is a valid fd obtained from stdin().as_raw_fd() at function start
-                    if !nix::unistd::isatty(unsafe { BorrowedFd::borrow_raw(stdin_raw) })
-                        .unwrap_or(false)
-                    {
-                        break;
-                    }
                     // Fall through to title write — timeout means no PTY output, safe to write.
                 }
                 Ok(_) => {}
@@ -919,7 +916,16 @@ impl Proxy {
                 }
                 if revents.contains(PollFlags::POLLIN) {
                     match nix_read(&stdin_fd, &mut buf) {
-                        Ok(0) => break, // stdin EOF = terminal gone, exit cleanly
+                        Ok(0) => {
+                            // stdin EOF: only treat as terminal disconnect if stdin is a real TTY.
+                            // When running headless, stdin may be /dev/null or a pipe,
+                            // which is always at EOF but does not mean the terminal is gone.
+                            if nix::unistd::isatty(unsafe { BorrowedFd::borrow_raw(stdin_raw) }).unwrap_or(false) {
+                                break;
+                            }
+                            // Not a TTY — stop polling stdin to avoid busy-waiting on permanent EOF
+                            poll_stdin = false;
+                        }
                         Ok(n) => {
                             self.last_user_input = Instant::now();
                             self.screen.clear_approval();

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -728,9 +728,20 @@ impl Proxy {
 
             let mut poll_fds = vec![
                 PollFd::new(master_fd, PollFlags::POLLIN),
-                PollFd::new(stdin_borrowed, if poll_stdin { PollFlags::POLLIN } else { PollFlags::empty() }),
-                PollFd::new(inject_listener_fd, PollFlags::POLLIN),
             ];
+
+            // Only include stdin in poll set while we're actively polling it.
+            // When stdin is a non-TTY (e.g. /dev/null in headless mode), we stop
+            // polling it to avoid busy-waiting — but we must fully remove it from
+            // the poll set, not just pass empty events, because some platforms
+            // (macOS) may still return immediately for a readable fd even with
+            // events=0.
+            if poll_stdin {
+                poll_fds.push(PollFd::new(stdin_borrowed, PollFlags::POLLIN));
+            }
+
+            let inject_listener_idx = poll_fds.len();
+            poll_fds.push(PollFd::new(inject_listener_fd, PollFlags::POLLIN));
 
             // Add inject client fds
             let client_raw_fds: Vec<i32> = self.inject_server.client_raw_fds().collect();
@@ -912,42 +923,44 @@ impl Proxy {
                 }
             }
 
-            // Handle stdin
-            if let Some(revents) = poll_fds[1].revents() {
-                if revents.contains(PollFlags::POLLHUP) {
-                    // Terminal disconnected - exit cleanly
-                    break;
-                }
-                if revents.contains(PollFlags::POLLIN) {
-                    match nix_read(&stdin_fd, &mut buf) {
-                        Ok(0) => {
-                            // stdin EOF: only treat as terminal disconnect if stdin is a real TTY.
-                            // When running headless, stdin may be /dev/null or a pipe,
-                            // which is always at EOF but does not mean the terminal is gone.
-                            if nix::unistd::isatty(unsafe { BorrowedFd::borrow_raw(stdin_raw) }).unwrap_or(false) {
-                                break;
+            // Handle stdin (only if we're still polling it)
+            if poll_stdin {
+                if let Some(revents) = poll_fds[1].revents() {
+                    if revents.contains(PollFlags::POLLHUP) {
+                        // Terminal disconnected - exit cleanly
+                        break;
+                    }
+                    if revents.contains(PollFlags::POLLIN) {
+                        match nix_read(&stdin_fd, &mut buf) {
+                            Ok(0) => {
+                                // stdin EOF: only treat as terminal disconnect if stdin is a real TTY.
+                                // When running headless, stdin may be /dev/null or a pipe,
+                                // which is always at EOF but does not mean the terminal is gone.
+                                if nix::unistd::isatty(unsafe { BorrowedFd::borrow_raw(stdin_raw) }).unwrap_or(false) {
+                                    break;
+                                }
+                                // Not a TTY — stop polling stdin to avoid busy-waiting on permanent EOF
+                                poll_stdin = false;
                             }
-                            // Not a TTY — stop polling stdin to avoid busy-waiting on permanent EOF
-                            poll_stdin = false;
-                        }
-                        Ok(n) => {
-                            self.last_user_input = Instant::now();
-                            self.screen.clear_approval();
-                            // Update delivery state for user activity
-                            if let Ok(mut state) = self.delivery_state.write() {
-                                state.last_user_input = Instant::now();
-                                state.approval = false;
+                            Ok(n) => {
+                                self.last_user_input = Instant::now();
+                                self.screen.clear_approval();
+                                // Update delivery state for user activity
+                                if let Ok(mut state) = self.delivery_state.write() {
+                                    state.last_user_input = Instant::now();
+                                    state.approval = false;
+                                }
+                                write_all(&self.pty_master, &buf[..n])?;
                             }
-                            write_all(&self.pty_master, &buf[..n])?;
+                            Err(Errno::EAGAIN) => {}
+                            Err(e) => bail!("read from stdin failed: {}", e),
                         }
-                        Err(Errno::EAGAIN) => {}
-                        Err(e) => bail!("read from stdin failed: {}", e),
                     }
                 }
             }
 
             // Handle inject server accept
-            if let Some(revents) = poll_fds[2].revents() {
+            if let Some(revents) = poll_fds[inject_listener_idx].revents() {
                 if revents.contains(PollFlags::POLLIN) {
                     self.inject_server.accept()?;
                 }
@@ -955,7 +968,7 @@ impl Proxy {
 
             // Handle inject client data (process in reverse to handle removals)
             for i in (0..client_raw_fds.len()).rev() {
-                let poll_idx = 3 + i;
+                let poll_idx = inject_listener_idx + 1 + i;
                 if let Some(revents) = poll_fds[poll_idx].revents() {
                     if revents.contains(PollFlags::POLLIN) || revents.contains(PollFlags::POLLHUP) {
                         match self.inject_server.read_client(i)? {


### PR DESCRIPTION
# Fix headless PTY background launches on macOS
...oh man, this was an odyssey.

## Summary
Fixes the macOS `--headless --go` regressions on the PTY-backed launch path.

Validated end result:
- headless Codex works again
- headless OpenCode works again
- bare headless Claude without a prompt/task now fails fast with a clear error
- prompt/task-based headless Claude still works

## Motivation
Headless launches on the PTY path had regressed in several overlapping ways, which made this investigation a bit deceptive at first:

- background PTY launches could drop instance identity before `hcom pty` even started
- non-TTY stdin handling on macOS could prematurely tear down the PTY loop
- invalid/non-useful stdin could stay in the poll set and cause hot wakeups
- the non-blocking inject listener could keep waking spuriously on macOS after `WouldBlock`
- bare `hcom claude --headless` without a prompt/task looked like “headless PTY is broken” but is actually a separate unsupported detached-Claude path

User-facing symptoms included:
- Codex/OpenCode ending up in `launch_failed`
- missing `delivery.start` / `notify.registered`
- PTY spin / high CPU
- Claude launching and exiting immediately in unsupported bare headless mode

## What changed

### Launcher / background PTY env
- Propagate `HCOM_INSTANCE_NAME` into the background PTY runner env
- Apply `tool_extra_env(tool)` on background PTY launches too

### PTY loop hardening
- Do not treat stdin EOF as terminal disconnect when stdin is not a TTY
- Fully remove stdin from the poll set when it should no longer be polled
- Drop stdin polling on `POLLNVAL`
- Ignore stdin `POLLHUP` for non-TTY headless PTY sessions
- Add one-iteration listener backoff after inject-listener `WouldBlock`

### PTY child identity
- Mark PTY child processes with `HCOM_LAUNCHED=1`

### Claude safety guard
- Reject bare `hcom claude --headless` without a prompt/task
- Keep prompt/task-based headless Claude behavior intact

## Notes / implementation details
- The main headless Codex/OpenCode fix was restoring `HCOM_INSTANCE_NAME` on the background PTY path so delivery can initialize for the correct instance.
- The PTY poll loop changes are specifically aimed at non-interactive stdin on macOS (`/dev/null`, closed pipes, invalid fds).
- The inject listener still stays non-blocking; the fix is not to change socket mode, but to back off for one iteration after `WouldBlock`.
- The `HCOM_LAUNCHED=1` PTY-child env fix ensures downstream hooks/tool integrations still recognize PTY-managed child sessions as hcom-launched.
- Bare headless Claude is intentionally not “fixed” into a PTY-backed live session model in this PR. The safe change here is explicit early validation.

## Validation

### Automated
- `cargo test`
- Added regression coverage for:
  - background runner env propagation
  - Claude headless validation
  - PTY child launch env
  - inject listener accept helper behavior / timing resilience

### Manual
- `./target/release/hcom codex --headless --go`
  - launches successfully
  - transitions to `listening`
  - round-trip message delivery works
- `./target/release/hcom opencode --headless --go`
  - launches successfully
  - transitions to `listening`
  - round-trip message delivery works
- `./target/release/hcom claude --headless --go`
  - now fails fast with a clear prompt/task requirement
- `./target/release/hcom claude --headless --go 'Ping!'`
  - launches successfully
  - later message delivery round-trip works

### Active-binary PTY re-check
- Rebuilt release binary
- Launched fresh PTY-backed headless Codex from `./target/release/hcom`
- Observed normal `delivery.start` / `notify.registered`
- Observed no new recent `proxy.poll_spin_trace` / `POLLNVAL` log entries
- Focused process check showed normal CPU for PTY wrapper and child

### Final pre-PR hardening
- Updated PTY stdin handling so non-TTY `POLLHUP` disables stdin polling instead of breaking the PTY loop
- Made the inject accept regression test resilient to non-blocking localhost timing
- Reran focused PTY tests and full `cargo test` successfully

## Deferred follow-up
Not included in this PR:
- true PTY-backed headless Claude as a live background session model
- deeper investigation of Claude initial-prompt swallowing on detached launches
- any broader resume/fork cleanup around tool marker vars beyond the validated fixes here
(those are deferred follow-up items rather than blockers for restoring stable headless Codex/OpenCode PTY launches)

## Commit stack
- `fix(pty): don't treat stdin EOF as terminal disconnect when stdin is not a TTY`
- `fix(pty): mark PTY child processes as hcom-launched`
- `fix(pty): fully remove stdin from poll set when not a TTY`
- `fix(headless): restore stable PTY background launches`
- `fix(pty): tighten headless stdin and inject test handling`
