### PR TITLE
Normalize claude + --headless + prompt to print-headless; bound PTY listener backoff

### DIFF
--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -127,13 +127,18 @@ pub fn run(argv: &[String], flags: &GlobalFlags) -> Result<i32> {
         }
     }
 
-    // Merge env config args with CLI args
-    let (merged_args, background, use_pty) =
-        prepare_launch_execution(&tool, &tool_args, &hcom_config, headless);
-
     // System/initial prompt handling
     let system_prompt = hcom_flags.system_prompt;
     let initial_prompt = hcom_flags.initial_prompt;
+
+    // Merge env config args with CLI args
+    let (merged_args, background, use_pty) = prepare_launch_execution(
+        &tool,
+        &tool_args,
+        &hcom_config,
+        headless,
+        initial_prompt.as_deref(),
+    );
 
     validate_claude_headless_launch(&tool, background, &merged_args, initial_prompt.as_deref())?;
 
@@ -211,13 +216,27 @@ pub(crate) fn prepare_launch_execution(
     cli_args: &[String],
     config: &HcomConfig,
     headless: bool,
+    initial_prompt: Option<&str>,
 ) -> (Vec<String>, bool, bool) {
     let mut merged_args = merge_tool_args(tool, cli_args, config);
     let background = headless || is_background_from_args(tool, &merged_args);
     let use_pty = tool != "claude" || (!background && cfg!(unix));
 
     if tool == "claude" && background {
-        let spec = claude_args::resolve_claude_args(Some(&merged_args), None);
+        // Claude-specific normalization: a headless launch with a prompt (positional
+        // or --hcom-prompt) must go through print mode. If the user asked for
+        // --headless without -p/--print, inject -p so add_background_defaults fires
+        // and the child runs with --output-format stream-json --verbose.
+        let mut spec = claude_args::resolve_claude_args(Some(&merged_args), None);
+        let has_cli_prompt = spec.positional_tokens.iter().any(|t| !t.trim().is_empty());
+        let has_hcom_prompt = initial_prompt.is_some_and(|p| !p.trim().is_empty());
+        if !spec.is_background && (has_cli_prompt || has_hcom_prompt) {
+            let mut with_print = Vec::with_capacity(merged_args.len() + 1);
+            with_print.push("-p".to_string());
+            with_print.extend(merged_args.iter().cloned());
+            merged_args = with_print;
+            spec = claude_args::resolve_claude_args(Some(&merged_args), None);
+        }
         let updated = claude_args::add_background_defaults(&spec);
         merged_args = updated.rebuild_tokens(true);
     }
@@ -859,13 +878,75 @@ mod tests {
     fn test_prepare_launch_execution_adds_claude_background_defaults() {
         let config = HcomConfig::default();
         let (args, background, use_pty) =
-            prepare_launch_execution("claude", &s(&["-p"]), &config, true);
+            prepare_launch_execution("claude", &s(&["-p"]), &config, true, None);
         assert!(background);
         assert!(!use_pty);
 
         let spec = crate::hooks::claude_args::resolve_claude_args(Some(&args), None);
         assert!(spec.has_flag(&["--output-format"], &["--output-format="]));
         assert!(spec.has_flag(&["--verbose"], &[]));
+    }
+
+    #[test]
+    fn test_prepare_launch_execution_headless_with_hcom_prompt_injects_print() {
+        // `hcom claude --headless --hcom-prompt "..."` passed validation before this
+        // fix but launched without -p, so add_background_defaults never fired and the
+        // child ran as a detached plain `claude` without --output-format stream-json
+        // --verbose. Normalize by injecting -p when a prompt is present.
+        let config = HcomConfig::default();
+        let (args, background, use_pty) = prepare_launch_execution(
+            "claude",
+            &s(&[]),
+            &config,
+            true,
+            Some("say hi in hcom"),
+        );
+        assert!(background);
+        assert!(!use_pty);
+
+        let spec = crate::hooks::claude_args::resolve_claude_args(Some(&args), None);
+        assert!(spec.is_background, "-p should have been injected");
+        assert!(spec.has_flag(&["--output-format"], &["--output-format="]));
+        assert!(spec.has_flag(&["--verbose"], &[]));
+    }
+
+    #[test]
+    fn test_prepare_launch_execution_headless_with_positional_prompt_injects_print() {
+        // `hcom claude --headless "task text"` — positional prompt, no -p yet.
+        let config = HcomConfig::default();
+        let (args, _background, _use_pty) =
+            prepare_launch_execution("claude", &s(&["task text"]), &config, true, None);
+        let spec = crate::hooks::claude_args::resolve_claude_args(Some(&args), None);
+        assert!(spec.is_background);
+        assert!(spec.has_flag(&["--output-format"], &["--output-format="]));
+        assert!(spec.has_flag(&["--verbose"], &[]));
+        // positional preserved
+        assert!(spec
+            .positional_tokens
+            .iter()
+            .any(|t| t == "task text"));
+    }
+
+    #[test]
+    fn test_prepare_launch_execution_headless_without_prompt_no_print_injection() {
+        // Bare `hcom claude --headless` stays as-is here — validation will reject it
+        // downstream in validate_claude_headless_launch. We don't want to silently
+        // promote it to print mode with no prompt.
+        let config = HcomConfig::default();
+        let (args, background, _use_pty) =
+            prepare_launch_execution("claude", &s(&[]), &config, true, None);
+        assert!(background);
+        let spec = crate::hooks::claude_args::resolve_claude_args(Some(&args), None);
+        assert!(!spec.is_background, "no prompt → no -p injection");
+    }
+
+    #[test]
+    fn test_prepare_launch_execution_headless_only_applies_to_claude() {
+        // --headless on other tools must not grow a -p; that flag is Claude-specific.
+        let config = HcomConfig::default();
+        let (args, _bg, _pty) =
+            prepare_launch_execution("codex", &s(&[]), &config, true, Some("task"));
+        assert!(!args.iter().any(|t| t == "-p"));
     }
 
     #[test]

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -244,7 +244,7 @@ pub(crate) fn prepare_launch_execution(
     (merged_args, background, use_pty)
 }
 
-fn validate_claude_headless_launch(
+pub(crate) fn validate_claude_headless_launch(
     tool: &str,
     background: bool,
     merged_args: &[String],

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -32,44 +32,23 @@ fn is_in_path(name: &str) -> bool {
         .any(|dir| Path::new(dir).join(name).exists())
 }
 
-/// Check Claude hook installation.
+// Hook-installation checks delegate to the canonical `verify_*` functions in
+// `hooks::*` so `hcom status` and `hcom hooks status` never disagree.
+
 fn check_claude_hooks() -> bool {
-    let settings_path = dirs::home_dir()
-        .map(|h| h.join(".claude/settings.json"))
-        .unwrap_or_default();
-    if let Ok(content) = std::fs::read_to_string(&settings_path) {
-        content.contains("hcom") || content.contains("hook-comms")
-    } else {
-        false
-    }
+    crate::hooks::claude::verify_claude_hooks_installed(None, false)
 }
 
-/// Check Gemini hook installation.
 fn check_gemini_hooks() -> bool {
-    let settings_path = dirs::home_dir()
-        .map(|h| h.join(".gemini/settings.json"))
-        .unwrap_or_default();
-    if let Ok(content) = std::fs::read_to_string(&settings_path) {
-        content.contains("hcom") || content.contains("hook-comms")
-    } else {
-        false
-    }
+    crate::hooks::gemini::verify_gemini_hooks_installed(false)
 }
 
-/// Check Codex hook installation (native hooks.json + feature flag + rules file).
 fn check_codex_hooks() -> bool {
-    crate::hooks::codex::verify_codex_hooks_installed(true)
+    crate::hooks::codex::verify_codex_hooks_installed(false)
 }
 
-/// Check OpenCode plugin installation.
 fn check_opencode_hooks() -> bool {
-    let plugin_paths = [
-        dirs::home_dir().map(|h| h.join(".config/opencode/plugins/hcom.ts")),
-        dirs::config_dir().map(|h| h.join("opencode/plugins/hcom.ts")),
-    ];
-    plugin_paths
-        .iter()
-        .any(|p| p.as_ref().is_some_and(|p| p.exists()))
+    crate::hooks::opencode::verify_opencode_plugin_installed()
 }
 
 // ── Status Collection ────────────────────────────────────────────────────

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -769,11 +769,18 @@ impl Proxy {
 
             // Poll timeout: 5s when debug enabled (for periodic dumps), otherwise block
             // Delivery thread has its own timing via notify.wait(), doesn't need fast polling here
-            let poll_timeout = if self.screen.debug_enabled() {
+            let mut poll_timeout = if self.screen.debug_enabled() {
                 5000u16 // 5s for debug periodic dumps
             } else {
                 10000u16 // 10s, allows runtime debug flag check
             };
+            // During a one-iteration listener backoff (macOS spurious POLLIN workaround)
+            // the inject listener is excluded from the poll set. Cap the timeout short
+            // so an inject connection arriving while we're backed off doesn't wait the
+            // full 10s for the listener to re-enter the poll set on the next iteration.
+            if !include_listener {
+                poll_timeout = poll_timeout.min(100u16);
+            }
             match poll(&mut poll_fds, PollTimeout::from(poll_timeout)) {
                 Ok(0) => {
                     // Timeout - still update delivery state for time-based checks

--- a/src/relay/control.rs
+++ b/src/relay/control.rs
@@ -715,6 +715,18 @@ fn handle_remote_launch(
 ) -> Result<Value, String> {
     let request = RemoteLaunchRequest::from_params(params)?;
     let prepared = prepare_remote_launch(&request, config);
+    // Enforce the same Claude headless invariant the local CLI path enforces
+    // (src/commands/launch.rs validate_claude_headless_launch). The local
+    // path short-circuits into dispatch_remote before local validation fires,
+    // so a bare `hcom claude --headless --device X` would otherwise bypass it
+    // and fall through to a detached plain-claude launch on the remote.
+    crate::commands::launch::validate_claude_headless_launch(
+        &request.tool,
+        prepared.background,
+        &prepared.args,
+        request.initial_prompt.as_deref(),
+    )
+    .map_err(|e| e.to_string())?;
     let cwd = resolve_remote_cwd(request.cwd.as_deref())?;
 
     let result = launcher::launch(
@@ -1439,6 +1451,56 @@ mod tests {
         let prepared = prepare_remote_launch(&request, &HcomConfig::default());
         assert!(prepared.background);
         assert!(!prepared.pty);
+    }
+
+    #[test]
+    fn test_prepare_remote_launch_claude_headless_with_hcom_prompt_injects_print() {
+        // Remote claude --headless --hcom-prompt "..." must go through the same
+        // print-mode normalization as the local path.
+        let request = RemoteLaunchRequest::from_params(&json!({
+            "tool": "claude",
+            "count": 1,
+            "args": [],
+            "background": true,
+            "initial_prompt": "say hi in hcom",
+        }))
+        .unwrap();
+        let prepared = prepare_remote_launch(&request, &HcomConfig::default());
+        assert!(prepared.background);
+        assert!(!prepared.pty);
+        let spec = crate::hooks::claude_args::resolve_claude_args(Some(&prepared.args), None);
+        assert!(
+            spec.is_background,
+            "remote claude + --headless + --hcom-prompt must inject -p"
+        );
+        assert!(spec.has_flag(&["--output-format"], &["--output-format="]));
+        assert!(spec.has_flag(&["--verbose"], &[]));
+    }
+
+    #[test]
+    fn test_remote_launch_rejects_bare_claude_headless() {
+        // Bare remote `claude --headless` with no prompt must be rejected, matching
+        // the local CLI path's validate_claude_headless_launch invariant. Without
+        // this, the remote handler would fall through to a detached plain-claude
+        // launch. (We only assert the prepared state + validator result here,
+        // without calling the full handle_remote_launch which needs a live DB.)
+        let request = RemoteLaunchRequest::from_params(&json!({
+            "tool": "claude",
+            "count": 1,
+            "args": [],
+            "background": true,
+        }))
+        .unwrap();
+        let prepared = prepare_remote_launch(&request, &HcomConfig::default());
+        assert!(prepared.background);
+        let err = crate::commands::launch::validate_claude_headless_launch(
+            &request.tool,
+            prepared.background,
+            &prepared.args,
+            request.initial_prompt.as_deref(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("requires a prompt/task"));
     }
 
     #[test]

--- a/src/relay/control.rs
+++ b/src/relay/control.rs
@@ -680,6 +680,7 @@ fn prepare_remote_launch(
         &request.args,
         config,
         request.background,
+        request.initial_prompt.as_deref(),
     );
     PreparedRemoteLaunch {
         args,

--- a/src/router.rs
+++ b/src/router.rs
@@ -422,43 +422,48 @@ pub(crate) fn resolve_effective_dev_root(db_path: &Path) -> Option<(PathBuf, &'s
 }
 
 fn read_dev_root_from_kv(db_path: &Path) -> Option<PathBuf> {
-    let conn =
-        rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
-            .map_err(|e| {
+    // A missing db file or unset `dev_root` key are normal states (fresh HCOM_DIR,
+    // user never ran `hcom config dev_root`). Only warn on unexpected failures
+    // like permission denied or corruption.
+    let conn = match rusqlite::Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            if db_path.exists() {
                 log_warn(
                     "router",
                     "dev_root_kv_open_failed",
                     &format!("failed to open db at {}: {e}", db_path.display()),
                 );
-                e
-            })
-            .ok()?;
+            }
+            return None;
+        }
+    };
 
     conn.busy_timeout(std::time::Duration::from_millis(200))
         .ok();
 
-    let value = conn
-        .query_row(
-            "SELECT value FROM kv WHERE key = ?",
-            rusqlite::params![DEV_ROOT_KV_KEY],
-            |row| row.get::<_, Option<String>>(0),
-        )
-        .map_err(|e| {
+    let value = match conn.query_row(
+        "SELECT value FROM kv WHERE key = ?",
+        rusqlite::params![DEV_ROOT_KV_KEY],
+        |row| row.get::<_, Option<String>>(0),
+    ) {
+        Ok(v) => v,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return None,
+        Err(e) => {
             log_warn(
                 "router",
                 "dev_root_kv_read_failed",
                 &format!("failed to read dev_root from kv: {e}"),
             );
-            e
-        })
-        .ok()
-        .flatten()?;
-
-    if value.is_empty() {
-        None
-    } else {
-        Some(PathBuf::from(value))
+            return None;
+        }
     }
+    .filter(|s| !s.is_empty())?;
+
+    Some(PathBuf::from(value))
 }
 
 /// Check if two paths refer to the same file (follows symlinks).

--- a/src/scripts/bundled/confess.sh
+++ b/src/scripts/bundled/confess.sh
@@ -196,7 +196,7 @@ Instructions:
     --hcom-system-prompt "$confessor_system" \
     --hcom-prompt "$confessor_prompt" \
     --resume "$session_id" --fork-session \
-    --headless \
+    --headless -p \
     ${target_dir:+-C "$target_dir"} 2>&1) || {
     echo "Error: Failed to launch confessor" >&2
     exit 1

--- a/src/scripts/bundled/debate.sh
+++ b/src/scripts/bundled/debate.sh
@@ -171,7 +171,14 @@ fi
 trap cleanup ERR INT TERM
 
 bg_flag=""
-[[ "$interactive" == "false" ]] && bg_flag="--headless"
+if [[ "$interactive" == "false" ]]; then
+  # claude: explicit -p so --headless goes through print mode
+  if [[ "$tool" == "claude" ]]; then
+    bg_flag="--headless -p"
+  else
+    bg_flag="--headless"
+  fi
+fi
 
 if [[ "$spawn" == "true" ]]; then
   # --- SPAWN MODE ---

--- a/src/scripts/bundled/fatcow.sh
+++ b/src/scripts/bundled/fatcow.sh
@@ -149,11 +149,13 @@ ${ask_question}
 2. Send your answer: hcom send @${caller_name} -- <your answer>
 3. Stop yourself: run hcom stop"
 
-  # Resume
+  # Resume (claude: explicit -p so --headless goes through print mode)
+  claude_p_flag=""
+  [[ "$fatcow_tool" == "claude" ]] && claude_p_flag="-p"
   hcom 1 "$fatcow_tool" --go \
     --resume "$ask_name" \
     --hcom-prompt "$resume_prompt" \
-    --headless >/dev/null 2>&1 || {
+    --headless ${claude_p_flag} >/dev/null 2>&1 || {
     echo "Error: Resume failed" >&2
     exit 1
   }
@@ -270,7 +272,12 @@ ${ingest_section}
 
 Do NOT subscribe to events. Do NOT wait for questions. Summarize, then stop."
 
-  bg_flag="--headless"
+  # claude: explicit -p so --headless goes through print mode
+  if [[ "$tool" == "claude" ]]; then
+    bg_flag="--headless -p"
+  else
+    bg_flag="--headless"
+  fi
 
 else
   system_prompt='You are a fat cow - a dedicated codebase oracle.
@@ -326,7 +333,12 @@ You are a fat, lazy, knowledge-stuffed oracle. Eat all the files. Sit there. Ans
   if [[ "$interactive" == "true" ]]; then
     bg_flag=""
   else
-    bg_flag="--headless"
+    # claude: explicit -p so --headless goes through print mode
+    if [[ "$tool" == "claude" ]]; then
+      bg_flag="--headless -p"
+    else
+      bg_flag="--headless"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary

Addresses findings 1 and 2 from the post-merge review of #26 (@mafo + @bulu).

- **Finding 1 (blocker):** `hcom claude --headless --hcom-prompt 'task'` (or `hcom claude --headless 'task'`) passed validation but launched as a detached plain `claude` — the spec never saw `-p`/`--print`, so `add_background_defaults` didn't fire and the child never got `--output-format stream-json --verbose`. Fix: thread `initial_prompt` into `prepare_launch_execution` and inject `-p` when `tool=="claude" && background && prompt_present`, so `add_background_defaults` runs.
- **Finding 2 (small):** macOS kqueue spurious-POLLIN workaround drops the inject listener from the poll set for one iteration after `WouldBlock`, but the poll timeout stayed at 10s. An inject connection arriving during that iteration could wait the full timeout. Fix: cap the poll timeout at 100ms whenever the listener is excluded.
- **Bundled scripts:** `confess.sh`, `fatcow.sh`, `debate.sh` now pass `-p` explicitly to `--headless` claude launches. Belt-and-suspenders on top of the normalizer; guarded so `-p` only appears when the tool is claude (scripts that accept `--tool codex/gemini/opencode` stay untouched).

## Framing

Kept to **Claude-specific normalization** per @mafo's guidance — `--headless` semantics for `codex`/`gemini`/`opencode` are deliberately unchanged.

## Test plan

- [x] `cargo test` (1457 passed, 0 failed)
- [x] New unit tests in `src/commands/launch.rs`:
  - `test_prepare_launch_execution_headless_with_hcom_prompt_injects_print`
  - `test_prepare_launch_execution_headless_with_positional_prompt_injects_print`
  - `test_prepare_launch_execution_headless_without_prompt_no_print_injection`
  - `test_prepare_launch_execution_headless_only_applies_to_claude`
- [x] Live test from a **clean env** (findings were invisible from inside hcom sessions):
  ```
  env -u HCOM_INSTANCE_NAME hcom claude --headless --hcom-prompt 'respond via hcom send then stop' --go
  hcom send @<name> -- 'hi'
  → got reply via hcom
  ```
- [x] Independent src/ review by another agent (@mamo): no actionable findings.

## Deferred

PR #26's deferred follow-ups (true PTY-backed headless claude as a live background session model, --pty flag, prompt-swallowing investigation, LaunchBackend enum refactor) are scoped to a separate follow-up PR on branch `feat/claude-headless-full-ux` — keeping this one narrow since the two findings are straightforward and this is a safer standalone land.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `claude` headless sessions are launched/validated (including remote RPC), which can impact automation workflows and background agent behavior. PTY polling and hook-status checks are low risk but touch runtime I/O and UX signals.
> 
> **Overview**
> **Claude headless launches are normalized when a prompt is present.** `prepare_launch_execution` now receives `initial_prompt` and, for `tool=="claude"` in background/headless mode, injects `-p` when a positional prompt or `--hcom-prompt` is provided so `add_background_defaults` reliably adds `--output-format stream-json` and `--verbose`; new unit tests cover prompt/no-prompt and non-Claude cases.
> 
> **Remote launch now matches local invariants.** The relay `launch` handler threads `initial_prompt` through argument preparation and explicitly calls `validate_claude_headless_launch` to reject bare headless Claude launches that previously bypassed local validation.
> 
> **Smaller consistency/robustness fixes.** `hcom status` hook checks now delegate to the canonical `hooks::*::verify_*` functions, PTY polling caps the timeout during one-iteration inject-listener backoff to reduce connection latency, router `dev_root` KV reads avoid warning on missing DB/row, and bundled scripts pass `-p` explicitly for headless Claude launches (tool-guarded).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7130a033cf1321af5eee382faeb859a5313cb529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->