### PR TITLE
Full headless UX: PTY-headless claude, --pty flag, LaunchBackend enum

### DIFF
--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -918,6 +918,7 @@ const SHARED_LAUNCH_FLAGS: &[(&str, &str)] = &[
     ("--terminal <preset>", "Where new windows open"),
     ("--dir <path>", "Working directory"),
     ("--headless", "Run in background (no terminal window)"),
+    ("--pty", "Force PTY wrapper (claude: live headless session)"),
     ("--run-here", "Run in current terminal"),
     ("--hcom-prompt <text>", "Initial prompt"),
     ("--hcom-system-prompt <text>", "System prompt"),

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -269,7 +269,24 @@ pub(crate) fn validate_claude_headless_launch(
     merged_args: &[String],
     initial_prompt: Option<&str>,
 ) -> Result<()> {
-    if tool != "claude" || !background {
+    if tool != "claude" {
+        return Ok(());
+    }
+
+    let spec = claude_args::resolve_claude_args(Some(merged_args), None);
+
+    // --pty opts into a live PTY-backed TUI session. -p/--print is claude's
+    // one-shot print mode — it answers and exits. The two are mutually
+    // exclusive: a print-mode claude inside the PTY wrapper would end the
+    // session the moment it replied, defeating the whole point of --pty.
+    // Reject explicitly rather than stripping so the user notices.
+    if use_pty && spec.is_background {
+        bail!(
+            "Claude --pty conflicts with -p/--print: --pty hosts a live TUI session, -p is one-shot print mode that exits after replying. Use `--headless` alone for print mode, or `--headless --pty` (without -p) for a live session."
+        )
+    }
+
+    if !background {
         return Ok(());
     }
     // PTY-backed headless claude hosts the live TUI in a hidden terminal; the
@@ -280,7 +297,6 @@ pub(crate) fn validate_claude_headless_launch(
         return Ok(());
     }
 
-    let spec = claude_args::resolve_claude_args(Some(merged_args), None);
     let has_cli_prompt = spec.positional_tokens.iter().any(|t| !t.trim().is_empty());
     let has_hcom_prompt = initial_prompt.is_some_and(|p| !p.trim().is_empty());
 
@@ -1056,6 +1072,44 @@ mod tests {
         // --pty --headless claude with no prompt is a valid live-session launch —
         // the PTY wrapper keeps the TUI alive waiting for hcom inject.
         assert!(validate_claude_headless_launch("claude", true, true, &[], None).is_ok());
+    }
+
+    #[test]
+    fn test_validate_claude_pty_rejects_print_flag_headless() {
+        // `--headless --pty -p 'task'` would wrap a claude that's about to exit on
+        // its one-shot print reply. Explicit conflict with --pty's live-session
+        // semantics. Both local and remote paths share this validator.
+        let err = validate_claude_headless_launch(
+            "claude",
+            true,
+            true,
+            &s(&["-p", "task"]),
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--pty conflicts with -p/--print"));
+    }
+
+    #[test]
+    fn test_validate_claude_pty_rejects_print_flag_without_headless() {
+        // Same conflict if only --pty + -p are passed (no --headless). The spec is
+        // still background because -p is present, so is_background_from_args would
+        // have promoted use_pty to true regardless.
+        let err = validate_claude_headless_launch(
+            "claude",
+            true,
+            true,
+            &s(&["--print", "task"]),
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--pty conflicts with -p/--print"));
+    }
+
+    #[test]
+    fn test_validate_claude_pty_without_print_flag_ok() {
+        // Sanity: --pty without -p/--print stays allowed.
+        assert!(validate_claude_headless_launch("claude", true, true, &s(&["--model", "haiku"]), None).is_ok());
     }
 
     #[test]

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -33,6 +33,7 @@ pub fn run(argv: &[String], flags: &GlobalFlags) -> Result<i32> {
     let tag = hcom_flags.tag;
     let terminal = hcom_flags.terminal;
     let headless = hcom_flags.headless;
+    let pty_requested = hcom_flags.pty;
     let remote_device = hcom_flags.device.clone();
     let dir_override = hcom_flags.dir.clone();
     let tag_for_output = tag.clone();
@@ -85,6 +86,7 @@ pub fn run(argv: &[String], flags: &GlobalFlags) -> Result<i32> {
             "tag": tag,
             "launcher": launcher_name,
             "background": headless,
+            "pty": pty_requested,
             "terminal": terminal,
             "cwd": remote_cwd,
             "initial_prompt": hcom_flags.initial_prompt,
@@ -137,10 +139,17 @@ pub fn run(argv: &[String], flags: &GlobalFlags) -> Result<i32> {
         &tool_args,
         &hcom_config,
         headless,
+        pty_requested,
         initial_prompt.as_deref(),
     );
 
-    validate_claude_headless_launch(&tool, background, &merged_args, initial_prompt.as_deref())?;
+    validate_claude_headless_launch(
+        &tool,
+        background,
+        use_pty,
+        &merged_args,
+        initial_prompt.as_deref(),
+    )?;
 
     // Open DB
     let db = HcomDb::open()?;
@@ -216,17 +225,26 @@ pub(crate) fn prepare_launch_execution(
     cli_args: &[String],
     config: &HcomConfig,
     headless: bool,
+    pty_requested: bool,
     initial_prompt: Option<&str>,
 ) -> (Vec<String>, bool, bool) {
     let mut merged_args = merge_tool_args(tool, cli_args, config);
     let background = headless || is_background_from_args(tool, &merged_args);
-    let use_pty = tool != "claude" || (!background && cfg!(unix));
+    // --pty opt-in forces the PTY wrapper even in background/headless mode.
+    // For claude, this routes through the TUI-in-PTY path instead of
+    // detached print-mode, enabling a live background session that can
+    // receive hcom messages via the PTY inject path.
+    let use_pty = if tool == "claude" {
+        pty_requested || (!background && cfg!(unix))
+    } else {
+        true
+    };
 
-    if tool == "claude" && background {
-        // Claude-specific normalization: a headless launch with a prompt (positional
-        // or --hcom-prompt) must go through print mode. If the user asked for
-        // --headless without -p/--print, inject -p so add_background_defaults fires
-        // and the child runs with --output-format stream-json --verbose.
+    // Claude-specific print-mode normalization only applies when we are NOT
+    // routing through the PTY wrapper. PTY-hosted claude runs the interactive
+    // TUI — injecting -p would put it in one-shot print mode and defeat the
+    // whole point of keeping it alive for later hcom messages.
+    if tool == "claude" && background && !use_pty {
         let mut spec = claude_args::resolve_claude_args(Some(&merged_args), None);
         let has_cli_prompt = spec.positional_tokens.iter().any(|t| !t.trim().is_empty());
         let has_hcom_prompt = initial_prompt.is_some_and(|p| !p.trim().is_empty());
@@ -247,10 +265,18 @@ pub(crate) fn prepare_launch_execution(
 pub(crate) fn validate_claude_headless_launch(
     tool: &str,
     background: bool,
+    use_pty: bool,
     merged_args: &[String],
     initial_prompt: Option<&str>,
 ) -> Result<()> {
     if tool != "claude" || !background {
+        return Ok(());
+    }
+    // PTY-backed headless claude hosts the live TUI in a hidden terminal; the
+    // session stays alive waiting for hcom inject, so a starting prompt is
+    // optional. The no-prompt form would be impossible to launch without this
+    // carve-out because the invariant below would reject it.
+    if use_pty {
         return Ok(());
     }
 
@@ -263,7 +289,7 @@ pub(crate) fn validate_claude_headless_launch(
     }
 
     bail!(
-        "Claude headless mode requires a prompt/task. Try `hcom claude --headless --hcom-prompt 'say hi in hcom'` or `hcom claude -p 'say hi in hcom'`."
+        "Claude headless mode requires a prompt/task. Try `hcom claude --headless --hcom-prompt 'say hi in hcom'`, `hcom claude -p 'say hi in hcom'`, or `hcom claude --headless --pty` for a live session."
     )
 }
 
@@ -415,6 +441,7 @@ pub(crate) struct HcomLaunchFlags {
     pub terminal: Option<String>,
     pub device: Option<String>,
     pub headless: bool,
+    pub pty: bool,
     pub system_prompt: Option<String>,
     pub initial_prompt: Option<String>,
     pub run_here: Option<bool>,
@@ -588,6 +615,10 @@ pub(crate) fn extract_launch_flags(args: &[String]) -> (HcomLaunchFlags, Vec<Str
             }
             "--headless" => {
                 flags.headless = true;
+                i += 1;
+            }
+            "--pty" => {
+                flags.pty = true;
                 i += 1;
             }
             "--hcom-system-prompt" if i + 1 < args.len() => {
@@ -878,7 +909,7 @@ mod tests {
     fn test_prepare_launch_execution_adds_claude_background_defaults() {
         let config = HcomConfig::default();
         let (args, background, use_pty) =
-            prepare_launch_execution("claude", &s(&["-p"]), &config, true, None);
+            prepare_launch_execution("claude", &s(&["-p"]), &config, true, false, None);
         assert!(background);
         assert!(!use_pty);
 
@@ -899,6 +930,7 @@ mod tests {
             &s(&[]),
             &config,
             true,
+            false,
             Some("say hi in hcom"),
         );
         assert!(background);
@@ -915,7 +947,7 @@ mod tests {
         // `hcom claude --headless "task text"` — positional prompt, no -p yet.
         let config = HcomConfig::default();
         let (args, _background, _use_pty) =
-            prepare_launch_execution("claude", &s(&["task text"]), &config, true, None);
+            prepare_launch_execution("claude", &s(&["task text"]), &config, true, false, None);
         let spec = crate::hooks::claude_args::resolve_claude_args(Some(&args), None);
         assert!(spec.is_background);
         assert!(spec.has_flag(&["--output-format"], &["--output-format="]));
@@ -934,7 +966,7 @@ mod tests {
         // promote it to print mode with no prompt.
         let config = HcomConfig::default();
         let (args, background, _use_pty) =
-            prepare_launch_execution("claude", &s(&[]), &config, true, None);
+            prepare_launch_execution("claude", &s(&[]), &config, true, false, None);
         assert!(background);
         let spec = crate::hooks::claude_args::resolve_claude_args(Some(&args), None);
         assert!(!spec.is_background, "no prompt → no -p injection");
@@ -945,13 +977,51 @@ mod tests {
         // --headless on other tools must not grow a -p; that flag is Claude-specific.
         let config = HcomConfig::default();
         let (args, _bg, _pty) =
-            prepare_launch_execution("codex", &s(&[]), &config, true, Some("task"));
+            prepare_launch_execution("codex", &s(&[]), &config, true, false, Some("task"));
         assert!(!args.iter().any(|t| t == "-p"));
     }
 
     #[test]
+    fn test_prepare_launch_execution_claude_pty_headless_skips_print_injection() {
+        // `--pty --headless --hcom-prompt X`: the PTY wrapper hosts claude's TUI,
+        // so -p must NOT be injected. use_pty must be true even in background mode.
+        let config = HcomConfig::default();
+        let (args, background, use_pty) = prepare_launch_execution(
+            "claude",
+            &s(&[]),
+            &config,
+            true,
+            true,
+            Some("ping"),
+        );
+        assert!(background);
+        assert!(use_pty, "--pty opt-in must force PTY routing");
+
+        let spec = crate::hooks::claude_args::resolve_claude_args(Some(&args), None);
+        assert!(
+            !spec.is_background,
+            "PTY-hosted claude stays interactive; -p would kill the session"
+        );
+        assert!(!spec.has_flag(&["--output-format"], &["--output-format="]));
+        assert!(!spec.has_flag(&["--verbose"], &[]));
+    }
+
+    #[test]
+    fn test_prepare_launch_execution_claude_pty_interactive_unchanged() {
+        // `--pty` on its own (no --headless) is the existing interactive claude-pty
+        // path; use_pty should stay true and nothing else should change.
+        let config = HcomConfig::default();
+        let (args, background, use_pty) =
+            prepare_launch_execution("claude", &s(&[]), &config, false, true, None);
+        assert!(!background);
+        assert!(use_pty);
+        assert!(args.is_empty());
+    }
+
+    #[test]
     fn test_validate_claude_headless_launch_requires_prompt() {
-        let err = validate_claude_headless_launch("claude", true, &[], None).unwrap_err();
+        let err =
+            validate_claude_headless_launch("claude", true, false, &[], None).unwrap_err();
         assert!(err
             .to_string()
             .contains("Claude headless mode requires a prompt/task"));
@@ -962,6 +1032,7 @@ mod tests {
         assert!(validate_claude_headless_launch(
             "claude",
             true,
+            false,
             &s(&["-p", "say hi in hcom"]),
             None
         )
@@ -970,8 +1041,21 @@ mod tests {
 
     #[test]
     fn test_validate_claude_headless_launch_accepts_hcom_prompt() {
-        assert!(validate_claude_headless_launch("claude", true, &[], Some("say hi in hcom"))
-            .is_ok());
+        assert!(validate_claude_headless_launch(
+            "claude",
+            true,
+            false,
+            &[],
+            Some("say hi in hcom")
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_validate_claude_headless_launch_pty_allows_no_prompt() {
+        // --pty --headless claude with no prompt is a valid live-session launch —
+        // the PTY wrapper keeps the TUI alive waiting for hcom inject.
+        assert!(validate_claude_headless_launch("claude", true, true, &[], None).is_ok());
     }
 
     #[test]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -72,6 +72,43 @@ impl LaunchTool {
     }
 }
 
+/// How the child process is hosted. Computed from (tool, background, pty) at
+/// launch time so dispatch doesn't have to re-derive the combination.
+///
+/// - `InteractiveVisible`: foreground, user-visible terminal. All tools.
+/// - `HeadlessPty`:       background, PTY wrapper in a detached runner. Default
+///                        for gemini/codex/opencode; claude with `--pty`.
+/// - `NativePrint`:       background, direct claude spawn in print mode
+///                        (`-p --output-format stream-json --verbose`). Claude
+///                        only; one-shot, exits after the prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LaunchBackend {
+    InteractiveVisible,
+    HeadlessPty,
+    NativePrint,
+}
+
+impl LaunchBackend {
+    /// Resolve from the already-prepared (tool, background, pty) triple.
+    ///
+    /// `pty` here is the effective use-pty decision coming out of
+    /// `prepare_launch_execution` — for claude, that tracks the user's `--pty`
+    /// opt-in (plus the existing interactive default). For other tools it is
+    /// always true.
+    pub fn resolve(tool: &LaunchTool, background: bool, pty: bool) -> Self {
+        if !background {
+            return LaunchBackend::InteractiveVisible;
+        }
+        match tool {
+            LaunchTool::Claude if !pty => LaunchBackend::NativePrint,
+            LaunchTool::Claude | LaunchTool::ClaudePty => LaunchBackend::HeadlessPty,
+            LaunchTool::Gemini | LaunchTool::Codex | LaunchTool::OpenCode => {
+                LaunchBackend::HeadlessPty
+            }
+        }
+    }
+}
+
 /// Launch parameters.
 #[derive(Clone)]
 pub struct LaunchParams {
@@ -631,6 +668,11 @@ fn launch_pty_or_background(
 pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
     let normalized = LaunchTool::from_str(&params.tool, params.pty)?;
     let base_tool = normalized.base_tool();
+    let backend = LaunchBackend::resolve(
+        &normalized,
+        params.background,
+        normalized.uses_pty() || params.pty,
+    );
 
     // Validation
     if params.count == 0 {
@@ -641,9 +683,6 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
             "Too many {} instances requested (max 100)",
             normalized.as_str()
         );
-    }
-    if params.background && normalized == LaunchTool::ClaudePty {
-        bail!("Claude PTY does not support headless/background mode");
     }
 
     // Ensure hooks are installed (strict: refuse to launch without hooks)
@@ -894,7 +933,10 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
                         )]),
                     );
 
-                    if params.background {
+                    // LaunchTool::Claude only resolves to NativePrint (background,
+                    // direct spawn in print mode) or InteractiveVisible — the
+                    // PTY-backed variants live in LaunchTool::ClaudePty below.
+                    if matches!(backend, LaunchBackend::NativePrint) {
                         let log_filename = format!(
                             "background_{}_{}.log",
                             std::time::SystemTime::now()
@@ -982,27 +1024,28 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
                             json!(params.args),
                         )]),
                     );
-                    let effective_run_here = will_run_in_current_terminal(
-                        params.count,
-                        false,
-                        params.run_here,
-                        terminal_mode,
-                        inside_ai_tool,
-                    );
-                    let ok = launch_pty(
-                        "claude",
-                        working_dir,
-                        &instance_env,
-                        &instance_name,
+                    // Same background/foreground split as gemini/codex/opencode:
+                    // foreground → visible PTY in a terminal; background → PTY
+                    // wrapper in a detached runner. The wrapper handles the TUI
+                    // the same way either way, which is what lets PTY-headless
+                    // claude keep a live session that accepts hcom inject.
+                    launch_pty_or_background(
+                        &mut BackgroundLaunchCtx {
+                            db,
+                            tool: "claude",
+                            instance_name: &instance_name,
+                            process_id: &process_id,
+                            terminal_mode,
+                            tag: params.tag.as_deref().unwrap_or(""),
+                            working_dir,
+                            log_files: &mut log_files,
+                            handles: &mut handles,
+                        },
+                        &mut instance_env,
                         &params.args,
-                        effective_run_here,
-                        terminal_mode,
+                        &params,
                         inside_ai_tool,
-                    )?;
-                    if ok {
-                        handles.push(json!({"tool": "claude-pty", "instance_name": instance_name}));
-                    }
-                    Ok(ok)
+                    )
                 }
 
                 LaunchTool::Gemini => {
@@ -1297,6 +1340,57 @@ mod tests {
         assert!(LaunchTool::Gemini.uses_pty());
         assert!(LaunchTool::Codex.uses_pty());
         assert!(LaunchTool::OpenCode.uses_pty());
+    }
+
+    #[test]
+    fn test_launch_backend_resolve_interactive() {
+        // Any tool, !background → InteractiveVisible (visible terminal).
+        for tool in [
+            LaunchTool::Claude,
+            LaunchTool::ClaudePty,
+            LaunchTool::Gemini,
+            LaunchTool::Codex,
+            LaunchTool::OpenCode,
+        ] {
+            let pty = tool.uses_pty();
+            assert_eq!(
+                LaunchBackend::resolve(&tool, false, pty),
+                LaunchBackend::InteractiveVisible,
+                "{:?} should resolve to InteractiveVisible without background",
+                tool
+            );
+        }
+    }
+
+    #[test]
+    fn test_launch_backend_resolve_claude_native_print() {
+        // claude + background + NO pty → NativePrint (detached -p stream-json).
+        assert_eq!(
+            LaunchBackend::resolve(&LaunchTool::Claude, true, false),
+            LaunchBackend::NativePrint
+        );
+    }
+
+    #[test]
+    fn test_launch_backend_resolve_claude_pty_headless() {
+        // claude --pty --headless → HeadlessPty (PTY wrapper, live TUI).
+        assert_eq!(
+            LaunchBackend::resolve(&LaunchTool::ClaudePty, true, true),
+            LaunchBackend::HeadlessPty
+        );
+    }
+
+    #[test]
+    fn test_launch_backend_resolve_other_tools_headless() {
+        // gemini/codex/opencode + --headless → HeadlessPty (unchanged from today).
+        for tool in [LaunchTool::Gemini, LaunchTool::Codex, LaunchTool::OpenCode] {
+            assert_eq!(
+                LaunchBackend::resolve(&tool, true, true),
+                LaunchBackend::HeadlessPty,
+                "{:?} --headless should be HeadlessPty",
+                tool
+            );
+        }
     }
 
     #[test]

--- a/src/relay/control.rs
+++ b/src/relay/control.rs
@@ -640,6 +640,7 @@ struct RemoteLaunchRequest {
     system_prompt: Option<String>,
     initial_prompt: Option<String>,
     background: bool,
+    pty: bool,
     terminal: Option<String>,
     cwd: Option<String>,
 }
@@ -659,6 +660,7 @@ impl RemoteLaunchRequest {
             system_prompt: optional_param(params, "system_prompt").map(ToString::to_string),
             initial_prompt: optional_param(params, "initial_prompt").map(ToString::to_string),
             background: bool_param(params, "background", false),
+            pty: bool_param(params, "pty", false),
             terminal: optional_param(params, "terminal").map(ToString::to_string),
             cwd: optional_param(params, "cwd").map(ToString::to_string),
         })
@@ -680,6 +682,7 @@ fn prepare_remote_launch(
         &request.args,
         config,
         request.background,
+        request.pty,
         request.initial_prompt.as_deref(),
     );
     PreparedRemoteLaunch {
@@ -723,6 +726,7 @@ fn handle_remote_launch(
     crate::commands::launch::validate_claude_headless_launch(
         &request.tool,
         prepared.background,
+        prepared.pty,
         &prepared.args,
         request.initial_prompt.as_deref(),
     )
@@ -1496,6 +1500,7 @@ mod tests {
         let err = crate::commands::launch::validate_claude_headless_launch(
             &request.tool,
             prepared.background,
+            prepared.pty,
             &prepared.args,
             request.initial_prompt.as_deref(),
         )


### PR DESCRIPTION
## Summary

Addresses the deferred follow-ups from PR #26 + PR #27 for the headless-claude story. Stacks on top of PR #27 (findings 1 & 2 normalization); will auto-rebase once #27 merges.

- **PTY-headless claude.** Deferred in #26 as "true PTY-backed headless Claude as a live background session model." `hcom claude --headless --pty` now launches claude's interactive TUI inside the PTY wrapper in a detached runner — same shape gemini/codex/opencode have — giving claude a long-lived background session that accepts `hcom send` via the existing PTY inject path. Works with or without an initial prompt.
- **`--pty` opt-in flag.** New launch flag, parsed in `HcomLaunchFlags`, plumbed through `prepare_launch_execution`, forwarded over the relay, and surfaced in `SHARED_LAUNCH_FLAGS` help. For claude, combines with `--headless` to select the PTY path; on its own preserves today's foreground claude-pty behavior.
- **`LaunchBackend` enum.** `InteractiveVisible` / `HeadlessPty` / `NativePrint`. Resolved once in `launcher::launch()` from the already-prepared `(tool, background, pty)` triple. Dispatch branches on the enum where it clarifies intent; the other tools' paths already encode the split via `LaunchTool` and use `launch_pty_or_background` directly. Kept surgical per @mafo's guidance — no identity/delivery rewrites.

## Framing

Per @mafo's stability constraint: `--headless` semantics for codex/gemini/opencode are untouched. For claude, `--headless` without `--pty` still resolves to today's `NativePrint` (print-mode normalization from #27). `--pty` is the explicit opt-in for the new live-session form.

## Key code changes

- `src/commands/launch.rs`:
  - `HcomLaunchFlags.pty` + `--pty` parsing in `extract_launch_flags`.
  - `prepare_launch_execution` takes `pty_requested`, skips `-p` injection + `add_background_defaults` when the PTY wrapper is hosting the TUI.
  - `validate_claude_headless_launch` takes `use_pty`; bare `--pty --headless` is accepted.
  - `--pty` forwarded into the dispatch-remote payload.
- `src/relay/control.rs`: `RemoteLaunchRequest.pty`, forwarded into `prepare_remote_launch` and the local validator.
- `src/launcher.rs`:
  - Drop `bail!("Claude PTY does not support headless/background mode")`.
  - `LaunchTool::ClaudePty` arm now routes through `launch_pty_or_background` (matches gemini/codex/opencode).
  - `LaunchBackend` enum + `resolve((tool, background, pty))`.
  - `LaunchTool::Claude` background branch uses `matches!(backend, LaunchBackend::NativePrint)` for the print-mode path.
- `src/commands/help.rs`: `--pty` added to `SHARED_LAUNCH_FLAGS`.

## Test plan

- [x] `cargo test` — 1466 passed (5 new).
- [x] Unit tests for `--pty --headless` claude skipping `-p` injection, preserving `use_pty=true`.
- [x] Unit test for validator accepting no-prompt `--pty --headless`.
- [x] `LaunchBackend::resolve` matrix for `(tool × background × pty)`.
- [x] Live, clean env:
  ```
  env -u HCOM_INSTANCE_NAME hcom claude --headless --pty --hcom-prompt 'respond via hcom send then stop' --go
  hcom send @<name> -- 'hi'
  ```
  → reply arrived via PTY inject. ✓
- [x] Live, no initial prompt:
  ```
  env -u HCOM_INSTANCE_NAME hcom claude --headless --pty --go
  hcom send @<name> -- 'live?'
  ```
  → session reached `listening`, replied. ✓

## Related

- Stacks on #27 (normalize + listener backoff). Until #27 merges, the diff against main shows those commits too.
- Closes the PR #26 deferred-follow-up for "true PTY-backed headless Claude as a live background session model."
- The prompt-swallowing concern from #26 doesn't bite on this path: claude's TUI consumes the positional initial prompt the same way it does in interactive mode, and subsequent hcom messages arrive via the PTY inject TCP path (verified live). No `stream-json` coupling needed.