### PR TITLE
fix: handle UUID identities in instance_not_found_error_for

### DIFF
--- a/src/identity.rs
+++ b/src/identity.rs
@@ -66,7 +66,7 @@ pub fn instance_not_found_error(name: &str) -> String {
 /// `HcomDb::was_subagent_name` and returns the same "session may have ended"
 /// text used for raw agent_ids instead.
 pub fn instance_not_found_error_for(db: &HcomDb, name: &str) -> String {
-    if looks_like_agent_id(name) || db.was_subagent_name(name) {
+    if looks_like_agent_id(name) || looks_like_uuid(name) || db.was_subagent_name(name) {
         return format!(
             "Instance '{name}' not found. Your session may have ended. Stop working and end your turn."
         );


### PR DESCRIPTION
Sub-agents using UUID-based agent IDs (36 chars with hyphens) were getting incorrect `hcom start --as` recovery advice instead of the 'session may have ended' message.

## Problem

`instance_not_found_error_for()` checks `looks_like_agent_id()` (7-char hex) but not `looks_like_uuid()` (36-char UUID). When a sub-agent with a UUID identity loses its session, the error message incorrectly suggests `hcom start --as <uuid>` — which would rebind the parent's identity.

## Fix

Add `looks_like_uuid(name)` check alongside the existing `looks_like_agent_id(name)` check.

## Related

Fixes #29