### PR TITLE
fix(codex): remove unsupported --full-auto and transition to modern flags

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -434,7 +434,7 @@ impl HcomConfig {
             "codex_sandbox_mode" => {
                 // Normalize legacy value
                 self.codex_sandbox_mode = if value == "full-auto" {
-                    "danger-full-access".to_string()
+                    "workspace".to_string()
                 } else {
                     value.to_string()
                 };
@@ -1528,7 +1528,7 @@ mod tests {
     fn test_set_field_full_auto_normalization() {
         let mut config = HcomConfig::default();
         config.set_field("codex_sandbox_mode", "full-auto").unwrap();
-        assert_eq!(config.codex_sandbox_mode, "danger-full-access");
+        assert_eq!(config.codex_sandbox_mode, "workspace");
     }
 
     #[test]
@@ -1877,7 +1877,7 @@ auto_approve = false
             "full-auto".to_string(),
         );
         let config = HcomConfig::from_env_dict(&data).unwrap();
-        assert_eq!(config.codex_sandbox_mode, "danger-full-access");
+        assert_eq!(config.codex_sandbox_mode, "workspace");
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1816,7 +1816,8 @@ mod tests {
     fn test_sandbox_flags_in_get_sandbox_flags() {
         use crate::tools::codex_preprocessing::get_sandbox_flags;
         let flags = get_sandbox_flags("workspace");
-        assert!(flags.contains(&"--full-auto".to_string()));
+        assert!(flags.contains(&"--sandbox".to_string()));
+        assert!(flags.contains(&"workspace-write".to_string()));
     }
 
     #[test]

--- a/src/tools/codex_args.rs
+++ b/src/tools/codex_args.rs
@@ -49,7 +49,6 @@ const CASE_SENSITIVE_BOOLEAN_FLAGS: &[&str] = &["-V"];
 
 const BOOLEAN_FLAGS: &[&str] = &[
     "--oss",
-    "--full-auto",
     "--dangerously-bypass-approvals-and-sandbox",
     "--search",
     "--no-alt-screen",
@@ -107,7 +106,6 @@ const SANDBOX_FLAGS: &[&str] = &[
     "-s",
     "-a",
     "--ask-for-approval",
-    "--full-auto",
     "--dangerously-bypass-approvals-and-sandbox",
 ];
 
@@ -504,15 +502,6 @@ pub fn validate_conflicts(spec: &CodexArgsSpec) -> Vec<String> {
         warnings.push("--json flag is only valid with 'exec' subcommand".to_string());
     }
 
-    if spec.has_flag(&["--full-auto"], &[])
-        && spec.has_flag(&["--dangerously-bypass-approvals-and-sandbox"], &[])
-    {
-        warnings.push(
-            "--full-auto and --dangerously-bypass-approvals-and-sandbox are redundant together"
-                .to_string(),
-        );
-    }
-
     warnings
 }
 
@@ -845,9 +834,9 @@ mod tests {
 
     #[test]
     fn test_parse_boolean_flags() {
-        let args = sv(&["--full-auto", "--oss"]);
+        let args = sv(&["--last", "--oss"]);
         let spec = parse_tokens(&args, SourceType::Cli);
-        assert!(spec.has_flag(&["--full-auto"], &[]));
+        assert!(spec.has_flag(&["--last"], &[]));
         assert!(spec.has_flag(&["--oss"], &[]));
     }
 
@@ -861,9 +850,9 @@ mod tests {
 
     #[test]
     fn test_parse_double_dash() {
-        let args = sv(&["--full-auto", "--", "--not-a-flag"]);
+        let args = sv(&["--oss", "--", "--not-a-flag"]);
         let spec = parse_tokens(&args, SourceType::Cli);
-        assert!(spec.has_flag(&["--full-auto"], &[]));
+        assert!(spec.has_flag(&["--oss"], &[]));
         assert_eq!(spec.positional_tokens, vec!["--not-a-flag"]);
     }
 
@@ -873,10 +862,10 @@ mod tests {
             &sv(&["--sandbox", "workspace-write", "-a", "untrusted"]),
             SourceType::Env,
         );
-        let cli_spec = parse_tokens(&sv(&["--full-auto"]), SourceType::Cli);
+        let cli_spec = parse_tokens(&sv(&["--dangerously-bypass-approvals-and-sandbox"]), SourceType::Cli);
         let merged = merge_codex_args(&env_spec, &cli_spec);
-        // CLI has --full-auto (sandbox flag), so ALL env sandbox flags stripped
-        assert!(merged.has_flag(&["--full-auto"], &[]));
+        // CLI has --dangerously-bypass-approvals-and-sandbox (sandbox flag), so ALL env sandbox flags stripped
+        assert!(merged.has_flag(&["--dangerously-bypass-approvals-and-sandbox"], &[]));
         assert!(!merged.has_flag(&["-a"], &[]));
     }
 
@@ -947,11 +936,20 @@ mod tests {
 
     #[test]
     fn test_resolve_from_env() {
-        let spec = resolve_codex_args(None, Some("--model gpt-4 --full-auto"));
+        let spec = resolve_codex_args(None, Some("--model gpt-4 --last"));
         assert_eq!(
             spec.get_flag_value("--model"),
             Some(FlagValue::Single("gpt-4".to_string()))
         );
-        assert!(spec.has_flag(&["--full-auto"], &[]));
+        assert!(spec.has_flag(&["--last"], &[]));
     }
+
+    #[test]
+    fn test_full_auto_removed() {
+        let args = sv(&["--full-auto"]);
+        let spec = parse_tokens(&args, SourceType::Cli);
+        assert!(spec.has_errors());
+        assert!(spec.errors[0].contains("unknown option '--full-auto'"));
+    }
+
 }

--- a/src/tools/codex_preprocessing.rs
+++ b/src/tools/codex_preprocessing.rs
@@ -6,7 +6,7 @@ use super::codex_args::resolve_codex_args;
 
 /// Sandbox modes aligned with Codex TUI presets.
 ///
-/// - `workspace`: Default — --full-auto (workspace-write + on-request approvals)
+/// - `workspace`: Default — --sandbox workspace-write --ask-for-approval on-request
 /// - `untrusted`: Workspace writes, approval before untrusted commands
 /// - `danger-full-access`: Full Access — --dangerously-bypass-approvals-and-sandbox
 /// - `none`: Raw codex, user's own settings (hcom may not work)
@@ -20,7 +20,12 @@ pub fn get_sandbox_flags(mode: &str) -> Vec<String> {
 
     match mode {
         "workspace" => {
-            let mut flags = vec!["--full-auto".to_string()];
+            let mut flags = vec![
+                "--sandbox".to_string(),
+                "workspace-write".to_string(),
+                "--ask-for-approval".to_string(),
+                "on-request".to_string(),
+            ];
             flags.extend(net);
             flags
         }
@@ -40,7 +45,12 @@ pub fn get_sandbox_flags(mode: &str) -> Vec<String> {
         "none" => vec![],
         // Default to workspace
         _ => {
-            let mut flags = vec!["--full-auto".to_string()];
+            let mut flags = vec![
+                "--sandbox".to_string(),
+                "workspace-write".to_string(),
+                "--ask-for-approval".to_string(),
+                "on-request".to_string(),
+            ];
             flags.extend(net);
             flags
         }
@@ -63,7 +73,6 @@ pub fn ensure_hcom_writable(tokens: &[String]) -> Vec<String> {
             "--sandbox",
             "-s",
             "--dangerously-bypass-approvals-and-sandbox",
-            "--full-auto",
         ],
         &["--sandbox=", "-s="],
     );
@@ -285,7 +294,10 @@ mod tests {
     #[test]
     fn test_sandbox_flags_workspace() {
         let flags = get_sandbox_flags("workspace");
-        assert!(flags.contains(&"--full-auto".to_string()));
+        assert!(flags.contains(&"--sandbox".to_string()));
+        assert!(flags.contains(&"workspace-write".to_string()));
+        assert!(flags.contains(&"--ask-for-approval".to_string()));
+        assert!(flags.contains(&"on-request".to_string()));
         assert!(flags.contains(&"sandbox_workspace_write.network_access=true".to_string()));
     }
 
@@ -316,15 +328,16 @@ mod tests {
     #[test]
     fn test_sandbox_flags_unknown_defaults_to_workspace() {
         let flags = get_sandbox_flags("bogus");
-        assert!(flags.contains(&"--full-auto".to_string()));
+        assert!(flags.contains(&"--sandbox".to_string()));
+        assert!(flags.contains(&"workspace-write".to_string()));
     }
 
     #[test]
     #[serial]
     fn test_ensure_hcom_writable_adds_dir() {
         init_config();
-        // With --full-auto, sandbox is active → should add --add-dir
-        let tokens = s(&["--full-auto"]);
+        // With --sandbox workspace-write, sandbox is active → should add --add-dir
+        let tokens = s(&["--sandbox", "workspace-write"]);
         let result = ensure_hcom_writable(&tokens);
         assert_eq!(result[0], "--add-dir");
         assert!(result.len() > 2);
@@ -343,7 +356,12 @@ mod tests {
     fn test_ensure_hcom_writable_no_duplicate() {
         init_config();
         let hcom_dir = paths::hcom_dir().to_string_lossy().to_string();
-        let tokens = vec!["--full-auto".to_string(), "--add-dir".to_string(), hcom_dir];
+        let tokens = vec![
+            "--sandbox".to_string(),
+            "workspace-write".to_string(),
+            "--add-dir".to_string(),
+            hcom_dir,
+        ];
         let result = ensure_hcom_writable(&tokens);
         let add_dir_count = result.iter().filter(|t| *t == "--add-dir").count();
         assert_eq!(add_dir_count, 1);
@@ -441,10 +459,11 @@ mod tests {
         let args = s(&[
             "resume",
             "--config=developer_instructions=OLD",
-            "--full-auto",
+            "--sandbox",
+            "workspace-write",
         ]);
         let result = strip_codex_developer_instructions(&args);
-        assert_eq!(result, s(&["resume", "--full-auto"]));
+        assert_eq!(result, s(&["resume", "--sandbox", "workspace-write"]));
     }
 
     #[test]
@@ -453,7 +472,8 @@ mod tests {
         init_config();
         let args = s(&["-m", "o3"]);
         let result = preprocess_codex_args(&args, "BOOTSTRAP", "workspace");
-        assert!(result.contains(&"--full-auto".to_string()));
+        assert!(result.contains(&"--sandbox".to_string()));
+        assert!(result.contains(&"workspace-write".to_string()));
         assert!(result.contains(&"--add-dir".to_string()));
         assert!(result.iter().any(|t| t.contains("developer_instructions=")));
     }
@@ -462,7 +482,8 @@ mod tests {
     fn test_preprocess_codex_args_none_mode() {
         let args = s(&["-m", "o3"]);
         let result = preprocess_codex_args(&args, "BOOTSTRAP", "none");
-        assert!(!result.contains(&"--full-auto".to_string()));
+        assert!(!result.contains(&"--sandbox".to_string()));
+        assert!(!result.contains(&"workspace-write".to_string()));
         assert!(!result.contains(&"--add-dir".to_string()));
         assert!(result.iter().any(|t| t.contains("developer_instructions=")));
     }


### PR DESCRIPTION
## Problem
hcom hardcodes the `--full-auto` flag when launching Codex agents. Modern `codex-cli` (v0.128.0+) rejects this flag, causing launch failures with an 'unexpected argument' error.

## Solution
- Replaced `--full-auto` with modern flags (`--sandbox workspace-write --ask-for-approval on-request`) in `src/tools/codex_preprocessing.rs`.
- Removed `--full-auto` from the Codex argument parser in `src/tools/codex_args.rs`.
- Updated `src/config.rs` to normalize legacy 'full-auto' sandbox mode to 'workspace' instead of 'danger-full-access'.
- Updated unit tests in `codex_preprocessing`, `codex_args`, `config`, and `terminal`.

## Test Plan
- Ran `cargo test codex_args`
- Ran `cargo test codex_preprocessing`
- Ran `cargo test config`
- Verified that `--full-auto` is now rejected by the parser and correctly replaced in preprocessing logic.