### PR TITLE
fix(codex): ensure hcom DB is writable in sandbox mode

### DIFF
--- a/src/tools/codex_preprocessing.rs
+++ b/src/tools/codex_preprocessing.rs
@@ -80,19 +80,42 @@ pub fn ensure_hcom_writable(tokens: &[String]) -> Vec<String> {
     }
 
     let hcom_dir = paths::hcom_dir().to_string_lossy().to_string();
+    let quoted_hcom_dir = serde_json::to_string(&hcom_dir).unwrap_or_else(|_| format!("\"{}\"", hcom_dir));
+    let config_val = format!("sandbox_workspace_write.writable_roots=[{}]", quoted_hcom_dir);
 
     // Check if --add-dir with hcom path already exists
-    for (i, token) in spec.clean_tokens.iter().enumerate() {
-        if token == "--add-dir"
-            && i + 1 < spec.clean_tokens.len()
-            && spec.clean_tokens[i + 1] == hcom_dir
-        {
-            return tokens.to_vec(); // Already present
-        }
+    let has_add_dir = if let Some(val) = spec.get_flag_value("--add-dir") {
+        val.as_list().contains(&hcom_dir.as_str())
+    } else {
+        false
+    };
+
+    // Check if the config override already exists
+    let has_config = if let Some(val) = spec.get_flag_value("-c") {
+        val.as_list().contains(&config_val.as_str())
+    } else {
+        false
+    };
+
+    if has_add_dir && has_config {
+        return tokens.to_vec(); // Both already present
     }
 
-    // Prepend --add-dir at the beginning
-    let mut result = vec!["--add-dir".to_string(), hcom_dir];
+    let mut result = Vec::new();
+
+    if !has_add_dir {
+        result.push("--add-dir".to_string());
+        result.push(hcom_dir.clone());
+    }
+
+    if !has_config {
+        // ALSO inject -c sandbox_workspace_write.writable_roots=["<hcom_dir>"] as a
+        // workaround for Codex sandbox profile resolution issues where --add-dir
+        // is sometimes dropped.
+        result.push("-c".to_string());
+        result.push(config_val);
+    }
+
     result.extend(tokens.iter().cloned());
     result
 }
@@ -357,10 +380,49 @@ mod tests {
     fn test_ensure_hcom_writable_no_duplicate() {
         init_config();
         let hcom_dir = paths::hcom_dir().to_string_lossy().to_string();
+        // If only --add-dir is already present, it should not duplicate that flag.
+        // The config override may still be injected.
         let tokens = vec!["--full-auto".to_string(), "--add-dir".to_string(), hcom_dir];
         let result = ensure_hcom_writable(&tokens);
         let add_dir_count = result.iter().filter(|t| *t == "--add-dir").count();
         assert_eq!(add_dir_count, 1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_ensure_hcom_writable_avoids_duplicate_config() {
+        init_config();
+        let hcom_dir = paths::hcom_dir().to_string_lossy().to_string();
+        let config_val = format!("sandbox_workspace_write.writable_roots=[\"{}\"]", hcom_dir);
+        // If both are present, should return original tokens
+        let tokens = vec![
+            "--sandbox".to_string(),
+            "workspace-write".to_string(),
+            "--add-dir".to_string(),
+            hcom_dir,
+            "-c".to_string(),
+            config_val,
+        ];
+        let result = ensure_hcom_writable(&tokens);
+        assert_eq!(result, tokens);
+    }
+
+    #[test]
+    #[serial]
+    fn test_ensure_hcom_writable_adds_config_override() {
+        init_config();
+        let hcom_dir = paths::hcom_dir().to_string_lossy().to_string();
+        let tokens = s(&["--sandbox", "workspace-write"]);
+        let result = ensure_hcom_writable(&tokens);
+        
+        // Should contain --add-dir <hcom_dir>
+        assert!(result.contains(&"--add-dir".to_string()));
+        assert!(result.contains(&hcom_dir));
+        
+        // Should ALSO contain -c sandbox_workspace_write.writable_roots=["<hcom_dir>"]
+        let config_val = format!("sandbox_workspace_write.writable_roots=[\"{}\"]", hcom_dir);
+        assert!(result.contains(&"-c".to_string()));
+        assert!(result.contains(&config_val));
     }
 
     #[test]


### PR DESCRIPTION
### Problem Statement
In Codex versions prior to 0.128.0, one-off CLI flags like `--add-dir` could be dropped or ignored during the reconciliation of configuration layers and permission profiles. Specifically, when a named profile or environment-level sandbox setting is resolved, it may supersede the filesystem permissions granted via the `--add-dir` launch flag without warning. This frequently resulted in "Operation not permitted" errors when `hcom` attempted to write to its SQLite database, even though the flag appeared correctly in the process list. This is a known persistence bug tracked in **openai/codex#11401**.

### Solution
This PR implements a "defense-in-depth" approach to directory permissions. Instead of relying solely on the `--add-dir` flag, we now explicitly inject a direct configuration override:
`-c sandbox_workspace_write.writable_roots=["/path/to/hcom"]`

By providing both the CLI flag and the config-level override, we ensure the `hcom` directory survives the configuration reconciliation process across all session types.

**Key Changes:**
- **Robust Flag Detection:** Updated `ensure_hcom_writable` to use the `CodexArgSpec` parser, ensuring we correctly detect existing `-c` and `--add-dir` values.
- **Safe Path Injection:** Used `serde_json` to escape the `hcom_dir` path, preventing injection vulnerabilities or parsing errors if the path contains quotes or special characters.
- **Dual Injection:** Modified the logic to inject both the flag and the config override if they are missing.

### Verification
- Added `test_ensure_hcom_writable_avoids_duplicate_config`
- Added `test_ensure_hcom_writable_adds_config_override`
- Confirmed all `codex_preprocessing` tests pass via `cargo test codex_preprocessing`.