### PR TITLE
feat: add KiloCode agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > **Hook your coding agents together**
 
-`hcom` is a CLI that agents can use to message, watch, and spawn each other across terminals. It integrates with Claude Code, Gemini, Codex, and OpenCode without changing how you use them.
+`hcom` is a CLI that agents can use to message, watch, and spawn each other across terminals. It integrates with Claude Code, Gemini, Codex, OpenCode, and Kilo Code without changing how you use them.
 
 Use it to coordinate pipelines, run different AI CLIs as each other's subagents, or just instead of copy-paste.
 
@@ -43,7 +43,7 @@ uv tool install hcom  # or: pip install hcom
 Terminal 1:
 
 ```bash
-hcom claude   # codex / gemini / opencode
+hcom claude   # codex / gemini / opencode / kilo
 ```
 
 Terminal 2:
@@ -216,6 +216,7 @@ brew uninstall hcom          # or: rm $(which hcom)
 | Gemini CLI | automatic | `hcom gemini` |
 | Codex CLI | automatic | `hcom codex` |
 | OpenCode | automatic | `hcom opencode` |
+| Kilo Code | automatic | `hcom kilo` |
 | Anything else | manual via `hcom listen` | `hcom start` (run inside tool) |
 
 ```bash
@@ -248,7 +249,7 @@ What you might type from a shell. Agents run their own commands that they learn 
 ### Spawn
 
 ```bash
-hcom [N] claude|gemini|codex|opencode   # launch N agents
+hcom [N] claude|gemini|codex|opencode|kilo   # launch N agents
 hcom r <name|session_id>                # resume agent
 hcom f <name|session_id>                # fork session
 hcom kill <name|tag:T|all>              # kill + close terminal pane
@@ -311,7 +312,7 @@ hcom config -i <name> <key> <value>   # per-agent override at runtime
 | `terminal` | Where new agent windows open (`hcom config terminal --info`) |
 | `timeout` | Idle timeout for headless/vanilla Claude (seconds) |
 | `subagent_timeout` | Keep-alive for Claude subagents (seconds) |
-| `claude_args` / `gemini_args` / `codex_args` / `opencode_args` | Default args passed to the tool |
+| `claude_args` / `gemini_args` / `codex_args` / `opencode_args` / `kilo_args` | Default args passed to the tool |
 
 ### Scope
 
@@ -397,6 +398,35 @@ For concurrent worktrees, scope each to its own DB:
 
 ```bash
 HCOM_DIR=$PWD/.hcom HCOM_DEV_ROOT=$PWD hcom claude
+```
+
+### Testing a fork alongside the original
+
+To test a custom fork (e.g., with kilo support) without replacing your installed `hcom`:
+
+```bash
+# 1. Clone your fork
+git clone https://github.com/Solar2004/hcom.git ~/hcom-kilo
+cd ~/hcom-kilo
+cargo build
+
+# 2. Use dev_root to point at the fork build
+hcom config dev_root $(pwd)
+hcom status          # now runs your fork
+
+# 3. Revert to original anytime
+hcom config dev_root --unset
+```
+
+Or use a symlink swap:
+
+```bash
+# Point to your fork build
+ln -sf ~/hcom-kilo/target/debug/hcom ~/.cargo/bin/hcom-kilo
+
+# Run either
+hcom          # original installed version
+hcom-kilo     # your fork
 ```
 
 </details>

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -63,10 +63,10 @@ You MUST use `hcom <cmd+flags> --name {instance_name}` for all hcom commands:
   Filters (same flag=OR, different=AND): --agent NAME | --type message|status|life | --status listening|active|blocked | --cmd PATTERN (contains, ^prefix, =exact) | --file PATH (*.py for glob, file.py for contains)
   Event-based notifications, watch agents, subscribe, react: events sub [filters] | --help
 - Handoff context: bundle prepare
-- Spawn agents: [num] <claude|gemini|codex|opencode> [--tag labelOrGroup] [--terminal tmux|kitty|wezterm|etc]
+- Spawn agents: [num] <claude|gemini|codex|opencode|kilo> [--tag labelOrGroup] [--terminal tmux|kitty|wezterm|etc]
   Example: `hcom 1 claude --tag cool` -> automatic <hcom> msg when ready -> send it task via hcom send
   Resume: hcom r <name> [args] | Fork: hcom f <name> [args] | Kill: hcom kill <name(s)>
-  background, set prompt, system, forward args: <claude|gemini|codex|opencode> --help
+  background, set prompt, system, forward args: <claude|gemini|codex|opencode|kilo> --help
 - Run workflows: run <script> [args] [--help]
   {scripts}
 - View agent screen: term [name] | inject text/enter: term inject <name> ['text'] [--enter]
@@ -412,7 +412,7 @@ pub fn get_bootstrap(
 
     // Tool-specific delivery
     if tool == "claude"
-        || ((tool == "codex" || tool == "gemini" || tool == "opencode") && ctx.is_launched)
+        || ((tool == "codex" || tool == "gemini" || tool == "opencode" || tool == "kilo") && ctx.is_launched)
     {
         parts.push(DELIVERY_AUTO);
     } else {

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -176,7 +176,7 @@ const LIST_HELP: &[HelpEntry] = &[
     ("Tool labels:", ""),
     (
         "",
-        "[CLAUDE] [GEMINI] [CODEX] [OPENCODE]  hcom-launched (PTY + hooks)",
+        "[CLAUDE] [GEMINI] [CODEX] [OPENCODE] [KILO] [KILOCODE]  hcom-launched (PTY + hooks)",
     ),
     (
         "",
@@ -432,7 +432,7 @@ const RESET_HELP: &[HelpEntry] = &[
     ),
     (
         "",
-        "  HCOM_DIR=$PWD/.hcom -> $PWD/.claude, .gemini, .codex, .opencode",
+        "  HCOM_DIR=$PWD/.hcom -> $PWD/.claude, .gemini, .codex, .opencode, .kilo, .kilocode",
     ),
     ("", ""),
     ("", "To remove local setup:"),
@@ -466,7 +466,7 @@ const CONFIG_HELP: &[HelpEntry] = &[
         "Subagent keep-alive seconds after task",
     ),
     (
-        "  claude_args / gemini_args / codex_args / opencode_args",
+        "  claude_args / gemini_args / codex_args / opencode_args / kilo_args",
         "",
     ),
     ("  auto_approve", "Auto-approve safe hcom commands"),
@@ -530,7 +530,7 @@ const TRANSCRIPT_HELP: &[HelpEntry] = &[
     ("  --limit N", "Max results (default: 20)"),
     (
         "  --agent TYPE",
-        "Filter: claude | gemini | codex | opencode",
+        "Filter: claude | gemini | codex | opencode | kilo | kilocode",
     ),
     (
         "  --exclude-self",
@@ -598,7 +598,7 @@ const HOOKS_HELP: &[HelpEntry] = &[
     ("hooks status", "Same as above"),
     (
         "hooks add [tool]",
-        "Add hooks (claude | gemini | codex | opencode | all)",
+        "Add hooks (claude | gemini | codex | opencode | kilo | kilocode | all)",
     ),
     (
         "hooks remove [tool]",
@@ -723,12 +723,30 @@ const OPENCODE_SPEC: ToolHelpSpec = ToolHelpSpec {
     has_fork: true,
 };
 
+const KILO_SPEC: ToolHelpSpec = ToolHelpSpec {
+    name: "kilo",
+    label: "Kilo",
+    unique_examples: &[],
+    extra_env: &[],
+    has_fork: true,
+};
+
+const KILOCODE_SPEC: ToolHelpSpec = ToolHelpSpec {
+    name: "kilocode",
+    label: "KiloCode",
+    unique_examples: &[],
+    extra_env: &[],
+    has_fork: true,
+};
+
 fn get_tool_spec(name: &str) -> Option<&'static ToolHelpSpec> {
     match name {
         "claude" => Some(&CLAUDE_SPEC),
         "gemini" => Some(&GEMINI_SPEC),
         "codex" => Some(&CODEX_SPEC),
         "opencode" => Some(&OPENCODE_SPEC),
+        "kilo" => Some(&KILO_SPEC),
+        "kilocode" => Some(&KILOCODE_SPEC),
         _ => None,
     }
 }
@@ -888,6 +906,8 @@ pub const COMMAND_NAMES: &[&str] = &[
     "gemini",
     "codex",
     "opencode",
+    "kilo",
+    "kilocode",
 ];
 
 /// Get the top-level help text as a String.
@@ -900,9 +920,9 @@ Usage:\n\
   hcom <command>                        Run command\n\
 \n\
 Launch:\n\
-  hcom [N] claude|gemini|codex|opencode [flags] [tool-args]\n\
+  hcom [N] claude|gemini|codex|opencode|kilo|kilocode [flags] [tool-args]\n\
   hcom r <name>                         Resume stopped agent\n\
-  hcom f <name>                         Fork agent session (claude/codex/opencode)\n\
+  hcom f <name>                         Fork agent session (claude/codex/opencode/kilo/kilocode)\n\
   hcom kill <name(s)|tag:T|all>         Kill + close terminal pane\n\
 \n\
 Commands:\n\
@@ -997,7 +1017,7 @@ pub fn get_command_help(name: &str) -> String {
         return resume_fork_help(
             "hcom f <target> [tool-args...]    Fork an agent session (active or stopped)",
             "Creates a new agent that continues from the forked session.\n\
-             Supported tools: claude, codex, opencode. (gemini does not fork.)\n\
+             Supported tools: claude, codex, opencode, kilo, kilocode. (gemini does not fork.)\n\
              Remote fork (`:<device>`) requires --dir to pin the target cwd.",
             "hcom r <target>                   Resume a stopped agent",
         );
@@ -1118,6 +1138,8 @@ mod tests {
             "gemini",
             "codex",
             "opencode",
+            "kilo",
+            "kilocode",
         ];
         for cmd in commands {
             let help = get_command_help(cmd);
@@ -1170,7 +1192,7 @@ mod tests {
     fn top_level_help_scopes_fork_to_supported_tools() {
         let help = get_help_text();
         assert!(help.contains(
-            "hcom f <name>                         Fork agent session (claude/codex/opencode)"
+            "hcom f <name>                         Fork agent session (claude/codex/opencode/kilo/kilocode)"
         ));
     }
 }

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -16,7 +16,7 @@ pub struct HooksArgs {
 }
 
 /// Valid tool names for hooks management.
-const HOOK_TOOLS: &[&str] = &["claude", "gemini", "codex", "opencode"];
+const HOOK_TOOLS: &[&str] = &["claude", "gemini", "codex", "opencode", "kilocode"];
 
 /// Get hook installation status for each tool.
 fn get_tool_status() -> Vec<(&'static str, bool, String)> {
@@ -40,11 +40,17 @@ fn get_tool_status() -> Vec<(&'static str, bool, String)> {
         .to_string_lossy()
         .to_string();
 
+    let kilocode_installed = crate::hooks::kilo::verify_kilocode_plugin_installed();
+    let kilocode_path = crate::hooks::kilo::get_kilocode_plugin_path()
+        .to_string_lossy()
+        .to_string();
+
     vec![
         ("claude", claude_installed, claude_path),
         ("gemini", gemini_installed, gemini_path),
         ("codex", codex_installed, codex_path),
         ("opencode", opencode_installed, opencode_path),
+        ("kilocode", kilocode_installed, kilocode_path),
     ]
 }
 
@@ -81,7 +87,7 @@ fn cmd_hooks_add(argv: &[String]) -> i32 {
         vec![argv[0].as_str()]
     } else {
         eprintln!("Error: Unknown tool: {}", argv[0]);
-        eprintln!("Valid options: claude, gemini, codex, opencode, all");
+        eprintln!("Valid options: claude, gemini, codex, opencode, kilocode, all");
         return 1;
     };
 
@@ -101,6 +107,7 @@ fn cmd_hooks_add(argv: &[String]) -> i32 {
             "gemini" => crate::hooks::gemini::verify_gemini_hooks_installed(include_permissions),
             "codex" => crate::hooks::codex::verify_codex_hooks_installed(include_permissions),
             "opencode" => crate::hooks::opencode::verify_opencode_plugin_installed(),
+            "kilocode" => crate::hooks::kilo::verify_kilocode_plugin_installed(),
             _ => false,
         };
         if already {
@@ -121,6 +128,11 @@ fn cmd_hooks_add(argv: &[String]) -> i32 {
                 Err(e) => AddResult::Failed(Some(e.to_string())),
             },
             "opencode" => match crate::hooks::opencode::install_opencode_plugin() {
+                Ok(true) => AddResult::Added,
+                Ok(false) => AddResult::Failed(None),
+                Err(e) => AddResult::Failed(Some(e.to_string())),
+            },
+            "kilocode" => match crate::hooks::kilo::install_kilocode_plugin() {
                 Ok(true) => AddResult::Added,
                 Ok(false) => AddResult::Failed(None),
                 Err(e) => AddResult::Failed(Some(e.to_string())),
@@ -165,6 +177,7 @@ fn cmd_hooks_add(argv: &[String]) -> i32 {
                 "gemini" => "Gemini CLI",
                 "codex" => "Codex",
                 "opencode" => "OpenCode",
+                "kilocode" => "KiloCode",
                 other => other,
             };
             println!("Restart {tool_name} to activate hooks.");
@@ -185,7 +198,7 @@ pub fn cmd_hooks_remove(argv: &[String]) -> i32 {
         vec![argv[0].as_str()]
     } else {
         eprintln!("Error: Unknown tool: {}", argv[0]);
-        eprintln!("Valid options: claude, gemini, codex, opencode, all");
+        eprintln!("Valid options: claude, gemini, codex, opencode, kilocode, all");
         return 1;
     };
 
@@ -205,6 +218,14 @@ pub fn cmd_hooks_remove(argv: &[String]) -> i32 {
             "gemini" => crate::hooks::gemini::remove_gemini_hooks(),
             "codex" => crate::hooks::codex::remove_codex_hooks(),
             "opencode" => match crate::hooks::opencode::remove_opencode_plugin() {
+                Ok(()) => true,
+                Err(e) => {
+                    eprintln!("Failed to remove {tool} hooks: {e}");
+                    fail_count += 1;
+                    continue;
+                }
+            },
+            "kilocode" => match crate::hooks::kilo::remove_kilocode_plugin() {
                 Ok(()) => true,
                 Err(e) => {
                     eprintln!("Failed to remove {tool} hooks: {e}");
@@ -251,8 +272,8 @@ pub fn cmd_hooks(_db: &HcomDb, args: &HooksArgs, _ctx: Option<&CommandContext>) 
              Usage:\n  \
              hcom hooks                  Show hook status for all tools\n  \
              hcom hooks status           Same as above\n  \
-             hcom hooks add [tool]       Add hooks (claude|gemini|codex|opencode|all)\n  \
-             hcom hooks remove [tool]    Remove hooks (claude|gemini|codex|opencode|all)\n\n\
+               hcom hooks add [tool]       Add hooks (claude|gemini|codex|opencode|kilocode|all)\n  \
+               hcom hooks remove [tool]    Remove hooks (claude|gemini|codex|opencode|kilocode|all)\n\n\
              Examples:\n  \
              hcom hooks add claude       Add Claude Code hooks only\n  \
              hcom hooks add              Auto-detect tool or add all\n  \
@@ -286,7 +307,7 @@ mod tests {
         // (unless running inside one, which is fine — it'll detect it)
         let tool = detect_current_tool();
         assert!(
-            ["claude", "gemini", "codex", "opencode", "adhoc"].contains(&tool),
+            ["claude", "gemini", "codex", "opencode", "kilocode", "adhoc"].contains(&tool),
             "unexpected tool: {tool}"
         );
     }

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -407,6 +407,8 @@ pub(crate) fn print_launch_preview(preview: LaunchPreview<'_>) {
             "gemini" => &preview.config.gemini_args,
             "codex" => &preview.config.codex_args,
             "opencode" => &preview.config.opencode_args,
+            "kilo" => &preview.config.kilo_args,
+            "kilocode" => &preview.config.kilo_args,
             _ => "",
         }
     } else {
@@ -555,7 +557,7 @@ pub(crate) fn merge_tool_args(tool: &str, cli_args: &[String], config: &HcomConf
             let merged = codex_args::merge_codex_args(&env_spec, &cli_spec);
             merged.rebuild_tokens(true, true)
         }
-        _ => cli_args.to_vec(), // opencode: pass through
+        _ => cli_args.to_vec(), // opencode, kilo: pass through
     }
 }
 

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -872,7 +872,7 @@ fn build_resume_args(tool: &str, session_id: &str, fork: bool) -> Vec<String> {
             let subcmd = if fork { "fork" } else { "resume" };
             vec![subcmd.to_string(), session_id.to_string()]
         }
-        "opencode" => {
+        "opencode" | "kilocode" => {
             let mut args = vec!["--session".to_string(), session_id.to_string()];
             if fork {
                 args.push("--fork".to_string());
@@ -908,7 +908,7 @@ fn merge_resume_args(tool: &str, original: &[String], resume: &[String]) -> Vec<
             let merged = codex_args::merge_codex_args(&orig_spec, &resume_spec);
             merged.rebuild_tokens(true, true)
         }
-        "opencode" => merge_opencode_args(original, resume),
+        "opencode" | "kilocode" => merge_opencode_args(original, resume),
         _ => {
             // For unknown tools: resume args only.
             resume.to_vec()
@@ -1229,6 +1229,28 @@ fn lookup_opencode_session(session_id: &str) -> Option<String> {
     .ok()
 }
 
+fn lookup_kilocode_session(session_id: &str) -> Option<String> {
+    let kilocode_data = opencode_data_dir().map(|d| {
+        let parent = d.parent()?;
+        Some(parent.join("kilocode"))
+    })??;
+    let db_path = kilocode_data.join("kilocode.db");
+    if !db_path.exists() {
+        return None;
+    }
+    let conn = rusqlite::Connection::open_with_flags(
+        &db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()?;
+    conn.query_row(
+        "SELECT directory FROM session WHERE id = ?1",
+        rusqlite::params![session_id],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+}
+
 /// Resolve a session ID to the owning tool and (optionally) a pre-recovered
 /// working directory.
 ///
@@ -1237,10 +1259,13 @@ fn lookup_opencode_session(session_id: &str) -> Option<String> {
 /// - Opencode: returns `(tool="opencode", None)` — opencode stores sessions
 ///   in SQLite; CWD comes from a separate DB query, not a transcript file.
 fn find_session_on_disk(session_id: &str) -> Option<(String, Option<String>)> {
-    // 1. Opencode: prefix-scoped, query the SQLite DB directly.
+    // 1. Opencode/KiloCode: prefix-scoped, query the SQLite DB directly.
     if is_opencode_session_id(session_id) {
         if lookup_opencode_session(session_id).is_some() {
             return Some(("opencode".to_string(), None));
+        }
+        if lookup_kilocode_session(session_id).is_some() {
+            return Some(("kilocode".to_string(), None));
         }
         return None;
     }
@@ -1377,12 +1402,20 @@ fn build_adopt_plan(
         let opencode_db = opencode_data_dir()
             .map(|d| d.join("opencode.db").display().to_string())
             .unwrap_or_else(|| "(no data dir)".to_string());
+        let kilocode_db = opencode_data_dir()
+            .and_then(|d| {
+                let parent = d.parent()?;
+                Some(parent.join("kilocode/kilocode.db").display().to_string())
+            })
+            .unwrap_or_else(|| "(no data dir)".to_string());
         if is_opencode_session_id(session_id) {
             anyhow::anyhow!(
                 "Session {sid} not found. Searched:\n  \
-                 - Opencode: {opencode_db} (table 'session')",
+                 - Opencode: {opencode_db} (table 'session')\n  \
+                 - KiloCode: {kilocode_db} (table 'session')",
                 sid = session_id,
                 opencode_db = opencode_db,
+                kilocode_db = kilocode_db,
             )
         } else {
             let claude_projects = claude_config_dir().join("projects");
@@ -1407,6 +1440,8 @@ fn build_adopt_plan(
     } else {
         let raw = if tool == "opencode" {
             lookup_opencode_session(session_id)
+        } else if tool == "kilocode" {
+            lookup_kilocode_session(session_id)
         } else if let Some(ref path) = transcript_path {
             extract_cwd_from_transcript(path, &tool)
         } else {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -51,6 +51,14 @@ fn check_opencode_hooks() -> bool {
     crate::hooks::opencode::verify_opencode_plugin_installed()
 }
 
+fn check_kilo_hooks() -> bool {
+    crate::hooks::kilo::verify_kilocode_plugin_installed()
+}
+
+fn check_kilocode_hooks() -> bool {
+    crate::hooks::kilo::verify_kilocode_plugin_installed()
+}
+
 // ── Status Collection ────────────────────────────────────────────────────
 
 struct ToolStatus {
@@ -92,6 +100,16 @@ fn get_tool_statuses() -> Vec<ToolStatus> {
             name: "OpenCode",
             installed: is_in_path("opencode"),
             hooks: check_opencode_hooks(),
+        },
+        ToolStatus {
+            name: "Kilo",
+            installed: is_in_path("kilo"),
+            hooks: check_kilo_hooks(),
+        },
+        ToolStatus {
+            name: "KiloCode",
+            installed: is_in_path("kilocode"),
+            hooks: check_kilocode_hooks(),
         },
     ]
 }
@@ -239,6 +257,14 @@ pub fn cmd_status(db: &HcomDb, args: &StatusArgs, _ctx: Option<&CommandContext>)
                 "opencode": {
                     "installed": tools[3].installed,
                     "hooks": tools[3].hooks,
+                },
+                "kilo": {
+                    "installed": tools[4].installed,
+                    "hooks": tools[4].hooks,
+                },
+                "kilocode": {
+                    "installed": tools[5].installed,
+                    "hooks": tools[5].hooks,
                 },
             },
             "terminal": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,7 @@ const TOML_KEY_MAP: &[(&str, &str)] = &[
     ("codex_sandbox_mode", "launch.codex.sandbox_mode"),
     ("codex_system_prompt", "launch.codex.system_prompt"),
     ("opencode_args", "launch.opencode.args"),
+    ("kilo_args", "launch.kilo.args"),
     ("relay", "relay.url"),
     ("relay_id", "relay.id"),
     ("relay_token", "relay.token"),
@@ -118,6 +119,7 @@ const FIELD_TO_ENV: &[(&str, &str)] = &[
     ("gemini_system_prompt", "HCOM_GEMINI_SYSTEM_PROMPT"),
     ("codex_system_prompt", "HCOM_CODEX_SYSTEM_PROMPT"),
     ("opencode_args", "HCOM_OPENCODE_ARGS"),
+    ("kilo_args", "HCOM_KILO_ARGS"),
     ("relay", "HCOM_RELAY"),
     ("relay_id", "HCOM_RELAY_ID"),
     ("relay_token", "HCOM_RELAY_TOKEN"),
@@ -223,6 +225,7 @@ pub struct HcomConfig {
     pub gemini_args: String,
     pub codex_args: String,
     pub opencode_args: String,
+    pub kilo_args: String,
     pub codex_sandbox_mode: String,
     pub gemini_system_prompt: String,
     pub codex_system_prompt: String,
@@ -249,6 +252,7 @@ impl Default for HcomConfig {
             gemini_args: String::new(),
             codex_args: String::new(),
             opencode_args: String::new(),
+            kilo_args: String::new(),
             codex_sandbox_mode: "workspace".to_string(),
             gemini_system_prompt: String::new(),
             codex_system_prompt: String::new(),
@@ -337,6 +341,7 @@ impl HcomConfig {
             ("gemini_args", &self.gemini_args),
             ("codex_args", &self.codex_args),
             ("opencode_args", &self.opencode_args),
+            ("kilo_args", &self.kilo_args),
         ] {
             if !value.is_empty() {
                 if let Err(e) = shell_words::split(value) {
@@ -395,6 +400,7 @@ impl HcomConfig {
             "gemini_args" => Some(self.gemini_args.clone()),
             "codex_args" => Some(self.codex_args.clone()),
             "opencode_args" => Some(self.opencode_args.clone()),
+            "kilo_args" => Some(self.kilo_args.clone()),
             "codex_sandbox_mode" => Some(self.codex_sandbox_mode.clone()),
             "gemini_system_prompt" => Some(self.gemini_system_prompt.clone()),
             "codex_system_prompt" => Some(self.codex_system_prompt.clone()),
@@ -431,6 +437,7 @@ impl HcomConfig {
             "gemini_args" => self.gemini_args = value.to_string(),
             "codex_args" => self.codex_args = value.to_string(),
             "opencode_args" => self.opencode_args = value.to_string(),
+            "kilo_args" => self.kilo_args = value.to_string(),
             "codex_sandbox_mode" => {
                 // Normalize legacy value
                 self.codex_sandbox_mode = if value == "full-auto" {
@@ -545,6 +552,7 @@ impl HcomConfig {
             "gemini_args",
             "codex_args",
             "opencode_args",
+            "kilo_args",
             "codex_sandbox_mode",
             "gemini_system_prompt",
             "codex_system_prompt",
@@ -892,6 +900,9 @@ sandbox_mode = "workspace"
 system_prompt = ""
 
 [launch.opencode]
+args = ""
+
+[launch.kilo]
 args = ""
 
 [preferences]

--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -313,6 +313,18 @@ impl ToolConfig {
         }
     }
 
+    /// Get config for KiloCode (fork of OpenCode — same plugin-based delivery).
+    pub fn kilocode() -> Self {
+        Self {
+            tool: "kilocode".to_string(),
+            require_idle: false,
+            require_ready_prompt: false,
+            require_prompt_empty: false,
+            block_on_user_activity: false,
+            block_on_approval: false,
+        }
+    }
+
     /// Get config by tool.
     pub fn for_tool(tool: crate::tool::Tool) -> Self {
         match tool {
@@ -320,6 +332,7 @@ impl ToolConfig {
             crate::tool::Tool::Gemini => Self::gemini(),
             crate::tool::Tool::Codex => Self::codex(),
             crate::tool::Tool::OpenCode => Self::opencode(),
+            crate::tool::Tool::Kilo => Self::kilocode(),
             crate::tool::Tool::Adhoc => Self::claude(),
         }
     }
@@ -597,7 +610,7 @@ pub fn run_delivery_loop(
     // After that, the plugin takes over (messages.transform for active, promptAsync for idle).
     use crate::tool::Tool;
     use std::str::FromStr;
-    if matches!(Tool::from_str(&config.tool), Ok(Tool::OpenCode)) {
+    if matches!(Tool::from_str(&config.tool), Ok(Tool::OpenCode) | Ok(Tool::Kilo)) {
         log_info(
             "native",
             "delivery.opencode_mode",

--- a/src/hooks/family.rs
+++ b/src/hooks/family.rs
@@ -39,6 +39,12 @@ pub static TOOL_NAME_MAPPINGS: LazyLock<
     codex.insert("file", vec!["apply_patch"]);
     m.insert("codex", codex);
 
+    let mut kilo = HashMap::new();
+    kilo.insert("bash", vec!["Bash", "execute_command", "shell"]);
+    kilo.insert("file", vec!["Write", "Edit"]);
+    kilo.insert("delegate", vec!["Task", "Agent"]);
+    m.insert("kilocode", kilo);
+
     m
 });
 

--- a/src/hooks/kilo.rs
+++ b/src/hooks/kilo.rs
@@ -1,0 +1,655 @@
+use std::time::Instant;
+
+use serde_json::Value;
+
+use crate::bootstrap;
+use crate::db::HcomDb;
+use crate::instance_binding;
+use crate::instance_lifecycle as lifecycle;
+use crate::instances;
+use crate::log::{log_error, log_info};
+use crate::shared::ST_LISTENING;
+use crate::shared::context::HcomContext;
+
+use super::common;
+use super::common::finalize_session;
+
+fn parse_flag(argv: &[String], flag: &str) -> Option<String> {
+    argv.iter()
+        .position(|a| a == flag)
+        .and_then(|i| argv.get(i + 1))
+        .cloned()
+}
+
+fn has_flag(argv: &[String], flag: &str) -> bool {
+    argv.iter().any(|a| a == flag)
+}
+
+fn parse_value_arg(argv: &[String], flags: &[&str]) -> Option<String> {
+    for (idx, token) in argv.iter().enumerate() {
+        for flag in flags {
+            if token == flag {
+                return argv.get(idx + 1).cloned();
+            }
+            let prefix = format!("{flag}=");
+            if let Some(value) = token.strip_prefix(&prefix) {
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn parse_launch_model(raw: &str) -> Option<Value> {
+    let (provider_id, model_id) = raw.split_once('/')?;
+    if provider_id.is_empty() || model_id.is_empty() {
+        return None;
+    }
+    Some(serde_json::json!({
+        "providerID": provider_id,
+        "modelID": model_id,
+    }))
+}
+
+fn launch_agent_and_model_from_args(launch_args: Option<&str>) -> (Option<String>, Option<Value>) {
+    let Some(raw_args) = launch_args.filter(|value| !value.is_empty()) else {
+        return (None, None);
+    };
+    let argv: Vec<String> = match serde_json::from_str(raw_args) {
+        Ok(args) => args,
+        Err(_) => return (None, None),
+    };
+    let agent = parse_value_arg(&argv, &["--agent"]);
+    let model =
+        parse_value_arg(&argv, &["--model", "-m"]).and_then(|value| parse_launch_model(&value));
+    (agent, model)
+}
+
+fn launch_agent_and_model(db: &HcomDb, instance_name: &str) -> (Option<String>, Option<Value>) {
+    db.get_instance_full(instance_name)
+        .ok()
+        .flatten()
+        .map(|instance| launch_agent_and_model_from_args(instance.launch_args.as_deref()))
+        .unwrap_or((None, None))
+}
+
+fn upsert_plugin_notify_endpoint(db: &HcomDb, instance_name: &str, port: u16) {
+    if let Err(e) = db.upsert_notify_endpoint(instance_name, "plugin", port) {
+        log_error(
+            "native",
+            "kilocode.register_notify_fail",
+            &format!(
+                "Failed to register plugin notify port for {}: {}",
+                instance_name, e
+            ),
+        );
+    }
+}
+
+fn notify_all_endpoints(db: &HcomDb, instance_name: &str) {
+    lifecycle::notify_instance_endpoints(db, instance_name, &[]);
+}
+
+fn get_kilocode_db_path() -> Option<String> {
+    let xdg_data = std::env::var("XDG_DATA_HOME").unwrap_or_else(|_| {
+        let home = std::env::var("HOME").unwrap_or_default();
+        format!("{}/.local/share", home)
+    });
+    let db_path = std::path::PathBuf::from(&xdg_data)
+        .join("kilocode")
+        .join("kilocode.db");
+    if db_path.exists() {
+        Some(db_path.to_string_lossy().to_string())
+    } else {
+        None
+    }
+}
+
+fn handle_start(ctx: &HcomContext, db: &HcomDb, argv: &[String]) -> (i32, String) {
+    let session_id = match parse_flag(argv, "--session-id") {
+        Some(sid) => sid,
+        None => return (0, r#"{"error":"Missing --session-id"}"#.to_string()),
+    };
+
+    let notify_port: Option<u16> = parse_flag(argv, "--notify-port").and_then(|s| s.parse().ok());
+
+    let process_id = match &ctx.process_id {
+        Some(pid) => pid.clone(),
+        None => return (0, r#"{"error":"HCOM_PROCESS_ID not set"}"#.to_string()),
+    };
+
+    if let Ok(Some(existing_name)) = db.get_session_binding(&session_id) {
+        let mut rebind_updates = serde_json::Map::new();
+        rebind_updates.insert("name_announced".into(), serde_json::json!(false));
+        rebind_updates.insert("session_id".into(), serde_json::json!(&session_id));
+
+        if let Some(db_path) = get_kilocode_db_path() {
+            rebind_updates.insert("transcript_path".into(), serde_json::json!(db_path));
+        }
+
+        instances::update_instance_position(db, &existing_name, &rebind_updates);
+        lifecycle::set_status(
+            db,
+            &existing_name,
+            ST_LISTENING,
+            "start",
+            Default::default(),
+        );
+
+        let hcom_config = crate::config::HcomConfig::load(None).unwrap_or_default();
+        let bootstrap_text = bootstrap::get_bootstrap(
+            db,
+            &ctx.hcom_dir,
+            &existing_name,
+            "kilocode",
+            ctx.is_background,
+            ctx.is_launched,
+            &ctx.notes,
+            &hcom_config.tag,
+            crate::relay::is_relay_enabled(&hcom_config),
+            ctx.background_name.as_deref(),
+        );
+
+        if let Some(port) = notify_port {
+            upsert_plugin_notify_endpoint(db, &existing_name, port);
+        }
+
+        log_info(
+            "hooks",
+            "kilocode-start.rebind",
+            &format!("instance={} session_id={}", existing_name, session_id),
+        );
+
+        let (launch_agent, launch_model) = launch_agent_and_model(db, &existing_name);
+        let mut result = serde_json::json!({
+            "name": existing_name,
+            "session_id": session_id,
+        });
+        result["bootstrap"] = Value::String(bootstrap_text);
+        if let Some(agent) = launch_agent {
+            result["agent"] = Value::String(agent);
+        }
+        if let Some(model) = launch_model {
+            result["model"] = model;
+        }
+        return (0, serde_json::to_string(&result).unwrap_or_default());
+    }
+
+    let instance_name =
+        match instance_binding::bind_session_to_process(db, &session_id, Some(&process_id)) {
+            Some(name) => name,
+            None => {
+                return (
+                    0,
+                    r#"{"error":"No instance bound to this process"}"#.to_string(),
+                );
+            }
+        };
+
+    if let Err(e) = db.rebind_instance_session(&instance_name, &session_id) {
+        log_error(
+            "hooks",
+            "hook.error",
+            &format!("hook=kilocode-start op=rebind_session err={}", e),
+        );
+    }
+
+    if let Ok(Some(existing)) = db.get_instance_full(&instance_name) {
+        if existing.last_event_id == 0 {
+            let launch_event_id: Option<i64> = std::env::var("HCOM_LAUNCH_EVENT_ID")
+                .ok()
+                .and_then(|s| s.parse().ok());
+            let current_max = db.get_last_event_id();
+            let new_id = match launch_event_id {
+                Some(lei) if lei <= current_max => lei,
+                _ => current_max,
+            };
+            let mut id_updates = serde_json::Map::new();
+            id_updates.insert("last_event_id".into(), serde_json::json!(new_id));
+            instances::update_instance_position(db, &instance_name, &id_updates);
+        }
+    }
+
+    lifecycle::set_status(
+        db,
+        &instance_name,
+        ST_LISTENING,
+        "start",
+        Default::default(),
+    );
+
+    instance_binding::capture_and_store_launch_context(db, &instance_name);
+
+    let mut updates = serde_json::Map::new();
+    updates.insert("session_id".into(), serde_json::json!(&session_id));
+    if let Some(db_path) = get_kilocode_db_path() {
+        updates.insert("transcript_path".into(), serde_json::json!(db_path));
+    }
+    if !ctx.cwd.as_os_str().is_empty() {
+        updates.insert(
+            "directory".into(),
+            serde_json::json!(ctx.cwd.to_string_lossy()),
+        );
+    }
+    instances::update_instance_position(db, &instance_name, &updates);
+
+    if let Some(port) = notify_port {
+        upsert_plugin_notify_endpoint(db, &instance_name, port);
+    }
+
+    let tag = db
+        .get_instance_full(&instance_name)
+        .ok()
+        .flatten()
+        .and_then(|d| d.tag.clone())
+        .unwrap_or_default();
+
+    let hcom_config = crate::config::HcomConfig::load(None).unwrap_or_default();
+    let relay_enabled = crate::relay::is_relay_enabled(&hcom_config);
+    let effective_tag = if tag.is_empty() {
+        &hcom_config.tag
+    } else {
+        &tag
+    };
+    let bootstrap_text = bootstrap::get_bootstrap(
+        db,
+        &ctx.hcom_dir,
+        &instance_name,
+        "kilocode",
+        ctx.is_background,
+        ctx.is_launched,
+        &ctx.notes,
+        effective_tag,
+        relay_enabled,
+        ctx.background_name.as_deref(),
+    );
+
+    crate::relay::worker::ensure_worker(true);
+
+    let (launch_agent, launch_model) = launch_agent_and_model(db, &instance_name);
+    let mut response = serde_json::json!({
+        "name": instance_name,
+        "session_id": session_id,
+    });
+    response["bootstrap"] = Value::String(bootstrap_text);
+    if let Some(agent) = launch_agent {
+        response["agent"] = Value::String(agent);
+    }
+    if let Some(model) = launch_model {
+        response["model"] = model;
+    }
+    (0, serde_json::to_string(&response).unwrap_or_default())
+}
+
+fn handle_status(db: &HcomDb, argv: &[String]) -> (i32, String) {
+    let name = match parse_flag(argv, "--name") {
+        Some(n) => n,
+        None => return (0, r#"{"error":"Missing --name or --status"}"#.to_string()),
+    };
+    let status = match parse_flag(argv, "--status") {
+        Some(s) => s,
+        None => return (0, r#"{"error":"Missing --name or --status"}"#.to_string()),
+    };
+
+    let context = parse_flag(argv, "--context").unwrap_or_default();
+    let detail = parse_flag(argv, "--detail").unwrap_or_default();
+
+    lifecycle::set_status(
+        db,
+        &name,
+        &status,
+        &context,
+        lifecycle::StatusUpdate {
+            detail: &detail,
+            ..Default::default()
+        },
+    );
+
+    if status == ST_LISTENING {
+        notify_all_endpoints(db, &name);
+    }
+
+    (0, r#"{"ok":true}"#.to_string())
+}
+
+fn handle_read(db: &HcomDb, argv: &[String]) -> (i32, String) {
+    let name = match parse_flag(argv, "--name") {
+        Some(n) => n,
+        None => return (0, r#"{"error":"Missing --name"}"#.to_string()),
+    };
+
+    let format_mode = has_flag(argv, "--format");
+    let check_mode = has_flag(argv, "--check");
+    let ack_mode = has_flag(argv, "--ack");
+
+    let raw_messages = db.get_unread_messages(&name);
+    let messages: Vec<Value> = raw_messages.iter().map(common::message_to_value).collect();
+
+    if format_mode {
+        if messages.is_empty() {
+            return (0, String::new());
+        }
+        let deliver = common::limit_delivery_messages(&messages);
+        let formatted = common::format_messages_json_for_instance(db, &deliver, &name);
+        return (0, formatted);
+    }
+
+    if ack_mode {
+        let up_to = parse_flag(argv, "--up-to");
+        if let Some(up_to_str) = up_to {
+            let ack_id: i64 = match up_to_str.parse() {
+                Ok(id) => id,
+                Err(_) => {
+                    return (
+                        0,
+                        serde_json::json!({"error": format!("Invalid --up-to: {}", up_to_str)})
+                            .to_string(),
+                    );
+                }
+            };
+            let mut updates = serde_json::Map::new();
+            updates.insert("last_event_id".into(), serde_json::json!(ack_id));
+            instances::update_instance_position(db, &name, &updates);
+            return (0, serde_json::json!({"acked_to": ack_id}).to_string());
+        }
+        if messages.is_empty() {
+            return (0, r#"{"acked":0}"#.to_string());
+        }
+        let last_id = messages
+            .iter()
+            .filter_map(|m| m.get("event_id").and_then(|v| v.as_i64()))
+            .max()
+            .unwrap_or(0);
+        let ack_id = if last_id > 0 {
+            last_id
+        } else {
+            db.get_last_event_id()
+        };
+        if ack_id > 0 {
+            let mut updates = serde_json::Map::new();
+            updates.insert("last_event_id".into(), serde_json::json!(ack_id));
+            instances::update_instance_position(db, &name, &updates);
+        }
+        return (0, serde_json::json!({"acked": messages.len()}).to_string());
+    }
+
+    if check_mode {
+        return (
+            0,
+            if messages.is_empty() { "false" } else { "true" }.to_string(),
+        );
+    }
+
+    (
+        0,
+        serde_json::to_string(&messages).unwrap_or_else(|_| "[]".to_string()),
+    )
+}
+
+fn handle_stop(db: &HcomDb, argv: &[String]) -> (i32, String) {
+    let name = match parse_flag(argv, "--name") {
+        Some(n) => n,
+        None => return (0, r#"{"error":"Missing --name"}"#.to_string()),
+    };
+    let reason = parse_flag(argv, "--reason").unwrap_or_else(|| "unknown".to_string());
+
+    finalize_session(db, &name, &reason, None);
+
+    (0, r#"{"ok":true}"#.to_string())
+}
+
+pub fn dispatch_kilo_hook(hook_name: &str, argv: &[String]) -> (i32, String) {
+    let start = Instant::now();
+
+    let ctx = HcomContext::from_os();
+
+    crate::paths::ensure_hcom_directories_at(&ctx.hcom_dir);
+
+    let db = match HcomDb::open() {
+        Ok(db) => db,
+        Err(e) => {
+            log_error(
+                "hooks",
+                "hook.error",
+                &format!("hook={} op=db_open err={}", hook_name, e),
+            );
+            return (
+                0,
+                serde_json::json!({"error": format!("DB open failed: {}", e)}).to_string(),
+            );
+        }
+    };
+
+    if !common::hook_gate_check(&ctx, &db) {
+        return (0, String::new());
+    }
+
+    let handler_argv: Vec<String> = if !argv.is_empty() && argv[0] == hook_name {
+        argv[1..].to_vec()
+    } else {
+        argv.to_vec()
+    };
+
+    let handler_start = Instant::now();
+    let hook_name_owned = hook_name.to_string();
+
+    let (exit_code, output) = common::dispatch_with_panic_guard(
+        "kilocode",
+        &hook_name_owned,
+        (
+            0,
+            serde_json::json!({"error": "internal panic"}).to_string(),
+        ),
+        || match hook_name_owned.as_str() {
+            "kilocode-start" => handle_start(&ctx, &db, &handler_argv),
+            "kilocode-status" => handle_status(&db, &handler_argv),
+            "kilocode-read" => handle_read(&db, &handler_argv),
+            "kilocode-stop" => handle_stop(&db, &handler_argv),
+            _ => (
+                0,
+                serde_json::json!({"error": format!("Unknown KiloCode hook: {}", hook_name_owned)})
+                    .to_string(),
+            ),
+        },
+    );
+
+    let handler_ms = handler_start.elapsed().as_secs_f64() * 1000.0;
+    let total_ms = start.elapsed().as_secs_f64() * 1000.0;
+    log_info(
+        "hooks",
+        "kilocode.dispatch.timing",
+        &format!(
+            "hook={} handler_ms={:.2} total_ms={:.2} exit_code={}",
+            hook_name, handler_ms, total_ms, exit_code
+        ),
+    );
+
+    (exit_code, output)
+}
+
+pub const PLUGIN_SOURCE: &str = include_str!("../opencode_plugin/kilo-hcom.ts");
+
+const PLUGIN_FILENAME: &str = "kilo-hcom.ts";
+
+fn current_home_dir() -> std::path::PathBuf {
+    std::env::var("HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default())
+}
+
+fn xdg_config_home() -> String {
+    std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+        let home = std::env::var("HOME").unwrap_or_default();
+        format!("{}/.config", home)
+    })
+}
+
+pub fn get_kilocode_plugin_dir() -> std::path::PathBuf {
+    let tool_root = crate::runtime_env::tool_config_root();
+    let home = current_home_dir();
+    if tool_root == home {
+        std::path::PathBuf::from(xdg_config_home())
+            .join("kilocode")
+            .join("plugins")
+    } else {
+        tool_root.join(".kilocode").join("plugins")
+    }
+}
+
+pub fn get_kilocode_plugin_path() -> std::path::PathBuf {
+    get_kilocode_plugin_dir().join(PLUGIN_FILENAME)
+}
+
+fn scan_plugin_dirs() -> Vec<std::path::PathBuf> {
+    let mut candidates = Vec::new();
+    let xdg_base = std::path::PathBuf::from(xdg_config_home()).join("kilocode");
+    candidates.push(xdg_base.join("plugin"));
+    candidates.push(xdg_base.join("plugins"));
+
+    if let Ok(custom_dir) = std::env::var("KILOCODE_CONFIG_DIR") {
+        let custom_base = std::path::PathBuf::from(custom_dir);
+        candidates.push(custom_base.join("plugin"));
+        candidates.push(custom_base.join("plugins"));
+    }
+
+    let tool_root = crate::runtime_env::tool_config_root();
+    let home = current_home_dir();
+    if tool_root != home {
+        let tool_base = tool_root.join(".kilocode");
+        candidates.push(tool_base.join("plugin"));
+        candidates.push(tool_base.join("plugins"));
+    }
+
+    let mut deduped = Vec::new();
+    for dir in candidates.into_iter().filter(|d| d.exists()) {
+        if !deduped.contains(&dir) {
+            deduped.push(dir);
+        }
+    }
+    deduped
+}
+
+pub fn verify_kilocode_plugin_installed() -> bool {
+    if plugin_matches_source(&get_kilocode_plugin_path()) {
+        return true;
+    }
+    scan_plugin_dirs()
+        .iter()
+        .map(|d| d.join(PLUGIN_FILENAME))
+        .any(|path| plugin_matches_source(&path))
+}
+
+pub fn install_kilocode_plugin() -> std::io::Result<bool> {
+    let target_dir = get_kilocode_plugin_dir();
+    let target = target_dir.join(PLUGIN_FILENAME);
+
+    std::fs::create_dir_all(&target_dir)?;
+
+    if target.is_symlink() || target.exists() {
+        std::fs::remove_file(&target)?;
+    }
+
+    std::fs::write(&target, PLUGIN_SOURCE)?;
+    Ok(true)
+}
+
+pub fn remove_kilocode_plugin() -> std::io::Result<()> {
+    let mut paths = vec![get_kilocode_plugin_path()];
+
+    let xdg_base = std::path::PathBuf::from(xdg_config_home()).join("kilocode");
+    for sub in &["plugin", "plugins"] {
+        let p = xdg_base.join(sub).join(PLUGIN_FILENAME);
+        if !paths.contains(&p) {
+            paths.push(p);
+        }
+    }
+    if let Ok(custom_dir) = std::env::var("KILOCODE_CONFIG_DIR") {
+        let custom_base = std::path::PathBuf::from(custom_dir);
+        for sub in &["plugin", "plugins"] {
+            let p = custom_base.join(sub).join(PLUGIN_FILENAME);
+            if !paths.contains(&p) {
+                paths.push(p);
+            }
+        }
+    }
+    let tool_root = crate::runtime_env::tool_config_root();
+    let home = current_home_dir();
+    if tool_root != home {
+        let tool_base = tool_root.join(".kilocode");
+        for sub in &["plugin", "plugins"] {
+            let p = tool_base.join(sub).join(PLUGIN_FILENAME);
+            if !paths.contains(&p) {
+                paths.push(p);
+            }
+        }
+    }
+
+    for p in paths {
+        if p.exists() {
+            std::fs::remove_file(&p)?;
+        }
+    }
+    Ok(())
+}
+
+fn plugin_matches_source(path: &std::path::Path) -> bool {
+    match std::fs::read_to_string(path) {
+        Ok(content) => content == PLUGIN_SOURCE,
+        Err(_) => false,
+    }
+}
+
+pub fn ensure_plugin_installed() -> bool {
+    if verify_kilocode_plugin_installed() {
+        return true;
+    }
+    install_kilocode_plugin().unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_flag() {
+        let argv = vec!["--name".to_string(), "test".to_string()];
+        assert_eq!(parse_flag(&argv, "--name"), Some("test".to_string()));
+        assert_eq!(parse_flag(&argv, "--other"), None);
+    }
+
+    #[test]
+    fn test_has_flag() {
+        let argv = vec!["--ack".to_string(), "--format".to_string()];
+        assert!(has_flag(&argv, "--ack"));
+        assert!(!has_flag(&argv, "--check"));
+    }
+
+    #[test]
+    fn test_parse_value_arg() {
+        let argv = vec!["--model".to_string(), "p/m".to_string()];
+        assert_eq!(
+            parse_value_arg(&argv, &["--model", "-m"]),
+            Some("p/m".to_string())
+        );
+
+        let argv2 = vec!["--model=p/m".to_string()];
+        assert_eq!(
+            parse_value_arg(&argv2, &["--model", "-m"]),
+            Some("p/m".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_launch_model() {
+        let result = parse_launch_model("anthropic/claude-4");
+        assert!(result.is_some());
+        let v = result.unwrap();
+        assert_eq!(v["providerID"], "anthropic");
+        assert_eq!(v["modelID"], "claude-4");
+
+        assert!(parse_launch_model("invalid").is_none());
+        assert!(parse_launch_model("/empty").is_none());
+    }
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -6,6 +6,7 @@ pub mod codex;
 pub mod common;
 pub mod family;
 pub mod gemini;
+pub mod kilo;
 pub mod opencode;
 pub mod utils;
 

--- a/src/instance_binding.rs
+++ b/src/instance_binding.rs
@@ -694,7 +694,7 @@ pub fn resolve_instance_from_binding(
 /// Auto-subscribe instance to default event subscriptions from config.
 /// Called during instance creation.
 fn auto_subscribe_defaults(db: &HcomDb, instance_name: &str, tool: &str) {
-    if !matches!(tool, "claude" | "gemini" | "codex" | "opencode") {
+    if !matches!(tool, "claude" | "gemini" | "codex" | "opencode" | "kilocode") {
         return;
     }
 

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -21,7 +21,7 @@ use crate::instances;
 use crate::paths;
 use crate::shared::constants::{HCOM_IDENTITY_VARS, TOOL_MARKER_VARS};
 use crate::terminal;
-use crate::tools::{codex_preprocessing, opencode_preprocessing};
+use crate::tools::{codex_preprocessing, kilo_preprocessing, opencode_preprocessing};
 
 /// Canonical tool types for launch.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,6 +31,7 @@ pub enum LaunchTool {
     Gemini,
     Codex,
     OpenCode,
+    Kilo,
 }
 
 impl LaunchTool {
@@ -42,6 +43,7 @@ impl LaunchTool {
             "gemini" => Ok(LaunchTool::Gemini),
             "codex" => Ok(LaunchTool::Codex),
             "opencode" => Ok(LaunchTool::OpenCode),
+            "kilocode" | "kilo" => Ok(LaunchTool::Kilo),
             _ => bail!("Unknown tool: {}", s),
         }
     }
@@ -53,6 +55,7 @@ impl LaunchTool {
             LaunchTool::Gemini => "gemini",
             LaunchTool::Codex => "codex",
             LaunchTool::OpenCode => "opencode",
+            LaunchTool::Kilo => "kilo",
         }
     }
 
@@ -63,6 +66,7 @@ impl LaunchTool {
             LaunchTool::Gemini => "gemini",
             LaunchTool::Codex => "codex",
             LaunchTool::OpenCode => "opencode",
+            LaunchTool::Kilo => "kilo",
         }
     }
 
@@ -102,7 +106,7 @@ impl LaunchBackend {
         match tool {
             LaunchTool::Claude if !pty => LaunchBackend::NativePrint,
             LaunchTool::Claude | LaunchTool::ClaudePty => LaunchBackend::HeadlessPty,
-            LaunchTool::Gemini | LaunchTool::Codex | LaunchTool::OpenCode => {
+            LaunchTool::Gemini | LaunchTool::Codex | LaunchTool::OpenCode | LaunchTool::Kilo => {
                 LaunchBackend::HeadlessPty
             }
         }
@@ -280,6 +284,7 @@ fn install_diag_context(tool: &LaunchTool, paths: &[(&str, std::path::PathBuf)])
         LaunchTool::Gemini => Some("GEMINI_CLI_HOME"),
         LaunchTool::Codex => Some("CODEX_HOME"),
         LaunchTool::OpenCode => None,
+        LaunchTool::Kilo => None,
     };
     if let Some(env_var) = tool_env_var {
         let _ = writeln!(
@@ -383,6 +388,13 @@ fn ensure_hooks_installed(tool: &LaunchTool) -> Result<()> {
             }
             let diag = install_diag_context(tool, &[]);
             bail!("Failed to setup OpenCode plugin. Run: hcom hooks add opencode\n{diag}");
+        }
+        LaunchTool::Kilo => {
+            if crate::hooks::kilo::ensure_plugin_installed() {
+                return Ok(());
+            }
+            let diag = install_diag_context(tool, &[]);
+            bail!("Failed to setup Kilo plugin. Run: hcom hooks add kilo\n{diag}");
         }
     }
 }
@@ -867,6 +879,11 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
                 params.args.push("--prompt".to_string());
                 params.args.push(full_prompt);
             }
+            LaunchTool::Kilo => {
+                // Kilo: --prompt flag (same as opencode)
+                params.args.push("--prompt".to_string());
+                params.args.push(full_prompt);
+            }
         }
     }
     let batch_id = params
@@ -977,6 +994,7 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
             LaunchTool::Gemini => "gemini",
             LaunchTool::Codex => "codex",
             LaunchTool::OpenCode => "opencode",
+            LaunchTool::Kilo => "kilo",
         };
         if !is_tool_installed(tool_binary) {
             eprintln!("Error: '{}' is not installed or not in PATH", tool_binary);
@@ -1250,6 +1268,40 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
                         inside_ai_tool,
                     )
                 }
+
+                LaunchTool::Kilo => {
+                    kilo_preprocessing::preprocess_kilo_env(
+                        &mut instance_env,
+                        &instance_name,
+                    );
+
+                    instances::update_instance_position(
+                        db,
+                        &instance_name,
+                        &serde_json::Map::from_iter([(
+                            "launch_args".to_string(),
+                            json!(params.args),
+                        )]),
+                    );
+
+                    launch_pty_or_background(
+                        &mut BackgroundLaunchCtx {
+                            db,
+                            tool: "kilo",
+                            instance_name: &instance_name,
+                            process_id: &process_id,
+                            terminal_mode,
+                            tag: params.tag.as_deref().unwrap_or(""),
+                            working_dir,
+                            log_files: &mut log_files,
+                            handles: &mut handles,
+                        },
+                        &mut instance_env,
+                        &params.args,
+                        &params,
+                        inside_ai_tool,
+                    )
+                }
             }
         })();
 
@@ -1350,6 +1402,7 @@ fn validate_tool_args(tool: &LaunchTool, args: &[String]) -> Vec<String> {
             errs
         }
         LaunchTool::OpenCode => Vec::new(),
+        LaunchTool::Kilo => Vec::new(),
     }
 }
 
@@ -1385,6 +1438,10 @@ mod tests {
             LaunchTool::from_str("opencode", false).unwrap(),
             LaunchTool::OpenCode
         );
+        assert_eq!(
+            LaunchTool::from_str("kilo", false).unwrap(),
+            LaunchTool::Kilo
+        );
         assert!(LaunchTool::from_str("unknown", false).is_err());
     }
 
@@ -1409,6 +1466,7 @@ mod tests {
         assert!(LaunchTool::Gemini.uses_pty());
         assert!(LaunchTool::Codex.uses_pty());
         assert!(LaunchTool::OpenCode.uses_pty());
+        assert!(LaunchTool::Kilo.uses_pty());
     }
 
     #[test]
@@ -1420,6 +1478,7 @@ mod tests {
             LaunchTool::Gemini,
             LaunchTool::Codex,
             LaunchTool::OpenCode,
+            LaunchTool::Kilo,
         ] {
             let pty = tool.uses_pty();
             assert_eq!(
@@ -1451,8 +1510,8 @@ mod tests {
 
     #[test]
     fn test_launch_backend_resolve_other_tools_headless() {
-        // gemini/codex/opencode + --headless → HeadlessPty (unchanged from today).
-        for tool in [LaunchTool::Gemini, LaunchTool::Codex, LaunchTool::OpenCode] {
+        // gemini/codex/opencode/kilo + --headless → HeadlessPty (unchanged from today).
+        for tool in [LaunchTool::Gemini, LaunchTool::Codex, LaunchTool::OpenCode, LaunchTool::Kilo] {
             assert_eq!(
                 LaunchBackend::resolve(&tool, true, true),
                 LaunchBackend::HeadlessPty,

--- a/src/opencode_plugin/hcom_kilo.ts
+++ b/src/opencode_plugin/hcom_kilo.ts
@@ -1,0 +1,496 @@
+import type { Plugin, PluginInput } from "@kilocode/plugin"
+import type { Event } from "@kilocode/sdk"
+import { appendFileSync } from "fs"
+import { homedir } from "os"
+
+const HCOM_DIR = process.env.HCOM_DIR || `${homedir()}/.hcom`
+const LOG_PATH = `${HCOM_DIR}/.tmp/logs/hcom.log`
+
+type PromptModel = {
+  providerID: string
+  modelID: string
+}
+
+function parseCliArgValue(...flags: string[]): string | null {
+  for (let i = 0; i < process.argv.length; i++) {
+    const token = process.argv[i]
+    for (const flag of flags) {
+      if (token === flag) return process.argv[i + 1] ?? null
+      if (token.startsWith(`${flag}=`)) return token.slice(flag.length + 1)
+    }
+  }
+  return null
+}
+
+function parseCliModelArg() {
+  const raw = parseCliArgValue("--model", "-m")
+  if (!raw) return null
+  const slash = raw.indexOf("/")
+  if (slash <= 0 || slash === raw.length - 1) return null
+  return {
+    providerID: raw.slice(0, slash),
+    modelID: raw.slice(slash + 1),
+  }
+}
+
+function normalizePromptModel(model: unknown) {
+  if (!model || typeof model !== "object") return null
+  const providerID = (model as Record<string, unknown>).providerID
+  const modelID = (model as Record<string, unknown>).modelID
+  if (typeof providerID !== "string" || typeof modelID !== "string") return null
+  return { providerID, modelID }
+}
+
+function log(
+  level: "DEBUG" | "INFO" | "WARN" | "ERROR",
+  event: string,
+  instance?: string | null,
+  extra?: Record<string, unknown>,
+) {
+  const entry = JSON.stringify({
+    ts: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    level,
+    subsystem: "plugin",
+    event,
+    ...(instance ? { instance } : {}),
+    ...extra,
+  })
+  try { appendFileSync(LOG_PATH, entry + "\n") } catch {}
+}
+
+export const HcomKiloPlugin: Plugin = async ({ client, $ }) => {
+  let hcomChecked = false
+  let hcomAvailable = false
+  let instanceName: string | null = null
+  let sessionId: string | null = null
+  let bootstrapText: string | null = null
+  let bindingPromise: Promise<void> | null = null
+  let reconcileTimer: ReturnType<typeof setInterval> | null = null
+  let reconcileInFlight = false
+  let notifyServer: ReturnType<typeof Bun.listen> | null = null
+  let lastReportedStatus: string | null = null
+  let pendingAckId: number | null = null
+  let deliveryInFlight = false
+  let permissionPending = false
+  let launchedAgent: string | null = parseCliArgValue("--agent")
+  let launchedModel: PromptModel | null = parseCliModelArg()
+  let currentAgent: string | null = launchedAgent
+  let currentModel: PromptModel | null = launchedModel
+
+  function checkHcom(): boolean {
+    if (!hcomChecked) {
+      hcomChecked = true
+      hcomAvailable = Bun.which("hcom") !== null
+      if (!hcomAvailable) {
+        log("WARN", "plugin.no_hcom")
+      }
+    }
+    return hcomAvailable
+  }
+
+  function isBoundSession(candidateSessionId?: string | null): boolean {
+    return !candidateSessionId || !sessionId || candidateSessionId === sessionId
+  }
+
+  function ignoreForeignSession(event: string, candidateSessionId?: string | null): boolean {
+    if (isBoundSession(candidateSessionId)) return false
+    log("DEBUG", event, instanceName, {
+      session_id: candidateSessionId,
+      bound_session_id: sessionId,
+    })
+    return true
+  }
+
+  function formatMessagesForInjection(messages: any[], recipientName: string): string {
+    const parts = messages.map((m: any) => {
+      const prefix = m.intent
+        ? m.thread
+          ? `[${m.intent}:${m.thread} #${m.event_id}]`
+          : `[${m.intent} #${m.event_id}]`
+        : m.thread
+          ? `[thread:${m.thread} #${m.event_id}]`
+          : `[new message #${m.event_id}]`
+      return `${prefix} ${m.from} -> ${recipientName}: ${m.message}`
+    })
+    if (messages.length === 1) return `<hcom>${parts[0]}</hcom>`
+    return `<hcom>[${messages.length} new messages] | ${parts.join(" | ")}</hcom>`
+  }
+
+  async function deliverPendingToIdle(sid: string): Promise<boolean> {
+    if (permissionPending) {
+      log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "permission_pending" })
+      return false
+    }
+    if (!instanceName) return false
+    if (ignoreForeignSession("plugin.delivery_ignored_foreign_session", sid)) {
+      return false
+    }
+    if (deliveryInFlight) {
+      log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "delivery_in_flight" })
+      return false
+    }
+    if (pendingAckId !== null) {
+      log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "pending_ack_in_flight", pending_ack: pendingAckId })
+      return false
+    }
+    deliveryInFlight = true
+    try {
+      const msgResult = await $.nothrow()`hcom opencode-read --name ${instanceName}`.quiet()
+      if (msgResult.exitCode !== 0) {
+        log("WARN", "plugin.delivery_read_failed", instanceName, { exit_code: msgResult.exitCode, stderr: msgResult.stderr.toString().slice(0, 200) })
+        return false
+      }
+      let rawMessages: any[] = []
+      try { rawMessages = JSON.parse(msgResult.text()) } catch (e) {
+        log("WARN", "plugin.delivery_parse_failed", instanceName, { error: String(e), raw: msgResult.text().slice(0, 200) })
+        return false
+      }
+      if (!Array.isArray(rawMessages) || rawMessages.length === 0) {
+        log("DEBUG", "plugin.delivery_no_messages", instanceName)
+        return false
+      }
+
+      const maxId = Math.max(...rawMessages.map((m: any) => m.event_id || 0))
+      if (maxId === 0) return false
+
+      const formatted = formatMessagesForInjection(rawMessages, instanceName)
+      pendingAckId = maxId
+      log("DEBUG", "plugin.delivery_payload", instanceName, {
+        session_id: sid,
+        current_agent: currentAgent,
+        current_model: currentModel?.modelID ?? null,
+      })
+      try {
+        const promptAsyncResult = client.session.promptAsync({
+          path: { id: sid },
+          body: {
+            agent: currentAgent ?? undefined,
+            model: currentModel ?? undefined,
+            parts: [{ type: "text", text: formatted }],
+          },
+        } as any)
+        if (promptAsyncResult && typeof (promptAsyncResult as Promise<unknown>).then === "function") {
+          void (promptAsyncResult as Promise<unknown>).catch((e) => {
+            if (pendingAckId === maxId) pendingAckId = null
+            log("ERROR", "plugin.delivery_prompt_failed", instanceName, {
+              error: String(e),
+              pending_ack: maxId,
+            })
+          })
+        }
+      } catch (e) {
+        pendingAckId = null
+        log("ERROR", "plugin.delivery_prompt_failed", instanceName, {
+          error: String(e),
+          pending_ack: maxId,
+          sync_throw: true,
+        })
+        return false
+      }
+      log("INFO", "plugin.delivery_pending", instanceName, {
+        msg: `promptAsync, ack deferred to transform (maxId=${maxId})`,
+        count: rawMessages.length,
+        pending_ack: maxId,
+      })
+      return true
+    } finally {
+      deliveryInFlight = false
+    }
+  }
+
+  async function reconcile(): Promise<void> {
+    if (reconcileInFlight) return
+    if (permissionPending) return
+    if (!instanceName || !sessionId) return
+    reconcileInFlight = true
+    try {
+      const statusResult = await client.session.status()
+      if (!statusResult.data) return
+      const current = statusResult.data[sessionId]
+      const isIdle = !current || current.type === "idle"
+      const hcomStatus = isIdle ? "listening" : "active"
+      if (hcomStatus !== lastReportedStatus) {
+        lastReportedStatus = hcomStatus
+        await $.nothrow()`hcom opencode-status --name ${instanceName} --status ${hcomStatus}`.quiet()
+        log("INFO", "plugin.reconcile_status", instanceName, { status: hcomStatus })
+      }
+    } catch (e) {
+      log("ERROR", "plugin.reconcile_error", instanceName, { error: String(e) })
+    } finally {
+      reconcileInFlight = false
+    }
+  }
+
+  function startReconcileTimer(): void {
+    stopReconcileTimer()
+    reconcileTimer = setInterval(() => { reconcile() }, 5_000)
+  }
+
+  function stopReconcileTimer(): void {
+    if (reconcileTimer) { clearInterval(reconcileTimer); reconcileTimer = null }
+  }
+
+  function startNotifyServer(): number | null {
+    if (notifyServer) return notifyServer.port
+    try {
+      notifyServer = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        socket: {
+          open(socket) {
+            socket.end()
+            log("DEBUG", "notify_server.wake", instanceName, { status: lastReportedStatus, pending_ack: pendingAckId })
+            if (sessionId && instanceName) deliverPendingToIdle(sessionId)
+          },
+          data() {},
+          close() {},
+          error() {},
+        },
+      })
+      log("INFO", "notify_server.started", instanceName, { port: notifyServer.port })
+      return notifyServer.port
+    } catch (e) {
+      log("ERROR", "notify_server.start_failed", instanceName, { error: String(e) })
+      return null
+    }
+  }
+
+  function stopNotifyServer(): void {
+    if (notifyServer) {
+      try { notifyServer.stop(true) } catch {}
+      notifyServer = null
+    }
+  }
+
+  async function bindIdentity(sid: string): Promise<void> {
+    if (instanceName || bindingPromise) return
+    if (process.env.HCOM_LAUNCHED !== "1") return
+
+    bindingPromise = (async () => {
+      try {
+        const notifyPort = startNotifyServer()
+        const result = notifyPort
+          ? await $.nothrow()`hcom opencode-start --session-id ${sid} --notify-port ${String(notifyPort)}`.quiet()
+          : await $.nothrow()`hcom opencode-start --session-id ${sid}`.quiet()
+        if (result.exitCode !== 0) { stopNotifyServer(); return }
+        const json = JSON.parse(result.text())
+        if (json.error) {
+          log("WARN", "plugin.bind_failed", null, { error: json.error })
+          stopNotifyServer()
+          return
+        }
+        const boundModel = normalizePromptModel(json.model)
+        if (typeof json.agent === "string") launchedAgent = json.agent
+        if (boundModel) launchedModel = boundModel
+        instanceName = json.name
+        sessionId = json.session_id
+        bootstrapText = json.bootstrap || null
+        currentAgent = launchedAgent
+        currentModel = launchedModel
+        log("INFO", "plugin.bound", instanceName, {
+          session_id: sessionId,
+          notify_port: notifyPort,
+          bootstrap_len: bootstrapText?.length ?? 0,
+          launched_agent: launchedAgent,
+          launched_model: launchedModel?.modelID ?? null,
+        })
+      } catch (e) {
+        log("ERROR", "plugin.bind_error", null, { error: String(e) })
+        stopNotifyServer()
+      } finally {
+        bindingPromise = null
+      }
+    })()
+    await bindingPromise
+  }
+
+  return {
+    event: async ({ event }: { event: Event }) => {
+      try {
+        if (!checkHcom()) return
+        const eventSessionId = event.properties?.sessionID ?? event.properties?.info?.id
+        if (eventSessionId && !sessionId) {
+          sessionId = eventSessionId as string
+        }
+        if (instanceName && ignoreForeignSession("plugin.event_ignored_foreign_session", eventSessionId)) {
+          return
+        }
+        switch (event.type) {
+          case "session.created": {
+            const createdSessionId = event.properties.info.id
+            log("INFO", "plugin.session_created", instanceName, { session_id: createdSessionId })
+            if (createdSessionId && !instanceName && !bindingPromise) {
+              await bindIdentity(createdSessionId)
+            }
+            break
+          }
+          case "permission.asked": {
+            permissionPending = true
+            const eventSessionId = event.properties.sessionID
+            if (eventSessionId && !instanceName && !bindingPromise) {
+              await bindIdentity(eventSessionId)
+            }
+            if (instanceName) {
+              lastReportedStatus = "blocked"
+              await $.nothrow()`hcom opencode-status --name ${instanceName} --status blocked --context ${"approval"} --detail ${String(event.properties.permission ?? "")}`.quiet()
+              log("INFO", "plugin.permission_asked", instanceName, { permission: event.properties.permission, request_id: event.properties.id })
+            }
+            break
+          }
+          case "permission.replied": {
+            permissionPending = false
+            const eventSessionId = event.properties.sessionID
+            if (instanceName) {
+              const statusResult = await client.session.status()
+              const current = eventSessionId ? statusResult.data?.[eventSessionId] : null
+              const hcomStatus = !current || current.type === "idle" ? "listening" : "active"
+              lastReportedStatus = hcomStatus
+              await $.nothrow()`hcom opencode-status --name ${instanceName} --status ${hcomStatus}`.quiet()
+              if (hcomStatus === "listening" && eventSessionId) {
+                await deliverPendingToIdle(eventSessionId)
+              }
+            }
+            break
+          }
+          case "session.status": {
+            const statusType = event.properties.status.type
+            const eventSessionId = event.properties.sessionID
+
+            log("DEBUG", "plugin.session_status", instanceName, { status: statusType })
+
+            if (eventSessionId && !instanceName && !bindingPromise) {
+              await bindIdentity(eventSessionId)
+            }
+
+            if (permissionPending) {
+              startReconcileTimer()
+              break
+            }
+            if (instanceName) {
+              const hcomStatus = statusType === "idle" ? "listening" : "active"
+              if (hcomStatus !== lastReportedStatus) {
+                lastReportedStatus = hcomStatus
+                await $.nothrow()`hcom opencode-status --name ${instanceName} --status ${hcomStatus}`.quiet()
+              }
+              startReconcileTimer()
+            }
+
+            if (statusType === "idle" && instanceName && eventSessionId) {
+              await deliverPendingToIdle(eventSessionId)
+            }
+            break
+          }
+          case "session.deleted":
+            log("INFO", "plugin.session_deleted", instanceName)
+            stopNotifyServer()
+            stopReconcileTimer()
+            if (instanceName) {
+              await $.nothrow()`hcom opencode-stop --name ${instanceName} --reason closed`.quiet()
+            }
+            instanceName = null
+            sessionId = null
+            bootstrapText = null
+            bindingPromise = null
+            lastReportedStatus = null
+            pendingAckId = null
+            deliveryInFlight = false
+            permissionPending = false
+            currentAgent = launchedAgent
+            currentModel = launchedModel
+            break
+          case "file.edited": {
+            const filePath = event.properties.file
+            if (instanceName) {
+              await $.nothrow()`hcom opencode-status --name ${instanceName} --status active --context ${"tool:write"} --detail ${String(filePath ?? "")}`.quiet()
+            }
+            break
+          }
+        }
+      } catch (e) {
+        log("ERROR", "plugin.event_error", instanceName, { error: String(e) })
+      }
+    },
+
+    "chat.message": async (input, output) => {
+      try {
+        if (!checkHcom()) return
+        if (input.sessionID && !sessionId) {
+          sessionId = input.sessionID
+        }
+        if (bindingPromise) await bindingPromise
+        if (input.sessionID && !instanceName) {
+          await bindIdentity(input.sessionID)
+        }
+        if (isBoundSession(input.sessionID)) {
+          if (input.agent) currentAgent = input.agent
+          const resolvedModel = normalizePromptModel(input.model)
+          if (resolvedModel) currentModel = resolvedModel
+        } else {
+          ignoreForeignSession("plugin.chat_message_ignored_foreign_session", input.sessionID)
+        }
+        log("DEBUG", "plugin.chat_message", instanceName, {
+          session_id: input.sessionID,
+          agent: input.agent,
+          model: input.model?.modelID,
+        })
+      } catch (e) {
+        log("ERROR", "plugin.chat_message_error", instanceName, { error: String(e) })
+      }
+    },
+
+    "experimental.chat.messages.transform": async (input, output) => {
+      try {
+        if (!checkHcom()) return
+        if (bindingPromise) await bindingPromise
+        if (!instanceName && sessionId) await bindIdentity(sessionId)
+        if (!instanceName || !sessionId) return
+
+        const messages = output.messages ?? []
+        const msgCount = messages.length
+        const userMsgCount = messages.filter((m: any) => m.info.role === "user").length
+        if (bootstrapText) {
+          const firstUserMsg = messages.find((m: any) => m.info.role === "user")
+          if (firstUserMsg) {
+            firstUserMsg.parts.push({
+              id: crypto.randomUUID(),
+              messageID: firstUserMsg.info.id,
+              sessionID: firstUserMsg.info.sessionID,
+              type: "text",
+              text: bootstrapText,
+              synthetic: true,
+            })
+            log("DEBUG", "plugin.transform_bootstrap", instanceName, { msg_count: msgCount, user_msgs: userMsgCount, bootstrap_len: bootstrapText.length })
+          } else {
+            log("WARN", "plugin.transform_no_user_msg", instanceName, { msg_count: msgCount })
+          }
+        } else {
+          log("DEBUG", "plugin.transform_no_bootstrap", instanceName, { msg_count: msgCount, user_msgs: userMsgCount })
+        }
+
+        if (pendingAckId !== null) {
+          const ackId = pendingAckId
+          pendingAckId = null
+          await $.nothrow()`hcom opencode-read --name ${instanceName} --ack --up-to ${String(ackId)}`.quiet()
+          log("INFO", "plugin.deferred_ack", instanceName, { acked_to: ackId })
+        }
+      } catch (e) {
+        log("ERROR", "plugin.transform_error", instanceName, { error: String(e) })
+      }
+    },
+
+    "experimental.session.compacting": async (input, output) => {
+      try {
+        if (!checkHcom()) return
+        if (!instanceName) return
+
+        output.context.push(
+          `You are connected to hcom as "${instanceName}". ` +
+          `Use --name ${instanceName} for all hcom commands.`
+        )
+        log("INFO", "plugin.compaction_reset", instanceName)
+      } catch (e) {
+        log("ERROR", "plugin.compaction_error", instanceName, { error: String(e) })
+      }
+    },
+  }
+}

--- a/src/opencode_plugin/kilo-hcom.ts
+++ b/src/opencode_plugin/kilo-hcom.ts
@@ -1,0 +1,496 @@
+import type { Plugin, PluginInput } from "@kilocode/plugin"
+import type { Event } from "@kilocode/sdk"
+import { appendFileSync } from "fs"
+import { homedir } from "os"
+
+const HCOM_DIR = process.env.HCOM_DIR || `${homedir()}/.hcom`
+const LOG_PATH = `${HCOM_DIR}/.tmp/logs/hcom-kilo.log`
+
+type PromptModel = {
+  providerID: string
+  modelID: string
+}
+
+function parseCliArgValue(...flags: string[]): string | null {
+  for (let i = 0; i < process.argv.length; i++) {
+    const token = process.argv[i]
+    for (const flag of flags) {
+      if (token === flag) return process.argv[i + 1] ?? null
+      if (token.startsWith(`${flag}=`)) return token.slice(flag.length + 1)
+    }
+  }
+  return null
+}
+
+function parseCliModelArg() {
+  const raw = parseCliArgValue("--model", "-m")
+  if (!raw) return null
+  const slash = raw.indexOf("/")
+  if (slash <= 0 || slash === raw.length - 1) return null
+  return {
+    providerID: raw.slice(0, slash),
+    modelID: raw.slice(slash + 1),
+  }
+}
+
+function normalizePromptModel(model: unknown) {
+  if (!model || typeof model !== "object") return null
+  const providerID = (model as Record<string, unknown>).providerID
+  const modelID = (model as Record<string, unknown>).modelID
+  if (typeof providerID !== "string" || typeof modelID !== "string") return null
+  return { providerID, modelID }
+}
+
+function log(
+  level: "DEBUG" | "INFO" | "WARN" | "ERROR",
+  event: string,
+  instance?: string | null,
+  extra?: Record<string, unknown>,
+) {
+  const entry = JSON.stringify({
+    ts: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    level,
+    subsystem: "kilo-plugin",
+    event,
+    ...(instance ? { instance } : {}),
+    ...extra,
+  })
+  try { appendFileSync(LOG_PATH, entry + "\n") } catch {}
+}
+
+export const HcomKiloPlugin: Plugin = async ({ client, $ }) => {
+  let hcomChecked = false
+  let hcomAvailable = false
+  let instanceName: string | null = null
+  let sessionId: string | null = null
+  let bootstrapText: string | null = null
+  let bindingPromise: Promise<void> | null = null
+  let reconcileTimer: ReturnType<typeof setInterval> | null = null
+  let reconcileInFlight = false
+  let notifyServer: ReturnType<typeof Bun.listen> | null = null
+  let lastReportedStatus: string | null = null
+  let pendingAckId: number | null = null
+  let deliveryInFlight = false
+  let permissionPending = false
+  let launchedAgent: string | null = parseCliArgValue("--agent")
+  let launchedModel: PromptModel | null = parseCliModelArg()
+  let currentAgent: string | null = launchedAgent
+  let currentModel: PromptModel | null = launchedModel
+
+  function checkHcom(): boolean {
+    if (!hcomChecked) {
+      hcomChecked = true
+      hcomAvailable = Bun.which("hcom") !== null
+      if (!hcomAvailable) {
+        log("WARN", "plugin.no_hcom")
+      }
+    }
+    return hcomAvailable
+  }
+
+  function isBoundSession(candidateSessionId?: string | null): boolean {
+    return !candidateSessionId || !sessionId || candidateSessionId === sessionId
+  }
+
+  function ignoreForeignSession(event: string, candidateSessionId?: string | null): boolean {
+    if (isBoundSession(candidateSessionId)) return false
+    log("DEBUG", event, instanceName, {
+      session_id: candidateSessionId,
+      bound_session_id: sessionId,
+    })
+    return true
+  }
+
+  function formatMessagesForInjection(messages: any[], recipientName: string): string {
+    const parts = messages.map((m: any) => {
+      const prefix = m.intent
+        ? m.thread
+          ? `[${m.intent}:${m.thread} #${m.event_id}]`
+          : `[${m.intent} #${m.event_id}]`
+        : m.thread
+          ? `[thread:${m.thread} #${m.event_id}]`
+          : `[new message #${m.event_id}]`
+      return `${prefix} ${m.from} -> ${recipientName}: ${m.message}`
+    })
+    if (messages.length === 1) return `<hcom>${parts[0]}</hcom>`
+    return `<hcom>[${messages.length} new messages] | ${parts.join(" | ")}</hcom>`
+  }
+
+  async function deliverPendingToIdle(sid: string): Promise<boolean> {
+    if (permissionPending) {
+      log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "permission_pending" })
+      return false
+    }
+    if (!instanceName) return false
+    if (ignoreForeignSession("plugin.delivery_ignored_foreign_session", sid)) {
+      return false
+    }
+    if (deliveryInFlight) {
+      log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "delivery_in_flight" })
+      return false
+    }
+    if (pendingAckId !== null) {
+      log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "pending_ack_in_flight", pending_ack: pendingAckId })
+      return false
+    }
+    deliveryInFlight = true
+    try {
+      const msgResult = await $.nothrow()`hcom kilo-read --name ${instanceName}`.quiet()
+      if (msgResult.exitCode !== 0) {
+        log("WARN", "plugin.delivery_read_failed", instanceName, { exit_code: msgResult.exitCode, stderr: msgResult.stderr.toString().slice(0, 200) })
+        return false
+      }
+      let rawMessages: any[] = []
+      try { rawMessages = JSON.parse(msgResult.text()) } catch (e) {
+        log("WARN", "plugin.delivery_parse_failed", instanceName, { error: String(e), raw: msgResult.text().slice(0, 200) })
+        return false
+      }
+      if (!Array.isArray(rawMessages) || rawMessages.length === 0) {
+        log("DEBUG", "plugin.delivery_no_messages", instanceName)
+        return false
+      }
+
+      const maxId = Math.max(...rawMessages.map((m: any) => m.event_id || 0))
+      if (maxId === 0) return false
+
+      const formatted = formatMessagesForInjection(rawMessages, instanceName)
+      pendingAckId = maxId
+      log("DEBUG", "plugin.delivery_payload", instanceName, {
+        session_id: sid,
+        current_agent: currentAgent,
+        current_model: currentModel?.modelID ?? null,
+      })
+      try {
+        const promptAsyncResult = client.session.promptAsync({
+          path: { id: sid },
+          body: {
+            agent: currentAgent ?? undefined,
+            model: currentModel ?? undefined,
+            parts: [{ type: "text", text: formatted }],
+          },
+        } as any)
+        if (promptAsyncResult && typeof (promptAsyncResult as Promise<unknown>).then === "function") {
+          void (promptAsyncResult as Promise<unknown>).catch((e) => {
+            if (pendingAckId === maxId) pendingAckId = null
+            log("ERROR", "plugin.delivery_prompt_failed", instanceName, {
+              error: String(e),
+              pending_ack: maxId,
+            })
+          })
+        }
+      } catch (e) {
+        pendingAckId = null
+        log("ERROR", "plugin.delivery_prompt_failed", instanceName, {
+          error: String(e),
+          pending_ack: maxId,
+          sync_throw: true,
+        })
+        return false
+      }
+      log("INFO", "plugin.delivery_pending", instanceName, {
+        msg: `promptAsync, ack deferred to transform (maxId=${maxId})`,
+        count: rawMessages.length,
+        pending_ack: maxId,
+      })
+      return true
+    } finally {
+      deliveryInFlight = false
+    }
+  }
+
+  async function reconcile(): Promise<void> {
+    if (reconcileInFlight) return
+    if (permissionPending) return
+    if (!instanceName || !sessionId) return
+    reconcileInFlight = true
+    try {
+      const statusResult = await client.session.status()
+      if (!statusResult.data) return
+      const current = statusResult.data[sessionId]
+      const isIdle = !current || current.type === "idle"
+      const hcomStatus = isIdle ? "listening" : "active"
+      if (hcomStatus !== lastReportedStatus) {
+        lastReportedStatus = hcomStatus
+        await $.nothrow()`hcom kilocode-status --name ${instanceName} --status ${hcomStatus}`.quiet()
+        log("INFO", "plugin.reconcile_status", instanceName, { status: hcomStatus })
+      }
+    } catch (e) {
+      log("ERROR", "plugin.reconcile_error", instanceName, { error: String(e) })
+    } finally {
+      reconcileInFlight = false
+    }
+  }
+
+  function startReconcileTimer(): void {
+    stopReconcileTimer()
+    reconcileTimer = setInterval(() => { reconcile() }, 5_000)
+  }
+
+  function stopReconcileTimer(): void {
+    if (reconcileTimer) { clearInterval(reconcileTimer); reconcileTimer = null }
+  }
+
+  function startNotifyServer(): number | null {
+    if (notifyServer) return notifyServer.port
+    try {
+      notifyServer = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        socket: {
+          open(socket) {
+            socket.end()
+            log("DEBUG", "notify_server.wake", instanceName, { status: lastReportedStatus, pending_ack: pendingAckId })
+            if (sessionId && instanceName) deliverPendingToIdle(sessionId)
+          },
+          data() {},
+          close() {},
+          error() {},
+        },
+      })
+      log("INFO", "notify_server.started", instanceName, { port: notifyServer.port })
+      return notifyServer.port
+    } catch (e) {
+      log("ERROR", "notify_server.start_failed", instanceName, { error: String(e) })
+      return null
+    }
+  }
+
+  function stopNotifyServer(): void {
+    if (notifyServer) {
+      try { notifyServer.stop(true) } catch {}
+      notifyServer = null
+    }
+  }
+
+  async function bindIdentity(sid: string): Promise<void> {
+    if (instanceName || bindingPromise) return
+    if (process.env.HCOM_LAUNCHED !== "1") return
+
+    bindingPromise = (async () => {
+      try {
+        const notifyPort = startNotifyServer()
+        const result = notifyPort
+          ? await $.nothrow()`hcom kilo-start --session-id ${sid} --notify-port ${String(notifyPort)}`.quiet()
+          : await $.nothrow()`hcom kilo-start --session-id ${sid}`.quiet()
+        if (result.exitCode !== 0) { stopNotifyServer(); return }
+        const json = JSON.parse(result.text())
+        if (json.error) {
+          log("WARN", "plugin.bind_failed", null, { error: json.error })
+          stopNotifyServer()
+          return
+        }
+        const boundModel = normalizePromptModel(json.model)
+        if (typeof json.agent === "string") launchedAgent = json.agent
+        if (boundModel) launchedModel = boundModel
+        instanceName = json.name
+        sessionId = json.session_id
+        bootstrapText = json.bootstrap || null
+        currentAgent = launchedAgent
+        currentModel = launchedModel
+        log("INFO", "plugin.bound", instanceName, {
+          session_id: sessionId,
+          notify_port: notifyPort,
+          bootstrap_len: bootstrapText?.length ?? 0,
+          launched_agent: launchedAgent,
+          launched_model: launchedModel?.modelID ?? null,
+        })
+      } catch (e) {
+        log("ERROR", "plugin.bind_error", null, { error: String(e) })
+        stopNotifyServer()
+      } finally {
+        bindingPromise = null
+      }
+    })()
+    await bindingPromise
+  }
+
+  return {
+    event: async ({ event }: { event: Event }) => {
+      try {
+        if (!checkHcom()) return
+        const eventSessionId = event.properties?.sessionID ?? event.properties?.info?.id
+        if (eventSessionId && !sessionId) {
+          sessionId = eventSessionId as string
+        }
+        if (instanceName && ignoreForeignSession("plugin.event_ignored_foreign_session", eventSessionId)) {
+          return
+        }
+        switch (event.type) {
+          case "session.created": {
+            const createdSessionId = event.properties.info.id
+            log("INFO", "plugin.session_created", instanceName, { session_id: createdSessionId })
+            if (createdSessionId && !instanceName && !bindingPromise) {
+              await bindIdentity(createdSessionId)
+            }
+            break
+          }
+          case "permission.asked": {
+            permissionPending = true
+            const eventSessionId = event.properties.sessionID
+            if (eventSessionId && !instanceName && !bindingPromise) {
+              await bindIdentity(eventSessionId)
+            }
+            if (instanceName) {
+              lastReportedStatus = "blocked"
+              await $.nothrow()`hcom kilo-status --name ${instanceName} --status blocked --context ${"approval"} --detail ${String(event.properties.permission ?? "")}`.quiet()
+              log("INFO", "plugin.permission_asked", instanceName, { permission: event.properties.permission, request_id: event.properties.id })
+            }
+            break
+          }
+          case "permission.replied": {
+            permissionPending = false
+            const eventSessionId = event.properties.sessionID
+            if (instanceName) {
+              const statusResult = await client.session.status()
+              const current = eventSessionId ? statusResult.data?.[eventSessionId] : null
+              const hcomStatus = !current || current.type === "idle" ? "listening" : "active"
+              lastReportedStatus = hcomStatus
+              await $.nothrow()`hcom kilo-status --name ${instanceName} --status ${hcomStatus}`.quiet()
+              if (hcomStatus === "listening" && eventSessionId) {
+                await deliverPendingToIdle(eventSessionId)
+              }
+            }
+            break
+          }
+          case "session.status": {
+            const statusType = event.properties.status.type
+            const eventSessionId = event.properties.sessionID
+
+            log("DEBUG", "plugin.session_status", instanceName, { status: statusType })
+
+            if (eventSessionId && !instanceName && !bindingPromise) {
+              await bindIdentity(eventSessionId)
+            }
+
+            if (permissionPending) {
+              startReconcileTimer()
+              break
+            }
+            if (instanceName) {
+              const hcomStatus = statusType === "idle" ? "listening" : "active"
+              if (hcomStatus !== lastReportedStatus) {
+                lastReportedStatus = hcomStatus
+        await $.nothrow()`hcom kilo-status --name ${instanceName} --status ${hcomStatus}`.quiet()
+              }
+              startReconcileTimer()
+            }
+
+            if (statusType === "idle" && instanceName && eventSessionId) {
+              await deliverPendingToIdle(eventSessionId)
+            }
+            break
+          }
+          case "session.deleted":
+            log("INFO", "plugin.session_deleted", instanceName)
+            stopNotifyServer()
+            stopReconcileTimer()
+            if (instanceName) {
+              await $.nothrow()`hcom kilo-stop --name ${instanceName} --reason closed`.quiet()
+            }
+            instanceName = null
+            sessionId = null
+            bootstrapText = null
+            bindingPromise = null
+            lastReportedStatus = null
+            pendingAckId = null
+            deliveryInFlight = false
+            permissionPending = false
+            currentAgent = launchedAgent
+            currentModel = launchedModel
+            break
+          case "file.edited": {
+            const filePath = event.properties.file
+            if (instanceName) {
+              await $.nothrow()`hcom kilo-status --name ${instanceName} --status active --context ${"tool:write"} --detail ${String(filePath ?? "")}`.quiet()
+            }
+            break
+          }
+        }
+      } catch (e) {
+        log("ERROR", "plugin.event_error", instanceName, { error: String(e) })
+      }
+    },
+
+    "chat.message": async (input, output) => {
+      try {
+        if (!checkHcom()) return
+        if (input.sessionID && !sessionId) {
+          sessionId = input.sessionID
+        }
+        if (bindingPromise) await bindingPromise
+        if (input.sessionID && !instanceName) {
+          await bindIdentity(input.sessionID)
+        }
+        if (isBoundSession(input.sessionID)) {
+          if (input.agent) currentAgent = input.agent
+          const resolvedModel = normalizePromptModel(input.model)
+          if (resolvedModel) currentModel = resolvedModel
+        } else {
+          ignoreForeignSession("plugin.chat_message_ignored_foreign_session", input.sessionID)
+        }
+        log("DEBUG", "plugin.chat_message", instanceName, {
+          session_id: input.sessionID,
+          agent: input.agent,
+          model: input.model?.modelID,
+        })
+      } catch (e) {
+        log("ERROR", "plugin.chat_message_error", instanceName, { error: String(e) })
+      }
+    },
+
+    "experimental.chat.messages.transform": async (input, output) => {
+      try {
+        if (!checkHcom()) return
+        if (bindingPromise) await bindingPromise
+        if (!instanceName && sessionId) await bindIdentity(sessionId)
+        if (!instanceName || !sessionId) return
+
+        const messages = output.messages ?? []
+        const msgCount = messages.length
+        const userMsgCount = messages.filter((m: any) => m.info.role === "user").length
+        if (bootstrapText) {
+          const firstUserMsg = messages.find((m: any) => m.info.role === "user")
+          if (firstUserMsg) {
+            firstUserMsg.parts.push({
+              id: crypto.randomUUID(),
+              messageID: firstUserMsg.info.id,
+              sessionID: firstUserMsg.info.sessionID,
+              type: "text",
+              text: bootstrapText,
+              synthetic: true,
+            })
+            log("DEBUG", "plugin.transform_bootstrap", instanceName, { msg_count: msgCount, user_msgs: userMsgCount, bootstrap_len: bootstrapText.length })
+          } else {
+            log("WARN", "plugin.transform_no_user_msg", instanceName, { msg_count: msgCount })
+          }
+        } else {
+          log("DEBUG", "plugin.transform_no_bootstrap", instanceName, { msg_count: msgCount, user_msgs: userMsgCount })
+        }
+
+        if (pendingAckId !== null) {
+          const ackId = pendingAckId
+          pendingAckId = null
+          await $.nothrow()`hcom kilo-read --name ${instanceName} --ack --up-to ${String(ackId)}`.quiet()
+          log("INFO", "plugin.deferred_ack", instanceName, { acked_to: ackId })
+        }
+      } catch (e) {
+        log("ERROR", "plugin.transform_error", instanceName, { error: String(e) })
+      }
+    },
+
+    "experimental.session.compacting": async (input, output) => {
+      try {
+        if (!checkHcom()) return
+        if (!instanceName) return
+
+        output.context.push(
+          `You are connected to hcom as "${instanceName}". ` +
+          `Use --name ${instanceName} for all hcom commands.`
+        )
+        log("INFO", "plugin.compaction_reset", instanceName)
+      } catch (e) {
+        log("ERROR", "plugin.compaction_error", instanceName, { error: String(e) })
+      }
+    },
+  }
+}

--- a/src/pty/screen.rs
+++ b/src/pty/screen.rs
@@ -344,6 +344,7 @@ impl ScreenTracker {
             Ok(Tool::Gemini) => self.get_gemini_input_text(),
             Ok(Tool::Codex) => self.get_codex_input_text(),
             Ok(Tool::OpenCode) => None, // OpenCode: plugin handles delivery, no PTY input detection needed
+            Ok(Tool::Kilo) => None, // Kilo: plugin handles delivery, same as OpenCode
             Ok(Tool::Adhoc) => None,
             Err(_) => None,
         }

--- a/src/router.rs
+++ b/src/router.rs
@@ -43,7 +43,7 @@ const COMMANDS: &[&str] = &[
 ];
 
 /// Tools that support launch commands (hcom [N] <tool>)
-const LAUNCH_TOOLS: &[&str] = &["claude", "codex", "gemini", "opencode", "f", "r"];
+const LAUNCH_TOOLS: &[&str] = &["claude", "codex", "gemini", "opencode", "kilocode", "kilo", "f", "r"];
 
 fn is_command(name: &str) -> bool {
     COMMANDS.contains(&name)
@@ -92,6 +92,7 @@ fn dispatch_hook_for_tool(tool: Tool, hook: &str, args: &[String]) -> (i32, Stri
             String::new(),
         ),
         Tool::OpenCode => crate::hooks::opencode::dispatch_opencode_hook(hook, args),
+        Tool::Kilo => crate::hooks::kilo::dispatch_kilo_hook(hook, args),
         Tool::Adhoc => unreachable!("adhoc has no hooks"),
     }
 }
@@ -1294,13 +1295,14 @@ mod tests {
         assert!(is_hook("gemini-beforeagent"));
         assert!(is_hook("codex-sessionstart"));
         assert!(is_hook("opencode-start"));
+        assert!(is_hook("kilocode-start"));
         assert!(!is_hook("send"));
         assert!(!is_hook("unknown"));
     }
 
     #[test]
     fn hooks_do_not_collide_with_commands_or_launch_tools() {
-        for tool in [Tool::Claude, Tool::Gemini, Tool::Codex, Tool::OpenCode] {
+        for tool in [Tool::Claude, Tool::Gemini, Tool::Codex, Tool::OpenCode, Tool::Kilo] {
             for hook in tool.hooks() {
                 assert!(!COMMANDS.contains(hook), "{hook} collides with command");
                 assert!(

--- a/src/shared/constants.rs
+++ b/src/shared/constants.rs
@@ -59,7 +59,7 @@ pub static BIND_MARKER_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\[hcom:([a-z0-9_]+)\]").unwrap());
 
 /// Tools available for launch.
-pub const RELEASED_TOOLS: &[&str] = &["claude", "gemini", "codex", "opencode"];
+pub const RELEASED_TOOLS: &[&str] = &["claude", "gemini", "codex", "opencode", "kilocode"];
 
 /// Tools that support background/headless mode.
 pub const RELEASED_BACKGROUND: &[&str] = &["claude"];
@@ -75,6 +75,7 @@ pub const TOOL_MARKER_VARS: &[&str] = &[
     "CODEX_MANAGED_BY_BUN",
     "CODEX_THREAD_ID",
     "OPENCODE",
+    "KILOCODE",
 ];
 
 /// HCOM identity vars — set per-instance, cleared to prevent parent identity leakage.
@@ -219,7 +220,8 @@ mod tests {
         assert!(RELEASED_TOOLS.contains(&"gemini"));
         assert!(RELEASED_TOOLS.contains(&"codex"));
         assert!(RELEASED_TOOLS.contains(&"opencode"));
-        assert_eq!(RELEASED_TOOLS.len(), 4);
+        assert!(RELEASED_TOOLS.contains(&"kilocode"));
+        assert_eq!(RELEASED_TOOLS.len(), 5);
     }
 
     #[test]

--- a/src/shared/platform.rs
+++ b/src/shared/platform.rs
@@ -149,6 +149,8 @@ pub fn detect_current_tool_from_env() -> &'static str {
         "codex"
     } else if is_eq("OPENCODE", "1") {
         "opencode"
+    } else if is_eq("KILOCODE", "1") {
+        "kilocode"
     } else {
         "adhoc"
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -403,6 +403,7 @@ pub fn which_bin(name: &str) -> Option<String> {
                 home.join(".claude").join("bin").join("claude"),
             ],
             "opencode" => &[home.join(".opencode").join("bin").join("opencode")],
+            "kilocode" => &[home.join(".kilocode").join("bin").join("kilocode")],
             _ => &[],
         };
         for fallback in fallbacks {
@@ -619,8 +620,12 @@ pub fn create_bash_script(
 ) -> Result<()> {
     let tool_name = tool_name.unwrap_or_else(|| {
         let cmd_lower = command_str.to_lowercase();
-        if cmd_lower.contains("opencode") {
+        if cmd_lower.contains("kilocode") {
+            "KiloCode"
+        } else if cmd_lower.contains("opencode") {
             "OpenCode"
+        } else if cmd_lower.contains("kilo") {
+            "Kilo"
         } else if cmd_lower.contains("gemini") {
             "Gemini"
         } else if cmd_lower.contains("codex") {

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,8 +1,3 @@
-//! Tool enum for type-safe tool identification across hcom.
-//!
-//! Centralizes tool-specific configuration (ready patterns, etc) to avoid
-//! scattered string comparisons and magic values.
-
 use std::str::FromStr;
 
 const CLAUDE_HOOKS: &[&str] = &[
@@ -43,73 +38,67 @@ const OPENCODE_HOOKS: &[&str] = &[
     "opencode-stop",
 ];
 
-/// Supported AI coding tools
+const KILO_HOOKS: &[&str] = &[
+    "kilocode-start",
+    "kilocode-status",
+    "kilocode-read",
+    "kilocode-stop",
+];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tool {
     Claude,
     Gemini,
     Codex,
     OpenCode,
+    Kilo,
     Adhoc,
 }
 
 impl Tool {
-    /// Get the ready pattern bytes for this tool
-    ///
-    /// Ready pattern appears when the tool's TUI has loaded. Used for delivery
-    /// thread startup detection (not gating — gate config is in delivery.rs).
     pub fn ready_pattern(&self) -> &'static [u8] {
         match self {
             Tool::Claude => b"? for shortcuts",
-            // Codex's responsive footer drops "? for shortcuts" in narrow terminals.
-            // Use the › prompt character instead — always visible when TUI is loaded.
             Tool::Codex => "\u{203A} ".as_bytes(),
             Tool::Gemini => b"Type your message",
-            // OpenCode: bottom status bar — appears when TUI is fully rendered.
-            // Gates delivery thread startup so PTY bootstrap inject doesn't fire
-            // into a blank screen before the input box exists.
             Tool::OpenCode => b"ctrl+p commands",
+            Tool::Kilo => b"ctrl+p commands",
             Tool::Adhoc => b"",
         }
     }
 
-    /// Get the tool name as a string (lowercase)
-    ///
-    /// Use this for DB storage, CLI output, and external interfaces.
     pub fn as_str(&self) -> &'static str {
         match self {
             Tool::Claude => "claude",
             Tool::Gemini => "gemini",
             Tool::Codex => "codex",
             Tool::OpenCode => "opencode",
+            Tool::Kilo => "kilo",
             Tool::Adhoc => "adhoc",
         }
     }
 
-    /// Hook command names owned by this tool.
     pub fn hooks(&self) -> &'static [&'static str] {
         match self {
             Tool::Claude => CLAUDE_HOOKS,
             Tool::Gemini => GEMINI_HOOKS,
             Tool::Codex => CODEX_HOOKS,
             Tool::OpenCode => OPENCODE_HOOKS,
+            Tool::Kilo => KILO_HOOKS,
             Tool::Adhoc => &[],
         }
     }
 
-    /// Return true if this tool owns the hook command name.
     pub fn owns_hook(&self, name: &str) -> bool {
         self.hooks().contains(&name)
     }
 
-    /// Resolve the tool that owns a hook command name.
     pub fn from_hook_name(name: &str) -> Option<Self> {
-        [Tool::Claude, Tool::Gemini, Tool::Codex, Tool::OpenCode]
+        [Tool::Claude, Tool::Gemini, Tool::Codex, Tool::OpenCode, Tool::Kilo]
             .into_iter()
             .find(|tool| tool.owns_hook(name))
     }
 
-    /// Return true if any supported tool owns the hook command name.
     pub fn is_hook_name(name: &str) -> bool {
         Self::from_hook_name(name).is_some()
     }
@@ -124,6 +113,7 @@ impl FromStr for Tool {
             "gemini" => Ok(Tool::Gemini),
             "codex" => Ok(Tool::Codex),
             "opencode" => Ok(Tool::OpenCode),
+            "kilo" | "kilocode" => Ok(Tool::Kilo),
             "adhoc" => Ok(Tool::Adhoc),
             _ => Err(format!("Unknown tool: {}", s)),
         }
@@ -150,7 +140,7 @@ mod tests {
     #[test]
     fn hook_names_are_disjoint() {
         let mut owners = HashMap::new();
-        for tool in [Tool::Claude, Tool::Gemini, Tool::Codex, Tool::OpenCode] {
+        for tool in [Tool::Claude, Tool::Gemini, Tool::Codex, Tool::OpenCode, Tool::Kilo] {
             for hook in tool.hooks() {
                 assert_eq!(
                     owners.insert(*hook, tool),
@@ -160,5 +150,11 @@ mod tests {
                 assert_eq!(Tool::from_hook_name(hook), Some(tool));
             }
         }
+    }
+
+    #[test]
+    fn kilocode_parses_to_kilo() {
+        assert_eq!("kilocode".parse::<Tool>().unwrap(), Tool::Kilo);
+        assert_eq!("kilo".parse::<Tool>().unwrap(), Tool::Kilo);
     }
 }

--- a/src/tools/kilo_preprocessing.rs
+++ b/src/tools/kilo_preprocessing.rs
@@ -1,0 +1,47 @@
+use std::collections::HashMap;
+
+const KILO_PERMISSION_JSON: &str = r#"{"bash":{"hcom *":"allow"}}"#;
+
+pub fn preprocess_kilo_env(env: &mut HashMap<String, String>, instance_name: &str) {
+    env.insert(
+        "KILO_PERMISSION".to_string(),
+        KILO_PERMISSION_JSON.to_string(),
+    );
+    env.insert("HCOM_NAME".to_string(), instance_name.to_string());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_preprocess_sets_permission() {
+        let mut env = HashMap::new();
+        preprocess_kilo_env(&mut env, "luna");
+        let perm = env.get("KILO_PERMISSION").unwrap();
+        assert!(perm.contains("hcom *"));
+        assert!(perm.contains("allow"));
+    }
+
+    #[test]
+    fn test_preprocess_sets_hcom_name() {
+        let mut env = HashMap::new();
+        preprocess_kilo_env(&mut env, "nova");
+        assert_eq!(env.get("HCOM_NAME").unwrap(), "nova");
+    }
+
+    #[test]
+    fn test_preprocess_overwrites_existing() {
+        let mut env = HashMap::new();
+        env.insert("HCOM_NAME".to_string(), "old".to_string());
+        preprocess_kilo_env(&mut env, "nova");
+        assert_eq!(env.get("HCOM_NAME").unwrap(), "nova");
+    }
+
+    #[test]
+    fn test_permission_json_is_valid() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(KILO_PERMISSION_JSON).expect("valid JSON");
+        assert!(parsed["bash"]["hcom *"].is_string());
+    }
+}

--- a/src/tools/kilocode_preprocessing.rs
+++ b/src/tools/kilocode_preprocessing.rs
@@ -1,0 +1,4 @@
+//! KiloCode launch preprocessing — delegates to kilo_preprocessing.
+//! KiloCode uses the same auto-approve pattern as Kilo (its predecessor).
+
+pub use crate::tools::kilo_preprocessing::preprocess_kilo_env as preprocess_kilocode_env;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -8,4 +8,5 @@ pub mod args_common;
 pub mod codex_args;
 pub mod codex_preprocessing;
 pub mod gemini_args;
+pub mod kilo_preprocessing;
 pub mod opencode_preprocessing;

--- a/src/tui/db.rs
+++ b/src/tui/db.rs
@@ -239,6 +239,7 @@ fn parse_tool(s: &str) -> Tool {
         "gemini" => Tool::Gemini,
         "codex" => Tool::Codex,
         "opencode" => Tool::OpenCode,
+        "kilocode" => Tool::Kilo,
         _ => Tool::Adhoc,
     }
 }

--- a/src/tui/model.rs
+++ b/src/tui/model.rs
@@ -81,6 +81,7 @@ pub enum Tool {
     Gemini,
     Codex,
     OpenCode,
+    Kilo,
     Adhoc,
 }
 
@@ -91,6 +92,7 @@ impl Tool {
             Self::Gemini => "gemini",
             Self::Codex => "codex",
             Self::OpenCode => "opencode",
+            Self::Kilo => "kilocode",
             Self::Adhoc => "adhoc",
         }
     }
@@ -101,7 +103,8 @@ impl Tool {
             Self::Claude => Self::Gemini,
             Self::Gemini => Self::Codex,
             Self::Codex => Self::OpenCode,
-            Self::OpenCode => Self::Claude,
+            Self::OpenCode => Self::Kilo,
+            Self::Kilo => Self::Claude,
             Self::Adhoc => Self::Adhoc,
         }
     }
@@ -109,10 +112,11 @@ impl Tool {
     /// Cycle backward (for launch panel). Adhoc is not launchable.
     pub fn prev(&self) -> Self {
         match self {
-            Self::Claude => Self::OpenCode,
+            Self::Claude => Self::Kilo,
             Self::Gemini => Self::Claude,
             Self::Codex => Self::Gemini,
             Self::OpenCode => Self::Codex,
+            Self::Kilo => Self::OpenCode,
             Self::Adhoc => Self::Adhoc,
         }
     }
@@ -1146,12 +1150,14 @@ mod tests {
         assert_eq!(Tool::Claude.next(), Tool::Gemini);
         assert_eq!(Tool::Gemini.next(), Tool::Codex);
         assert_eq!(Tool::Codex.next(), Tool::OpenCode);
-        assert_eq!(Tool::OpenCode.next(), Tool::Claude);
+        assert_eq!(Tool::OpenCode.next(), Tool::Kilo);
+        assert_eq!(Tool::Kilo.next(), Tool::Claude);
     }
 
     #[test]
     fn tool_prev_cycles_backward() {
-        assert_eq!(Tool::Claude.prev(), Tool::OpenCode);
+        assert_eq!(Tool::Claude.prev(), Tool::Kilo);
+        assert_eq!(Tool::Kilo.prev(), Tool::OpenCode);
         assert_eq!(Tool::OpenCode.prev(), Tool::Codex);
         assert_eq!(Tool::Codex.prev(), Tool::Gemini);
         assert_eq!(Tool::Gemini.prev(), Tool::Claude);

--- a/src/tui/render/agents.rs
+++ b/src/tui/render/agents.rs
@@ -82,6 +82,7 @@ fn tool_prefix_str(tool: Tool) -> &'static str {
         Tool::Gemini => "gem ",
         Tool::Codex => "cod ",
         Tool::OpenCode => "opc ",
+        Tool::Kilo => "kil ",
         Tool::Adhoc => "ah  ",
     }
 }

--- a/src/tui/rpc.rs
+++ b/src/tui/rpc.rs
@@ -89,7 +89,7 @@ pub fn build_launch_argv(
                 // gemini uses -i for initial prompt; headless not supported
                 argv.extend(["-i".into(), prompt.into()]);
             }
-            Tool::OpenCode => {
+            Tool::OpenCode | Tool::Kilo => {
                 argv.extend(["--prompt".into(), prompt.into()]);
             }
             Tool::Adhoc => {}


### PR DESCRIPTION
## Summary

Add KiloCode as a supported AI coding CLI in hcom (like Claude, Gemini, Codex, OpenCode). Includes Tool enum variant, LaunchTool, PTY launcher, hook lifecycle handlers, preprocessing, config support, help entries, status checks, and TUI support.

### Changes
- `Tool::Kilo` variant in `src/tool.rs`
- Full hook lifecycle in `src/hooks/kilo.rs` (start/status/read/stop)
- `src/tools/kilo_preprocessing.rs` — bash auto-approval env vars
- `src/opencode_plugin/kilo-hcom.ts` and `hcom_kilo.ts` — KiloCode plugins