### PR TITLE
feat(codex): accept --yolo launch flag

### DIFF
--- a/src/tools/codex_args.rs
+++ b/src/tools/codex_args.rs
@@ -61,6 +61,7 @@ const CASE_SENSITIVE_BOOLEAN_FLAGS: &[&str] = &["-V"];
 const BOOLEAN_FLAGS: &[&str] = &[
     "--oss",
     "--full-auto",
+    "--yolo",
     "--dangerously-bypass-approvals-and-sandbox",
     "--dangerously-bypass-hook-trust",
     "--search",
@@ -115,6 +116,7 @@ const SANDBOX_FLAGS: &[&str] = &[
     "-a",
     "--ask-for-approval",
     "--full-auto",
+    "--yolo",
     "--dangerously-bypass-approvals-and-sandbox",
 ];
 
@@ -846,11 +848,26 @@ mod tests {
 
     #[test]
     fn test_parse_boolean_flags() {
-        let args = sv(&["--full-auto", "--oss", "--dangerously-bypass-hook-trust"]);
+        let args = sv(&[
+            "--full-auto",
+            "--yolo",
+            "--oss",
+            "--dangerously-bypass-hook-trust",
+        ]);
         let spec = parse_tokens(&args, SourceType::Cli);
         assert!(spec.has_flag(&["--full-auto"], &[]));
+        assert!(spec.has_flag(&["--yolo"], &[]));
         assert!(spec.has_flag(&["--oss"], &[]));
         assert!(spec.has_flag(&["--dangerously-bypass-hook-trust"], &[]));
+    }
+
+    #[test]
+    fn test_parse_yolo_hidden_alias() {
+        let args = sv(&["--yolo", "-m", "gpt-5"]);
+        let spec = parse_tokens(&args, SourceType::Cli);
+        assert!(!spec.has_errors(), "{:?}", spec.errors);
+        assert!(spec.has_flag(&["--yolo"], &[]));
+        assert_eq!(spec.clean_tokens, args);
     }
 
     #[test]
@@ -880,6 +897,22 @@ mod tests {
         // CLI has --full-auto (sandbox flag), so ALL env sandbox flags stripped
         assert!(merged.has_flag(&["--full-auto"], &[]));
         assert!(!merged.has_flag(&["-a"], &[]));
+    }
+
+    #[test]
+    fn test_merge_yolo_overrides_sandbox_group() {
+        let env_spec = parse_tokens(
+            &sv(&["--sandbox", "workspace-write", "-a", "untrusted"]),
+            SourceType::Env,
+        );
+        let cli_spec = parse_tokens(&sv(&["--yolo"]), SourceType::Cli);
+        let merged = merge_codex_args(&env_spec, &cli_spec);
+
+        assert!(merged.has_flag(&["--yolo"], &[]));
+        assert!(!merged.has_flag(&["--sandbox"], &["--sandbox="]));
+        assert!(!merged.has_flag(&["-a"], &[]));
+        assert!(!merged.clean_tokens.contains(&"workspace-write".to_string()));
+        assert!(!merged.clean_tokens.contains(&"untrusted".to_string()));
     }
 
     #[test]

--- a/src/tools/codex_preprocessing.rs
+++ b/src/tools/codex_preprocessing.rs
@@ -77,6 +77,7 @@ pub fn ensure_hcom_writable(tokens: &[String]) -> Vec<String> {
             "-s",
             "--dangerously-bypass-approvals-and-sandbox",
             "--full-auto",
+            "--yolo",
         ],
         &["--sandbox=", "-s="],
     );
@@ -489,6 +490,16 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    fn test_ensure_hcom_writable_treats_yolo_as_sandbox_active() {
+        init_config();
+        let tokens = s(&["--yolo"]);
+        let result = ensure_hcom_writable(&tokens);
+        assert_eq!(result[0], "--add-dir");
+        assert!(result.contains(&"--yolo".to_string()));
+    }
+
+    #[test]
     fn test_ensure_hcom_writable_skips_no_sandbox() {
         // No sandbox flags → mode="none" → skip (doesn't use paths)
         let tokens = s(&["-m", "o3"]);
@@ -769,6 +780,20 @@ mod tests {
         assert!(!result.contains(&"workspace-write".to_string()));
         assert!(result.contains(&"--add-dir".to_string()));
         assert!(result.contains(&"sandbox_workspace_write.network_access=true".to_string()));
+    }
+
+    #[test]
+    #[serial]
+    fn test_preprocess_yolo_overrides_hcom_default_sandbox() {
+        init_config();
+        let args = s(&["--yolo", "-m", "o3"]);
+        let result = preprocess_codex_args(&args, "BOOTSTRAP", "workspace");
+
+        assert!(result.contains(&"--yolo".to_string()));
+        assert!(!result.contains(&"--sandbox".to_string()));
+        assert!(!result.contains(&"workspace-write".to_string()));
+        assert!(result.contains(&"sandbox_workspace_write.network_access=true".to_string()));
+        assert!(result.contains(&"--add-dir".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Codex CLI ships a hidden `--yolo` alias for `--full-auto` (equivalent to `--dangerously-bypass-approvals-and-sandbox`). hcom's Codex argument allowlist rejects it before launch, so `hcom codex --yolo` fails even though the underlying `codex --yolo --version` works:

```
$ hcom codex --yolo
Error: unrecognized flag: --yolo
```

This PR adds `--yolo` to the parser allowlist, sandbox-group set, and the hcom-writable sandbox-active detector — behavior parallels the existing handling for `--full-auto` and `--dangerously-bypass-approvals-and-sandbox`.

## Changes

- `src/tools/codex_args.rs`:
  - `BOOLEAN_FLAGS` adds `--yolo` (parser accepts it as a no-arg flag)
  - `SANDBOX_FLAGS` adds `--yolo` (treated as a sandbox-group override during arg merge)
  - New unit test `test_parse_yolo_hidden_alias`
  - New unit test `test_merge_yolo_overrides_sandbox_group`
  - Existing `test_parse_boolean_flags` extended to cover `--yolo`
- `src/tools/codex_preprocessing.rs`:
  - `ensure_hcom_writable` sandbox-active list adds `--yolo` (so hcom CWD lands in `--add-dir` set)
  - New unit test `test_ensure_hcom_writable_treats_yolo_as_sandbox_active`
  - New unit test `test_preprocess_yolo_overrides_hcom_default_sandbox`

No dependency changes. No schema or CLI-contract changes for existing flags. Doc updates intentionally omitted — happy to add if you'd prefer them in this PR.

## Test plan

- [x] `cargo test --release --locked` passes locally (all 4 new tests + full suite)
- [x] `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Manual: `hcom codex --yolo` accepts the flag and propagates it through preprocessing with sandbox-active treatment
- [ ] CI: would benefit from confirmation on macOS / Windows runners

Branched from `aannoo/hcom@main` and squash-friendly — single focused commit.