### PR TITLE
feat(cursor): add first-class Cursor Agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > **Hook your coding agents together**
 
-`hcom` is a CLI that agents can use to message, watch, and spawn each other across terminals. It integrates with Claude Code, Gemini, Codex, OpenCode and Antigravity without changing how you use them.
+`hcom` is a CLI that agents can use to message, watch, and spawn each other across terminals. It integrates with Claude Code, Gemini, Codex, OpenCode, Antigravity and Cursor without changing how you use them.
 
 Use it to coordinate pipelines, run different AI CLIs as each other's subagents, or just instead of copy-paste.
 
@@ -43,7 +43,7 @@ uv tool install hcom  # or: pip install hcom
 Terminal 1:
 
 ```bash
-hcom claude   # codex / gemini / opencode / agy
+hcom claude   # codex / gemini / opencode / agy / cursor-agent
 ```
 
 Terminal 2:
@@ -217,6 +217,7 @@ brew uninstall hcom          # or: rm $(which hcom)
 | Codex CLI | automatic | `hcom codex` |
 | Antigravity CLI | automatic | `hcom agy` |
 | OpenCode | automatic | `hcom opencode` |
+| Cursor CLI | automatic | `hcom cursor-agent` |
 | Anything else | manual via `hcom listen` | `hcom start` (run inside tool) |
 
 ```bash
@@ -249,7 +250,7 @@ What you might type from a shell. Agents run their own commands that they learn 
 ### Spawn
 
 ```bash
-hcom [N] claude|gemini|codex|agy|opencode   # launch N agents
+hcom [N] claude|gemini|codex|agy|opencode|cursor-agent   # launch N agents
 hcom r <name|session_id>                # resume agent
 hcom f <name|session_id>                # fork session
 hcom kill <name|tag:T|all>              # kill + close terminal pane
@@ -312,7 +313,7 @@ hcom config -i <name> <key> <value>   # per-agent override at runtime
 | `terminal` | Where new agent windows open (`hcom config terminal --info`) |
 | `timeout` | Idle timeout for headless/vanilla Claude (seconds) |
 | `subagent_timeout` | Keep-alive for Claude subagents (seconds) |
-| `claude_args` / `gemini_args` / `codex_args` / `opencode_args` | Default args passed to the tool |
+| `claude_args` / `gemini_args` / `codex_args` / `opencode_args` / `cursor_args` | Default args passed to the tool |
 
 ### Scope
 

--- a/skills/hcom-agent-messaging/SKILL.md
+++ b/skills/hcom-agent-messaging/SKILL.md
@@ -12,7 +12,7 @@ AI agents running in separate terminals are isolated. hcom connects them via hoo
 
 ```bash
 curl -fsSL https://github.com/aannoo/hcom/releases/latest/download/hcom-installer.sh | sh
-hcom claude       # or: hcom gemini, hcom codex, hcom opencode
+hcom claude       # or: hcom gemini, hcom codex, hcom opencode, hcom agy, hcom cursor-agent
 hcom              # TUI dashboard
 ```
 
@@ -56,6 +56,8 @@ run `hcom --help` for full command syntax and flags.
 | gemini cli (>= 0.26.0) | automatic | `hcom gemini` |
 | codex | automatic | `hcom codex` |
 | opencode | automatic | `hcom opencode` |
+| antigravity | automatic | `hcom agy` |
+| cursor | automatic | `hcom cursor-agent` |
 | any other ai tool | manual via `hcom listen` | `hcom start` (run inside tool) |
 
 session binding (hcom transcript, hcom r/f by session id) happens on first message or first prompt for all hcom-launched tools.

--- a/skills/hcom-agent-messaging/references/cross-tool.md
+++ b/skills/hcom-agent-messaging/references/cross-tool.md
@@ -45,6 +45,17 @@ Verified behavior when mixing different AI coding tools via hcom.
 - **Message delivery**: Plugin TCP endpoint
 - **Auto-approval**: `OPENCODE_PERMISSION={"bash":{"hcom *":"allow"}}` env var
 
+### Cursor (cursor-agent)
+- **Hooks**: sessionStart, beforeSubmitPrompt, preToolUse, postToolUse, stop, sessionEnd
+- **Payload**: JSON via stdin
+- **Session binding**: On sessionStart hook, immediate
+- **Message delivery**: Hook-based when hcom-launched. Active turn → body in postToolUse `additional_context`. Idle agent → a sentinel turn whose `stop` hook carries the body in `followup_message` (one extra turn vs. other tools — the idle wake costs a round-trip).
+- **Background mode**: HeadlessPty — runs under a PTY even when headless (cursor-agent `--print` drops the beforeSubmitPrompt + stop hooks, so hcom keeps the interactive TUI). No detached `--print` background like Claude.
+- **Approval handling**: cursor's interactive approval prompt ("Run this command?") is detected by PTY screen scrape; a message held at an approval surfaces status `blocked: approval pending`.
+- **Status detail**: edit tool is `StrReplace` (not `Edit`); file/edit tools key the path off `path` (not `file_path`); shell has the `run_terminal_cmd` variant; delegates are `Task`/`Subagent`.
+- **Fork**: not supported (cursor-agent has no native branch primitive — only `--resume`/`--continue`); resume preserved.
+- **Transcript**: cursor stores history in a protobuf+JSON store.db (no JSONL for hcom launches); parser support is limited.
+
 ## Working Patterns
 
 See `scripts/cross-tool-duo.sh` for Claude architect + Codex engineer, and `scripts/codex-worker.sh` for Codex coder + Claude reviewer. See `patterns.md` for all 6 tested patterns including Claude + Gemini mixed perspectives.

--- a/skills/hcom-agent-messaging/references/cross-tool.md
+++ b/skills/hcom-agent-messaging/references/cross-tool.md
@@ -43,7 +43,7 @@ Verified behavior when mixing different AI coding tools via hcom.
 - **Plugin location**: `$XDG_DATA_HOME/opencode/plugins/hcom/`
 - **Session binding**: Via TCP binding ceremony (plugin calls `hcom opencode-start --session-id`)
 - **Message delivery**: Plugin TCP endpoint
-- **Auto-approval**: `OPENCODE_PERMISSION={"bash":{"hcom *":"allow"}}` env var
+- **Auto-approval**: `OPENCODE_PERMISSION` env var scoped to safe hcom command prefixes
 
 ### Cursor (cursor-agent)
 - **Hooks**: sessionStart, beforeSubmitPrompt, preToolUse, postToolUse, stop, sessionEnd
@@ -54,7 +54,7 @@ Verified behavior when mixing different AI coding tools via hcom.
 - **Approval handling**: cursor's interactive approval prompt ("Run this command?") is detected by PTY screen scrape; a message held at an approval surfaces status `blocked: approval pending`.
 - **Status detail**: edit tool is `StrReplace` (not `Edit`); file/edit tools key the path off `path` (not `file_path`); shell has the `run_terminal_cmd` variant; delegates are `Task`/`Subagent`.
 - **Fork**: not supported (cursor-agent has no native branch primitive — only `--resume`/`--continue`); resume preserved.
-- **Transcript**: cursor stores history in a protobuf+JSON store.db (no JSONL for hcom launches); parser support is limited.
+- **Transcript**: cursor-agent writes JSONL under `~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl`. Parser support is limited: no timestamps, `cwd`, or tool-result blocks; user prompts require wrapper removal.
 
 ## Working Patterns
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -63,10 +63,10 @@ You MUST use `hcom <cmd+flags> --name {instance_name}` for all hcom commands:
   Filters (same flag=OR, different=AND): --agent NAME | --type message|status|life | --status listening|active|blocked | --cmd PATTERN (contains, ^prefix, =exact) | --file PATH (*.py for glob, file.py for contains)
   Event-based notifications, watch agents, subscribe, react: events sub [filters] | --help
 - Handoff context: bundle prepare
-- Spawn agents: [num] <claude|gemini|codex|opencode|antigravity|agy> [--tag labelOrGroup] [--terminal tmux|kitty|wezterm|etc]
+- Spawn agents: [num] <claude|gemini|codex|opencode|antigravity|agy|cursor> [--tag labelOrGroup] [--terminal tmux|kitty|wezterm|etc]
   Example: `hcom 1 claude --tag cool` -> automatic <hcom> msg when ready -> send it task via hcom send
   Resume: hcom r <name> [args] | Fork: hcom f <name> [args] | Kill: hcom kill <name(s)>
-  background, set prompt, system, forward args: <claude|gemini|codex|opencode> --help
+  background, set prompt, system, forward args: <claude|gemini|codex|opencode|cursor> --help
 - Run workflows: run <script> [args] [--help]
   {scripts}
 - View agent screen: term [name] | inject text/enter: term inject <name> ['text'] [--enter]
@@ -135,6 +135,15 @@ End your turn and wait — a reply will arrive on a later `<hcom>` wake when the
 pub(crate) fn is_antigravity_tool(tool: &str) -> bool {
     tool == "antigravity"
 }
+
+const CURSOR_DELIVERY: &str = r#"## CURSOR DELIVERY (hook-primary)
+
+Cursor delivers hcom messages through hooks:
+- A prompt that is only `<hcom>` is a wake trigger, not a task. Do not answer it and do not run tools or discovery commands. End your turn immediately. The queued hcom message will arrive automatically as your next prompt.
+- A populated `<hcom>…</hcom>` block is the real delivery. Read it and follow its `intent`.
+- After handling a delivery, end your turn so the next message can arrive.
+
+Messages arrive automatically — end your turn to receive them."#;
 
 const DELIVERY_AUTO: &str = r#"## DELIVERY
 
@@ -441,6 +450,8 @@ pub fn get_bootstrap(
     // Tool-specific delivery
     if tool == "antigravity" && ctx.is_launched {
         parts.push(ANTIGRAVITY_DELIVERY);
+    } else if tool == "cursor" && ctx.is_launched {
+        parts.push(CURSOR_DELIVERY);
     } else if tool == "claude"
         || ((tool == "codex" || tool == "gemini" || tool == "opencode") && ctx.is_launched)
     {
@@ -892,6 +903,28 @@ mod tests {
         );
 
         assert!(result.contains("Messages do NOT arrive automatically"));
+    }
+
+    #[test]
+    fn test_get_bootstrap_cursor_launched_gets_hook_primary_delivery() {
+        let (tmp, db) = setup_test_db();
+
+        let result = get_bootstrap(
+            &db,
+            tmp.path(),
+            "nova",
+            "cursor",
+            false,
+            true,
+            "",
+            "",
+            false,
+            None,
+        );
+
+        assert!(result.contains("CURSOR DELIVERY"));
+        assert!(result.contains("wake trigger"));
+        assert!(result.contains("End your turn immediately"));
     }
 
     #[test]

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -66,7 +66,7 @@ You MUST use `hcom <cmd+flags> --name {instance_name}` for all hcom commands:
 - Spawn agents: [num] <claude|gemini|codex|opencode|antigravity|agy|cursor> [--tag labelOrGroup] [--terminal tmux|kitty|wezterm|etc]
   Example: `hcom 1 claude --tag cool` -> automatic <hcom> msg when ready -> send it task via hcom send
   Resume: hcom r <name> [args] | Fork: hcom f <name> [args] | Kill: hcom kill <name(s)>
-  background, set prompt, system, forward args: <claude|gemini|codex|opencode|cursor> --help
+  background, set prompt, system, forward args: <claude|gemini|codex|opencode|agy|cursor> --help
 - Run workflows: run <script> [args] [--help]
   {scripts}
 - View agent screen: term [name] | inject text/enter: term inject <name> ['text'] [--enter]
@@ -136,7 +136,7 @@ pub(crate) fn is_antigravity_tool(tool: &str) -> bool {
     tool == "antigravity"
 }
 
-const CURSOR_DELIVERY: &str = r#"## CURSOR DELIVERY (hook-primary)
+const CURSOR_DELIVERY: &str = r#"## CURSOR DELIVERY
 
 Cursor delivers hcom messages through hooks:
 - A prompt that is only `<hcom>` is a wake trigger, not a task. Do not answer it and do not run tools or discovery commands. End your turn immediately. The queued hcom message will arrive automatically as your next prompt.
@@ -449,8 +449,10 @@ pub fn get_bootstrap(
 
     // Tool-specific delivery
     if tool == "antigravity" && ctx.is_launched {
+        parts.push(DELIVERY_AUTO);
         parts.push(ANTIGRAVITY_DELIVERY);
     } else if tool == "cursor" && ctx.is_launched {
+        parts.push(DELIVERY_AUTO);
         parts.push(CURSOR_DELIVERY);
     } else if tool == "claude"
         || ((tool == "codex" || tool == "gemini" || tool == "opencode") && ctx.is_launched)
@@ -815,7 +817,7 @@ mod tests {
         assert!(result.contains("ANTIGRAVITY DELIVERY"));
         assert!(result.contains("preview"));
         assert!(result.contains("hcom --help"));
-        assert!(!result.contains("Messages instantly and automatically arrive"));
+        assert!(result.contains("Messages instantly and automatically arrive"));
     }
 
     #[test]

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -92,6 +92,11 @@ pub const CONFIG_KEYS: &[(&str, &str, &str)] = &[
         "string",
     ),
     (
+        "HCOM_CURSOR_ARGS",
+        "Default args for cursor-agent on launch",
+        "string",
+    ),
+    (
         "HCOM_CODEX_SANDBOX_MODE",
         "Codex permission profile (workspace | untrusted | danger-full-access | none)",
         "string",
@@ -179,6 +184,7 @@ fn toml_path_for_key(field_name: &str) -> Option<&'static str> {
         "codex_sandbox_mode" => Some("launch.codex.sandbox_mode"),
         "codex_system_prompt" => Some("launch.codex.system_prompt"),
         "opencode_args" => Some("launch.opencode.args"),
+        "cursor_args" => Some("launch.cursor.args"),
         "relay" => Some("relay.url"),
         "relay_id" => Some("relay.id"),
         "relay_token" => Some("relay.token"),
@@ -1468,7 +1474,7 @@ Example:
   # hcom send \"@$HCOM_NAME completed task\"
 
 Notes:
-  - Only affects hcom-launched instances (hcom N claude/gemini/codex/opencode/agy)
+  - Only affects hcom-launched instances (hcom N claude/gemini/codex/opencode/agy/cursor)
   - Variable name must be a valid shell identifier
   - Works alongside HCOM_PROCESS_ID (always set) for identity",
         ),
@@ -1481,6 +1487,16 @@ Example: hcom config opencode_args \"--model o3\"
 Clear:   hcom config opencode_args \"\"
 
 Merged with launch-time cli args (launch args win on conflict).",
+        ),
+
+        "HCOM_CURSOR_ARGS" => Some(
+            "\
+HCOM_CURSOR_ARGS - Default args passed to cursor-agent on launch
+
+Example: hcom config cursor_args \"--model auto\"
+Clear:   hcom config cursor_args \"\"
+
+Prepended to launch-time cli args.",
         ),
 
         "HCOM_RELAY_ENABLED" => Some(

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1051,7 +1051,11 @@ pub fn cmd_config(db: &HcomDb, args: &ConfigArgs, ctx: Option<&CommandContext>) 
 
                 // Side effect: auto_approve changes must update tool permissions
                 if key == "HCOM_AUTO_APPROVE" {
-                    update_auto_approve_permissions(&value);
+                    return if update_auto_approve_permissions(&value) {
+                        0
+                    } else {
+                        1
+                    };
                 }
 
                 return 0;
@@ -1406,7 +1410,7 @@ Only needed if your broker requires authentication.",
 HCOM_AUTO_APPROVE - Auto-approve safe hcom commands
 
 Purpose:
-  When enabled, Claude/Gemini/Codex/OpenCode/Antigravity auto-approve \"safe\" hcom commands
+  When enabled, Claude/Gemini/Codex/OpenCode/Antigravity/Cursor auto-approve \"safe\" hcom commands
   without requiring user confirmation.
 
 Usage:
@@ -2040,28 +2044,22 @@ fn kitty_setup() -> i32 {
 }
 
 /// Update tool permissions when auto_approve changes.
-/// Delegates to `hcom hooks setup` for Claude/Gemini/Codex/OpenCode/Antigravity.
-fn update_auto_approve_permissions(value: &str) {
-    let enabled = !matches!(value, "0" | "false" | "False" | "no" | "off" | "");
-    // Re-run hooks setup to update tool permission files
-    let prefix = crate::runtime_env::get_hcom_prefix();
-    if let Some((cmd, prefix_args)) = prefix.split_first() {
-        let _ = std::process::Command::new(cmd)
-            .args(prefix_args)
-            .args(["hooks", "setup"])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .and_then(|mut c| c.wait());
-    }
+fn update_auto_approve_permissions(value: &str) -> bool {
+    let normalized = value.to_ascii_lowercase();
+    let enabled = !matches!(normalized.as_str(), "0" | "false" | "no" | "off" | "");
+    let failures = super::hooks::refresh_installed_hook_permissions(enabled);
 
     if enabled {
         println!(
-            "Auto-approve enabled for safe hcom commands in Claude/Gemini/Codex/OpenCode/Antigravity"
+            "Auto-approve enabled for safe hcom commands in Claude/Gemini/Codex/OpenCode/Antigravity/Cursor"
         );
     } else {
         println!("Auto-approve disabled - safe hcom commands will require approval");
     }
+    for (tool, error) in &failures {
+        eprintln!("Failed to update {tool} auto-approve permissions: {error}");
+    }
+    failures.is_empty()
 }
 
 /// Trigger relay push (best-effort, silent failure). C4 fix.

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -191,7 +191,7 @@ const LIST_HELP: &[HelpEntry] = &[
     ),
     (
         "",
-        "[claude] [gemini] [codex] [opencode] [antigravity]  vanilla (hooks only)",
+        "[claude] [gemini] [codex] [opencode] [antigravity] [cursor]  vanilla (hooks only)",
     ),
     ("", "[AD-HOC]                              manual polling"),
 ];
@@ -443,7 +443,7 @@ const RESET_HELP: &[HelpEntry] = &[
     ),
     (
         "",
-        "  HCOM_DIR=$PWD/.hcom -> $PWD/.claude, .gemini, .codex, .opencode, .antigravity",
+        "  HCOM_DIR=$PWD/.hcom -> $PWD/.claude, .gemini, .codex, .opencode, .antigravity, .cursor",
     ),
     ("", ""),
     ("", "To remove local setup:"),
@@ -477,7 +477,7 @@ const CONFIG_HELP: &[HelpEntry] = &[
         "Subagent keep-alive seconds after task",
     ),
     (
-        "  claude_args / gemini_args / codex_args / opencode_args",
+        "  claude_args / gemini_args / codex_args / opencode_args / cursor_args",
         "",
     ),
     ("  auto_approve", "Auto-approve safe hcom commands"),
@@ -609,11 +609,11 @@ const HOOKS_HELP: &[HelpEntry] = &[
     ("hooks status", "Same as above"),
     (
         "hooks add [tool]",
-        "Add hooks (claude | gemini | codex | opencode | all)",
+        "Add hooks (claude | gemini | codex | opencode | antigravity | cursor | all)",
     ),
     (
         "hooks remove [tool]",
-        "Remove hooks (claude | gemini | codex | opencode | all)",
+        "Remove hooks (claude | gemini | codex | opencode | antigravity | cursor | all)",
     ),
     ("", ""),
     (
@@ -848,6 +848,8 @@ pub const COMMAND_NAMES: &[&str] = &[
     "opencode",
     "antigravity",
     "agy",
+    "cursor",
+    "cursor-agent",
 ];
 
 /// Get the top-level help text as a String.
@@ -860,7 +862,7 @@ Usage:\n\
   hcom <command>                        Run command\n\
 \n\
 Launch:\n\
-  hcom [N] claude|gemini|codex|opencode|agy [flags] [tool-args]\n\
+  hcom [N] claude|gemini|codex|opencode|agy|cursor [flags] [tool-args]\n\
   hcom r <name>                         Resume stopped agent\n\
   hcom f <name>                         Fork agent session (claude/codex/opencode)\n\
   hcom kill <name(s)|tag:T|all>         Kill + close terminal pane\n\

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -667,11 +667,13 @@ fn get_tool_spec(name: &str) -> Option<&'static crate::integration_spec::Integra
 
 /// Generate tool launch help from the integration spec.
 fn generate_tool_help(spec: &crate::integration_spec::IntegrationSpec) -> String {
-    // The CLI uses "agy" rather than the canonical "antigravity" for Antigravity.
-    let t = if spec.tool == crate::tool::Tool::Antigravity {
-        "agy"
-    } else {
-        spec.name
+    // The displayed launch keyword can differ from the canonical internal
+    // `spec.name`: Antigravity launches as "agy", Cursor as "cursor-agent"
+    // (the real CLI binary — there is no `cursor` command to pass through to).
+    let t = match spec.tool {
+        crate::tool::Tool::Antigravity => "agy",
+        crate::tool::Tool::Cursor => "cursor-agent",
+        _ => spec.name,
     };
     let inside_ai = crate::shared::is_inside_ai_tool();
     let term_desc = if inside_ai {
@@ -862,7 +864,7 @@ Usage:\n\
   hcom <command>                        Run command\n\
 \n\
 Launch:\n\
-  hcom [N] claude|gemini|codex|opencode|agy|cursor [flags] [tool-args]\n\
+  hcom [N] claude|gemini|codex|opencode|agy|cursor-agent [flags] [tool-args]\n\
   hcom r <name>                         Resume stopped agent\n\
   hcom f <name>                         Fork agent session (claude/codex/opencode)\n\
   hcom kill <name(s)|tag:T|all>         Kill + close terminal pane\n\

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -19,7 +19,14 @@ pub struct HooksArgs {
 /// Valid tool names for hooks management. Must stay in sync with released
 /// hook-bearing specs in `integration_spec.rs` — see
 /// `router::tests::hook_tools_match_released_specs_with_hooks` for the guard.
-pub(crate) const HOOK_TOOLS: &[&str] = &["claude", "gemini", "codex", "opencode", "antigravity"];
+pub(crate) const HOOK_TOOLS: &[&str] = &[
+    "claude",
+    "gemini",
+    "codex",
+    "opencode",
+    "antigravity",
+    "cursor",
+];
 
 /// Get hook installation status for each tool.
 ///
@@ -72,7 +79,7 @@ fn cmd_hooks_add(argv: &[String]) -> i32 {
         vec![argv[0].as_str()]
     } else {
         eprintln!("Error: Unknown tool: {}", argv[0]);
-        eprintln!("Valid options: claude, gemini, codex, opencode, antigravity, all");
+        eprintln!("Valid options: claude, gemini, codex, opencode, antigravity, cursor, all");
         return 1;
     };
 
@@ -137,6 +144,7 @@ fn cmd_hooks_add(argv: &[String]) -> i32 {
                 "codex" => "Codex",
                 "opencode" => "OpenCode",
                 "antigravity" => "Antigravity",
+                "cursor" => "Cursor Agent",
                 other => other,
             };
             println!("Restart {tool_name} to activate hooks.");
@@ -157,7 +165,7 @@ pub fn cmd_hooks_remove(argv: &[String]) -> i32 {
         vec![argv[0].as_str()]
     } else {
         eprintln!("Error: Unknown tool: {}", argv[0]);
-        eprintln!("Valid options: claude, gemini, codex, opencode, antigravity, all");
+        eprintln!("Valid options: claude, gemini, codex, opencode, antigravity, cursor, all");
         return 1;
     };
 
@@ -218,8 +226,8 @@ pub fn cmd_hooks(_db: &HcomDb, args: &HooksArgs, _ctx: Option<&CommandContext>) 
              Usage:\n  \
              hcom hooks                  Show hook status for all tools\n  \
              hcom hooks status           Same as above\n  \
-             hcom hooks add [tool]       Add hooks (claude|gemini|codex|opencode|antigravity|all)\n  \
-             hcom hooks remove [tool]    Remove hooks (claude|gemini|codex|opencode|antigravity|all)\n\n\
+             hcom hooks add [tool]       Add hooks (claude|gemini|codex|opencode|antigravity|cursor|all)\n  \
+             hcom hooks remove [tool]    Remove hooks (claude|gemini|codex|opencode|antigravity|cursor|all)\n\n\
              Examples:\n  \
              hcom hooks add claude       Add Claude Code hooks only\n  \
              hcom hooks add              Auto-detect tool or add all\n  \

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -28,6 +28,27 @@ pub(crate) const HOOK_TOOLS: &[&str] = &[
     "cursor",
 ];
 
+/// Refresh permission state for hook integrations that are already installed.
+///
+/// This is used after `auto_approve` changes. It intentionally skips tools
+/// without installed hooks so changing one preference does not install new
+/// integrations as a side effect.
+pub(crate) fn refresh_installed_hook_permissions(enabled: bool) -> Vec<(&'static str, String)> {
+    let mut failures = Vec::new();
+    for name in HOOK_TOOLS {
+        let Ok(tool) = name.parse::<Tool>() else {
+            continue;
+        };
+        if !tool.verify_hooks_installed(false) {
+            continue;
+        }
+        if let Err(error) = tool.try_setup_hooks(enabled) {
+            failures.push((*name, error));
+        }
+    }
+    failures
+}
+
 /// Get hook installation status for each tool.
 ///
 /// Iterates [`HOOK_TOOLS`] and routes through the `Tool::*` hook adapter so a

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -435,6 +435,7 @@ pub(crate) fn print_launch_preview(preview: LaunchPreview<'_>) {
             "gemini" => preview.config.gemini_args.as_str(),
             "codex" => preview.config.codex_args.as_str(),
             "opencode" => preview.config.opencode_args.as_str(),
+            "cursor" | "cursor-agent" => preview.config.cursor_args.as_str(),
             _ => "",
         }
     } else {
@@ -585,6 +586,16 @@ pub(crate) fn merge_tool_args(tool: &str, cli_args: &[String], config: &HcomConf
             let cli_spec = codex_args::resolve_codex_args(Some(cli_args), None);
             let merged = codex_args::merge_codex_args(&env_spec, &cli_spec);
             merged.rebuild_tokens(true, true)
+        }
+        "cursor" | "cursor-agent" => {
+            let env_str = &config.cursor_args;
+            if env_str.is_empty() {
+                return cli_args.to_vec();
+            }
+            let mut env_tokens: Vec<String> =
+                crate::tools::args_common::shell_split(env_str).unwrap_or_default();
+            env_tokens.extend(cli_args.iter().cloned());
+            env_tokens
         }
         _ => cli_args.to_vec(), // opencode: pass through
     }

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -588,14 +588,17 @@ pub(crate) fn merge_tool_args(tool: &str, cli_args: &[String], config: &HcomConf
             merged.rebuild_tokens(true, true)
         }
         "cursor" | "cursor-agent" => {
+            // env config args first, explicit CLI args last (CLI wins under
+            // commander.js last-wins). Then strip any --print/-p that would put
+            // cursor in one-shot headless mode and break PTY hook delivery.
             let env_str = &config.cursor_args;
-            if env_str.is_empty() {
-                return cli_args.to_vec();
-            }
-            let mut env_tokens: Vec<String> =
-                crate::tools::args_common::shell_split(env_str).unwrap_or_default();
-            env_tokens.extend(cli_args.iter().cloned());
-            env_tokens
+            let mut tokens: Vec<String> = if env_str.is_empty() {
+                Vec::new()
+            } else {
+                crate::tools::args_common::shell_split(env_str).unwrap_or_default()
+            };
+            tokens.extend(cli_args.iter().cloned());
+            crate::tools::cursor_preprocessing::strip_cursor_print_flags(&tokens)
         }
         _ => cli_args.to_vec(), // opencode: pass through
     }

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -589,8 +589,8 @@ pub(crate) fn merge_tool_args(tool: &str, cli_args: &[String], config: &HcomConf
         }
         "cursor" | "cursor-agent" => {
             // env config args first, explicit CLI args last (CLI wins under
-            // commander.js last-wins). Then strip any --print/-p that would put
-            // cursor in one-shot headless mode and break PTY hook delivery.
+            // commander.js last-wins). Print-mode conflicts are rejected by the
+            // unified launcher so their meaning is never silently changed.
             let env_str = &config.cursor_args;
             let mut tokens: Vec<String> = if env_str.is_empty() {
                 Vec::new()
@@ -598,7 +598,7 @@ pub(crate) fn merge_tool_args(tool: &str, cli_args: &[String], config: &HcomConf
                 crate::tools::args_common::shell_split(env_str).unwrap_or_default()
             };
             tokens.extend(cli_args.iter().cloned());
-            crate::tools::cursor_preprocessing::strip_cursor_print_flags(&tokens)
+            tokens
         }
         _ => cli_args.to_vec(), // opencode: pass through
     }

--- a/src/commands/reset_preview.rs
+++ b/src/commands/reset_preview.rs
@@ -73,7 +73,7 @@ fn render_reset_all_preview(state: &ResetPreviewState) -> String {
          1. Stop all {instance_count} local instances (kills processes, logs snapshots)\n  \
          2. Archive database to ~/.hcom/archive/session-<timestamp>/\n  \
          3. Delete database (hcom.db)\n  \
-         4. Remove hooks from Claude/Gemini/Codex/OpenCode/Antigravity configs\n  \
+         4. Remove hooks from Claude/Gemini/Codex/OpenCode/Antigravity/Cursor configs\n  \
          5. Archive and delete config.toml + env\n  \
          6. Clear device identity (new UUID on next relay)\n\n\
          Add --go flag and run again to proceed:\n  \

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -1553,7 +1553,67 @@ fn find_session_on_disk(session_id: &str) -> Option<(String, Option<String>)> {
         return Some((tool, Some(path)));
     }
 
+    // 5. Cursor
+    if let Some(path) = derive_cursor_transcript_path(session_id) {
+        let tool = detect_agent_type(&path).to_string();
+        return Some((tool, Some(path)));
+    }
+
     None
+}
+
+/// Locate a cursor-agent transcript by conversation UUID (== hcom session_id).
+/// cursor writes it at `~/.cursor/projects/<slug>/agent-transcripts/<uuid>/
+/// <uuid>.jsonl` — the same path the hook reports. The `<slug>` can't be
+/// derived from the UUID, so scan the per-project dirs for the nested file.
+/// (The flat `projects/agent-transcripts/<uuid>.jsonl` mirror is skipped: it
+/// has no sibling `.workspace-trusted`, so no cwd could be recovered from it.)
+fn derive_cursor_transcript_path(session_id: &str) -> Option<String> {
+    let projects = dirs::home_dir()?.join(".cursor").join("projects");
+    let file = format!("{session_id}.jsonl");
+    for entry in std::fs::read_dir(&projects).ok()?.flatten() {
+        let candidate = entry
+            .path()
+            .join("agent-transcripts")
+            .join(session_id)
+            .join(&file);
+        if candidate.exists() {
+            return Some(candidate.to_string_lossy().to_string());
+        }
+    }
+    None
+}
+
+/// cursor transcripts carry no `cwd`, so recover it from the per-workspace
+/// `.workspace-trusted` marker cursor writes at
+/// `~/.cursor/projects/<slug>/.workspace-trusted` (`workspacePath` field). The
+/// transcript lives under `<slug>/agent-transcripts/<uuid>/<uuid>.jsonl`, so
+/// walk up to the project-slug dir (the direct child of `projects/`) and read
+/// it. Returns the recorded (canonicalized) workspace path.
+fn recover_cursor_cwd(transcript_path: &str) -> Option<String> {
+    let path = std::path::Path::new(transcript_path);
+    let mut slug_dir = None;
+    let mut cursor = path.parent();
+    while let Some(dir) = cursor {
+        if dir
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            == Some("projects")
+        {
+            slug_dir = Some(dir);
+            break;
+        }
+        cursor = dir.parent();
+    }
+    let marker = slug_dir?.join(".workspace-trusted");
+    let data = std::fs::read_to_string(&marker).ok()?;
+    let parsed: serde_json::Value = serde_json::from_str(&data).ok()?;
+    parsed
+        .get("workspacePath")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
 }
 
 /// Recover the session's working directory from the tool's on-disk state.
@@ -1565,6 +1625,8 @@ fn find_session_on_disk(session_id: &str) -> Option<(String, Option<String>)> {
 /// - **Gemini**: the session JSON has `projectHash = sha256(cwd)` (hex).
 ///   `~/.gemini/projects.json` maps `cwd → short-id`. Hash each key and
 ///   match against `projectHash` to recover the original CWD.
+/// - **Cursor**: the transcript has no `cwd`; recover it from the sibling
+///   `~/.cursor/projects/<slug>/.workspace-trusted` marker (`workspacePath`).
 fn extract_cwd_from_transcript(path: &str, tool: &str) -> Option<String> {
     match tool {
         "claude" => scan_lines_for_cwd(path, 20, |v| v.get("cwd").and_then(|c| c.as_str())),
@@ -1574,6 +1636,7 @@ fn extract_cwd_from_transcript(path: &str, tool: &str) -> Option<String> {
                 .and_then(|c| c.as_str())
         }),
         "gemini" => recover_gemini_cwd(path),
+        "cursor" => recover_cursor_cwd(path),
         _ => None,
     }
 }
@@ -1669,7 +1732,8 @@ fn build_adopt_plan(
                 "Session {sid} not found. Searched:\n  \
                  - Claude:   {claude}/*/{sid}.jsonl\n  \
                  - Codex:    ~/.codex/sessions/**/*-{sid}.jsonl\n  \
-                 - Gemini:   ~/.gemini/tmp/*/chats/session-*-{short}*.json",
+                 - Gemini:   ~/.gemini/tmp/*/chats/session-*-{short}*.json\n  \
+                 - Cursor:   ~/.cursor/projects/*/agent-transcripts/{sid}/{sid}.jsonl",
                 sid = session_id,
                 claude = claude_projects.display(),
                 short = session_id.split('-').next().unwrap_or(session_id),
@@ -1766,6 +1830,30 @@ mod tests {
     fn test_build_resume_args_claude_fork() {
         let args = build_resume_args("claude", "sess-123", true);
         assert_eq!(args, s(&["--resume", "sess-123", "--fork-session"]));
+    }
+
+    #[test]
+    fn test_recover_cursor_cwd_from_workspace_trusted() {
+        let dir = tempfile::tempdir().unwrap();
+        // Mirror ~/.cursor/projects/<slug>/{agent-transcripts/<uuid>/<uuid>.jsonl,.workspace-trusted}
+        let slug = dir.path().join("projects").join("Users-anno-Dev-x");
+        let tdir = slug.join("agent-transcripts").join("uuid-1");
+        std::fs::create_dir_all(&tdir).unwrap();
+        std::fs::write(
+            slug.join(".workspace-trusted"),
+            json!({"workspacePath": "/Users/anno/Dev/x", "trustMethod": null}).to_string(),
+        )
+        .unwrap();
+        let transcript = tdir.join("uuid-1.jsonl");
+        std::fs::write(&transcript, "{}").unwrap();
+
+        assert_eq!(
+            recover_cursor_cwd(&transcript.to_string_lossy()),
+            Some("/Users/anno/Dev/x".to_string())
+        );
+        // No marker → None (graceful: caller falls back to $PWD).
+        std::fs::remove_file(slug.join(".workspace-trusted")).unwrap();
+        assert_eq!(recover_cursor_cwd(&transcript.to_string_lossy()), None);
     }
 
     #[test]

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -1017,8 +1017,12 @@ fn merge_resume_args(tool: &str, original: &[String], resume: &[String]) -> Vec<
 ///     itself (snapshot dir or `--dir`), so a stale `--workspace` would fight
 ///     the recovered cwd and `--worktree` would spawn a *new* worktree.
 ///
-/// Resume args (`--resume <session_id>` + any user-supplied extra args) are
-/// prepended; preserved original flags follow.
+/// Resume args (`--resume <session_id>` + any user-supplied extra args) come
+/// first; preserved original flags follow. For **singular** flags that the
+/// resume args already specify (e.g. a resume-time `--model x`), the baked
+/// original copy is dropped so the resume value wins under commander.js
+/// last-wins — matching claude/codex/gemini precedence. **Repeatable** flags
+/// (`-H`/`--header`, `--plugin-dir`) are always kept and concatenate.
 fn merge_cursor_args(original: &[String], resume: &[String]) -> Vec<String> {
     // Flags whose following token is a value (so it isn't mistaken for the
     // positional prompt). `--resume`/`--worktree` also accept a value but are
@@ -1043,9 +1047,29 @@ fn merge_cursor_args(original: &[String], resume: &[String]) -> Vec<String> {
         "--worktree-base",
     ];
     const DROP_BOOLEAN: &[&str] = &["--continue", "--skip-worktree-setup"];
+    // Repeatable flags concatenate across resume + original, so they're never
+    // deduped (long names lowercased; `-H` matched case-sensitively below).
+    const REPEATABLE: &[&str] = &["--header", "--plugin-dir"];
 
     let is_flag = |t: &str| t.starts_with('-');
     let header_flags = ["-H"]; // cursor's repeatable header short flag takes a value
+    let is_repeatable = |token: &str, bare: &str| REPEATABLE.contains(&bare) || token == "-H";
+
+    // Singular flag base-names already present in the resume args — the baked
+    // original copy of any of these is dropped so resume wins (consistency with
+    // the other tools' resume-precedence). Repeatables are excluded.
+    let mut resume_singular_flags = std::collections::HashSet::new();
+    for token in resume {
+        if !is_flag(token) {
+            continue;
+        }
+        let lower = token.to_lowercase();
+        let bare = lower.split('=').next().unwrap_or(&lower).to_string();
+        if is_repeatable(token, &bare) {
+            continue;
+        }
+        resume_singular_flags.insert(bare);
+    }
 
     let mut preserved = Vec::new();
     let mut i = 0;
@@ -1068,11 +1092,18 @@ fn merge_cursor_args(original: &[String], resume: &[String]) -> Vec<String> {
             }
             continue;
         }
+        // Resume already specifies this singular flag → drop the baked dup
+        // (and its value token, when split form) so resume wins.
+        let deduped = !is_repeatable(token, bare) && resume_singular_flags.contains(bare);
         let takes_value = VALUE_FLAGS.contains(&bare) || header_flags.contains(&token.as_str());
         if takes_value {
-            preserved.push(token.clone());
+            if !deduped {
+                preserved.push(token.clone());
+            }
             if !token.contains('=') && i + 1 < original.len() {
-                preserved.push(original[i + 1].clone());
+                if !deduped {
+                    preserved.push(original[i + 1].clone());
+                }
                 i += 2;
             } else {
                 i += 1;
@@ -1081,8 +1112,10 @@ fn merge_cursor_args(original: &[String], resume: &[String]) -> Vec<String> {
         }
         if is_flag(token) {
             // Unknown/boolean config flag (e.g. --force, --yolo, --plan,
-            // --approve-mcps, --trust, --stream-partial-output): preserve.
-            preserved.push(token.clone());
+            // --approve-mcps, --trust): preserve unless resume overrides it.
+            if !deduped {
+                preserved.push(token.clone());
+            }
             i += 1;
             continue;
         }
@@ -1092,7 +1125,9 @@ fn merge_cursor_args(original: &[String], resume: &[String]) -> Vec<String> {
 
     let mut merged = resume.to_vec();
     merged.extend(preserved);
-    merged
+    // Defensive: never let a baked/resume-time --print drop cursor into one-shot
+    // headless mode (no beforeSubmitPrompt/stop hooks → broken delivery).
+    crate::tools::cursor_preprocessing::strip_cursor_print_flags(&merged)
 }
 
 /// Merge agy original args with resume args.
@@ -1942,6 +1977,53 @@ mod tests {
             merged,
             s(&["--resume", "sid", "--model=sonnet-4", "-H", "X-Trace: 1"])
         );
+    }
+
+    /// Precedence: a resume-time `--model x` must beat the baked `--model y`.
+    /// The baked singular copy is dropped (resume wins), while repeatable
+    /// flags from both sides concatenate.
+    #[test]
+    fn test_merge_resume_args_cursor_resume_value_beats_baked() {
+        let merged = merge_resume_args(
+            "cursor",
+            &s(&["--model", "y", "-H", "X-Baked: 1", "--force", "stale task"]),
+            &s(&["--resume", "sid", "--model", "x", "-H", "X-Resume: 1"]),
+        );
+        assert_eq!(
+            merged,
+            s(&[
+                "--resume",
+                "sid",
+                "--model",
+                "x",
+                "-H",
+                "X-Resume: 1",
+                // baked --model y dropped (resume wins); -H kept (repeatable);
+                // --force preserved.
+                "-H",
+                "X-Baked: 1",
+                "--force",
+            ])
+        );
+    }
+
+    /// Defensive print-strip: a baked `--print`/`-p`/`--stream-partial-output`
+    /// (e.g. from a stray HCOM_CURSOR_ARGS) must be stripped on resume so the
+    /// relaunch stays in PTY mode where delivery hooks fire.
+    #[test]
+    fn test_merge_resume_args_cursor_strips_print_flags() {
+        let merged = merge_resume_args(
+            "cursor",
+            &s(&[
+                "-p",
+                "--print",
+                "--stream-partial-output",
+                "--model",
+                "composer-2.5",
+            ]),
+            &s(&["--resume", "sid"]),
+        );
+        assert_eq!(merged, s(&["--resume", "sid", "--model", "composer-2.5"]));
     }
 
     #[test]

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -992,11 +992,107 @@ fn merge_resume_args(tool: &str, original: &[String], resume: &[String]) -> Vec<
         }
         "opencode" => merge_opencode_args(original, resume),
         "antigravity" => merge_antigravity_args(original, resume),
+        "cursor" => merge_cursor_args(original, resume),
         _ => {
             // For unknown tools: resume args only.
             resume.to_vec()
         }
     }
+}
+
+/// Merge cursor-agent original launch args with resume args.
+///
+/// cursor's launch_args bake in `HCOM_CURSOR_ARGS` (e.g. `--model composer-2.5
+/// --force`) plus the trailing positional task prompt that the launcher appends
+/// (`launcher.rs` Positional shape). On resume we must:
+///   - preserve user config flags (`--model`, `--force`/`--yolo`, `--sandbox`,
+///     `--mode`/`--plan`, `--output-format`, `--api-key`, `-H`/`--header`,
+///     `--plugin-dir`, …) so the resumed agent keeps its model/permissions;
+///   - drop the stale positional prompt — re-submitting the original task on a
+///     resume would re-run it;
+///   - strip flags hcom owns at relaunch: prior session selectors
+///     (`--resume`/`--continue`) and cwd/worktree selectors
+///     (`--workspace`, `-w`/`--worktree`, `--worktree-base`,
+///     `--skip-worktree-setup`) — the launcher sets the working directory
+///     itself (snapshot dir or `--dir`), so a stale `--workspace` would fight
+///     the recovered cwd and `--worktree` would spawn a *new* worktree.
+///
+/// Resume args (`--resume <session_id>` + any user-supplied extra args) are
+/// prepended; preserved original flags follow.
+fn merge_cursor_args(original: &[String], resume: &[String]) -> Vec<String> {
+    // Flags whose following token is a value (so it isn't mistaken for the
+    // positional prompt). `--resume`/`--worktree` also accept a value but are
+    // stripped, so they're handled by DROP_WITH_VALUE below. The repeatable
+    // header short flag `-H` is handled separately (case-sensitive) because
+    // lowercasing collides with the `-h` help flag.
+    const VALUE_FLAGS: &[&str] = &[
+        "--api-key",
+        "--header",
+        "--output-format",
+        "--mode",
+        "--model",
+        "--sandbox",
+        "--plugin-dir",
+    ];
+    // Strip these flags (and their value/optional-value token when split form).
+    const DROP_WITH_VALUE: &[&str] = &[
+        "--resume",
+        "--workspace",
+        "--worktree",
+        "-w",
+        "--worktree-base",
+    ];
+    const DROP_BOOLEAN: &[&str] = &["--continue", "--skip-worktree-setup"];
+
+    let is_flag = |t: &str| t.starts_with('-');
+    let header_flags = ["-H"]; // cursor's repeatable header short flag takes a value
+
+    let mut preserved = Vec::new();
+    let mut i = 0;
+    while i < original.len() {
+        let token = &original[i];
+        let lower = token.to_lowercase();
+        let bare = lower.split('=').next().unwrap_or(&lower);
+
+        if DROP_BOOLEAN.contains(&bare) {
+            i += 1;
+            continue;
+        }
+        if DROP_WITH_VALUE.contains(&bare) {
+            // `--flag=value`: single token. Bare `--flag`: consume an optional
+            // following value only when it isn't itself a flag.
+            if !token.contains('=') && i + 1 < original.len() && !is_flag(&original[i + 1]) {
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        let takes_value = VALUE_FLAGS.contains(&bare) || header_flags.contains(&token.as_str());
+        if takes_value {
+            preserved.push(token.clone());
+            if !token.contains('=') && i + 1 < original.len() {
+                preserved.push(original[i + 1].clone());
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        if is_flag(token) {
+            // Unknown/boolean config flag (e.g. --force, --yolo, --plan,
+            // --approve-mcps, --trust, --stream-partial-output): preserve.
+            preserved.push(token.clone());
+            i += 1;
+            continue;
+        }
+        // Bare positional = the stale task prompt. Drop it.
+        i += 1;
+    }
+
+    let mut merged = resume.to_vec();
+    merged.extend(preserved);
+    merged
 }
 
 /// Merge agy original args with resume args.
@@ -1774,6 +1870,78 @@ mod tests {
             &s(&["--conversation", "new-id"]),
         );
         assert_eq!(merged, s(&["--conversation", "new-id", "--sandbox"]));
+    }
+
+    /// cursor launch_args bake in HCOM_CURSOR_ARGS config plus a trailing
+    /// positional prompt. Resume must preserve config flags, drop the stale
+    /// prompt + old --resume, and prepend the new resume args.
+    #[test]
+    fn test_merge_resume_args_cursor_preserves_config_drops_prompt_and_session() {
+        let merged = merge_resume_args(
+            "cursor",
+            &s(&[
+                "--model",
+                "composer-2.5",
+                "--force",
+                "--resume",
+                "old-chat",
+                "fix the parser bug",
+            ]),
+            &s(&["--resume", "new-chat-id"]),
+        );
+        assert_eq!(
+            merged,
+            s(&[
+                "--resume",
+                "new-chat-id",
+                "--model",
+                "composer-2.5",
+                "--force"
+            ])
+        );
+    }
+
+    /// cwd/worktree selectors are owned by the launcher (snapshot dir or --dir),
+    /// so a stale --workspace / -w must be stripped and not fight the recovered
+    /// cwd. --continue and the prompt are also dropped.
+    #[test]
+    fn test_merge_resume_args_cursor_strips_workspace_worktree_continue() {
+        let merged = merge_resume_args(
+            "cursor",
+            &s(&[
+                "--workspace",
+                "/old/path",
+                "--continue",
+                "-w",
+                "feature-x",
+                "--sandbox",
+                "enabled",
+                "do the task",
+            ]),
+            &s(&["--resume", "sid"]),
+        );
+        assert_eq!(merged, s(&["--resume", "sid", "--sandbox", "enabled"]));
+    }
+
+    /// `--flag=value` form and the repeatable `-H` header value flag must be
+    /// preserved intact; the stale `--resume=old` equals-form is stripped.
+    #[test]
+    fn test_merge_resume_args_cursor_equals_form_and_header() {
+        let merged = merge_resume_args(
+            "cursor",
+            &s(&[
+                "--model=sonnet-4",
+                "--resume=old",
+                "-H",
+                "X-Trace: 1",
+                "summarize",
+            ]),
+            &s(&["--resume", "sid"]),
+        );
+        assert_eq!(
+            merged,
+            s(&["--resume", "sid", "--model=sonnet-4", "-H", "X-Trace: 1"])
+        );
     }
 
     #[test]

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -1125,9 +1125,9 @@ fn merge_cursor_args(original: &[String], resume: &[String]) -> Vec<String> {
 
     let mut merged = resume.to_vec();
     merged.extend(preserved);
-    // Defensive: never let a baked/resume-time --print drop cursor into one-shot
-    // headless mode (no beforeSubmitPrompt/stop hooks → broken delivery).
-    crate::tools::cursor_preprocessing::strip_cursor_print_flags(&merged)
+    // The unified launcher rejects cursor print flags with a clear error. Keep
+    // them visible here so a stale baked flag cannot silently change meaning.
+    merged
 }
 
 /// Merge agy original args with resume args.
@@ -2095,11 +2095,10 @@ mod tests {
         );
     }
 
-    /// Defensive print-strip: a baked `--print`/`-p`/`--stream-partial-output`
-    /// (e.g. from a stray HCOM_CURSOR_ARGS) must be stripped on resume so the
-    /// relaunch stays in PTY mode where delivery hooks fire.
+    /// A baked `--print`/`-p`/`--stream-partial-output` stays visible so the
+    /// launcher can reject it clearly instead of silently changing semantics.
     #[test]
-    fn test_merge_resume_args_cursor_strips_print_flags() {
+    fn test_merge_resume_args_cursor_preserves_print_flags_for_validation() {
         let merged = merge_resume_args(
             "cursor",
             &s(&[
@@ -2111,7 +2110,18 @@ mod tests {
             ]),
             &s(&["--resume", "sid"]),
         );
-        assert_eq!(merged, s(&["--resume", "sid", "--model", "composer-2.5"]));
+        assert_eq!(
+            merged,
+            s(&[
+                "--resume",
+                "sid",
+                "-p",
+                "--print",
+                "--stream-partial-output",
+                "--model",
+                "composer-2.5"
+            ])
+        );
     }
 
     #[test]

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -70,6 +70,10 @@ fn check_antigravity_hooks() -> bool {
     crate::hooks::antigravity::verify_antigravity_hooks_installed(false)
 }
 
+fn check_cursor_hooks() -> bool {
+    crate::hooks::cursor::verify_cursor_hooks_installed(false)
+}
+
 // ── Status Collection ────────────────────────────────────────────────────
 
 struct ToolStatus {
@@ -116,6 +120,11 @@ fn get_tool_statuses() -> Vec<ToolStatus> {
             name: "Antigravity",
             installed: is_antigravity_installed(),
             hooks: check_antigravity_hooks(),
+        },
+        ToolStatus {
+            name: "Cursor",
+            installed: crate::terminal::which_bin("cursor-agent").is_some(),
+            hooks: check_cursor_hooks(),
         },
     ]
 }
@@ -225,6 +234,7 @@ pub fn cmd_status(db: &HcomDb, args: &StatusArgs, _ctx: Option<&CommandContext>)
     let gemini_settings_path = crate::hooks::gemini::get_gemini_settings_path();
     let codex_config_path = crate::hooks::codex::get_codex_config_path();
     let antigravity_hooks_path = crate::hooks::antigravity::get_antigravity_hooks_path();
+    let cursor_hooks_path = crate::hooks::cursor::get_cursor_hooks_path();
 
     if json_mode {
         let log_summary = crate::log::get_log_summary(1.0);
@@ -268,6 +278,11 @@ pub fn cmd_status(db: &HcomDb, args: &StatusArgs, _ctx: Option<&CommandContext>)
                     "installed": tools[4].installed,
                     "hooks": tools[4].hooks,
                     "settings_path": antigravity_hooks_path.to_string_lossy(),
+                },
+                "cursor": {
+                    "installed": tools[5].installed,
+                    "hooks": tools[5].hooks,
+                    "settings_path": cursor_hooks_path.to_string_lossy(),
                 },
             },
             "terminal": {

--- a/src/commands/transcript.rs
+++ b/src/commands/transcript.rs
@@ -120,6 +120,10 @@ pub(crate) fn detect_agent_type(path: &str) -> &str {
     let lower = path.to_ascii_lowercase();
     if lower.contains("antigravity") || lower.contains("/agy/") || lower.contains("/agy-") {
         "antigravity"
+    } else if lower.contains(".cursor") {
+        // Must precede the Claude `/projects/` catch: cursor transcripts live at
+        // `~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl`.
+        "cursor"
     } else if path.contains(".claude") || path.contains("/projects/") {
         "claude"
     } else if lower.contains(".gemini") {
@@ -1341,12 +1345,14 @@ mod tests {
                 "/home/user/Library/Application Support/Antigravity/session.jsonl",
                 "antigravity",
             ),
+            (
+                "/home/user/.cursor/projects/x/agent-transcripts/abc/abc.jsonl",
+                "cursor",
+            ),
         ];
         let expected: std::collections::HashSet<&str> =
             crate::integration_spec::released_tool_names()
                 .into_iter()
-                // Cursor transcript parsing is a Phase 2 integration.
-                .filter(|tool| *tool != "cursor")
                 .collect();
         let actual: std::collections::HashSet<&str> = cases
             .iter()

--- a/src/commands/transcript.rs
+++ b/src/commands/transcript.rs
@@ -1376,11 +1376,12 @@ mod tests {
 
     #[test]
     fn detect_agent_type_cursor_keys_on_agent_transcripts_not_dotcursor() {
-        // Regression: a Claude transcript whose cwd-slug contains a checked-in
-        // `.cursor/` rules dir must NOT misroute to cursor (feeds resume tool
-        // detection → would break resume + pick the wrong parser).
+        // Regression: a Claude transcript path with a LITERAL `.cursor` segment
+        // (the CLAUDE_CONFIG_DIR-style vector the old `.contains(".cursor")`
+        // matcher WOULD have misrouted to cursor) must detect claude. Feeds
+        // resume tool detection → wrong match would break resume + parser.
         assert_eq!(
-            detect_agent_type("/home/u/.claude/projects/-repo--cursor-rules/abcd.jsonl"),
+            detect_agent_type("/home/u/.claude/projects/x/.cursor/abcd.jsonl"),
             "claude"
         );
         // A real cursor transcript (the `agent-transcripts` segment) detects cursor.

--- a/src/commands/transcript.rs
+++ b/src/commands/transcript.rs
@@ -120,9 +120,14 @@ pub(crate) fn detect_agent_type(path: &str) -> &str {
     let lower = path.to_ascii_lowercase();
     if lower.contains("antigravity") || lower.contains("/agy/") || lower.contains("/agy-") {
         "antigravity"
-    } else if lower.contains(".cursor") {
-        // Must precede the Claude `/projects/` catch: cursor transcripts live at
-        // `~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl`.
+    } else if lower.contains("agent-transcripts") {
+        // Cursor transcripts live at
+        // `~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl`. Key
+        // off the `agent-transcripts` segment — unique to cursor (claude/gemini/
+        // codex never produce it) and separator-independent. A bare `.cursor`
+        // substring is NOT cursor-unique: a Claude transcript whose cwd-slug
+        // contains a checked-in `.cursor/` rules dir would misroute. Must
+        // precede the Claude `/projects/` catch (cursor paths contain it too).
         "cursor"
     } else if path.contains(".claude") || path.contains("/projects/") {
         "claude"
@@ -1366,6 +1371,22 @@ mod tests {
         assert_eq!(
             actual, expected,
             "transcript path detection cases must cover every released integration"
+        );
+    }
+
+    #[test]
+    fn detect_agent_type_cursor_keys_on_agent_transcripts_not_dotcursor() {
+        // Regression: a Claude transcript whose cwd-slug contains a checked-in
+        // `.cursor/` rules dir must NOT misroute to cursor (feeds resume tool
+        // detection → would break resume + pick the wrong parser).
+        assert_eq!(
+            detect_agent_type("/home/u/.claude/projects/-repo--cursor-rules/abcd.jsonl"),
+            "claude"
+        );
+        // A real cursor transcript (the `agent-transcripts` segment) detects cursor.
+        assert_eq!(
+            detect_agent_type("/home/u/.cursor/projects/repo/agent-transcripts/uuid/uuid.jsonl"),
+            "cursor"
         );
     }
 

--- a/src/commands/transcript.rs
+++ b/src/commands/transcript.rs
@@ -1331,7 +1331,7 @@ mod tests {
     }
 
     #[test]
-    fn detect_agent_type_covers_released_integration_specs() {
+    fn detect_agent_type_covers_released_integrations_with_transcript_parsers() {
         let cases = [
             ("/home/user/.claude/projects/x/transcript.jsonl", "claude"),
             ("/home/user/.gemini/tmp/session.json", "gemini"),
@@ -1345,6 +1345,8 @@ mod tests {
         let expected: std::collections::HashSet<&str> =
             crate::integration_spec::released_tool_names()
                 .into_iter()
+                // Cursor transcript parsing is a Phase 2 integration.
+                .filter(|tool| *tool != "cursor")
                 .collect();
         let actual: std::collections::HashSet<&str> = cases
             .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,7 @@ const TOML_KEY_MAP: &[(&str, &str)] = &[
     ("codex_sandbox_mode", "launch.codex.sandbox_mode"),
     ("codex_system_prompt", "launch.codex.system_prompt"),
     ("opencode_args", "launch.opencode.args"),
+    ("cursor_args", "launch.cursor.args"),
     ("relay", "relay.url"),
     ("relay_id", "relay.id"),
     ("relay_token", "relay.token"),
@@ -118,6 +119,7 @@ const FIELD_TO_ENV: &[(&str, &str)] = &[
     ("gemini_system_prompt", "HCOM_GEMINI_SYSTEM_PROMPT"),
     ("codex_system_prompt", "HCOM_CODEX_SYSTEM_PROMPT"),
     ("opencode_args", "HCOM_OPENCODE_ARGS"),
+    ("cursor_args", "HCOM_CURSOR_ARGS"),
     ("relay", "HCOM_RELAY"),
     ("relay_id", "HCOM_RELAY_ID"),
     ("relay_token", "HCOM_RELAY_TOKEN"),
@@ -223,6 +225,7 @@ pub struct HcomConfig {
     pub gemini_args: String,
     pub codex_args: String,
     pub opencode_args: String,
+    pub cursor_args: String,
     pub codex_sandbox_mode: String,
     pub gemini_system_prompt: String,
     pub codex_system_prompt: String,
@@ -249,6 +252,7 @@ impl Default for HcomConfig {
             gemini_args: String::new(),
             codex_args: String::new(),
             opencode_args: String::new(),
+            cursor_args: String::new(),
             codex_sandbox_mode: "workspace".to_string(),
             gemini_system_prompt: String::new(),
             codex_system_prompt: String::new(),
@@ -337,6 +341,7 @@ impl HcomConfig {
             ("gemini_args", &self.gemini_args),
             ("codex_args", &self.codex_args),
             ("opencode_args", &self.opencode_args),
+            ("cursor_args", &self.cursor_args),
         ] {
             if !value.is_empty()
                 && let Err(e) = shell_words::split(value)
@@ -395,6 +400,7 @@ impl HcomConfig {
             "gemini_args" => Some(self.gemini_args.clone()),
             "codex_args" => Some(self.codex_args.clone()),
             "opencode_args" => Some(self.opencode_args.clone()),
+            "cursor_args" => Some(self.cursor_args.clone()),
             "codex_sandbox_mode" => Some(self.codex_sandbox_mode.clone()),
             "gemini_system_prompt" => Some(self.gemini_system_prompt.clone()),
             "codex_system_prompt" => Some(self.codex_system_prompt.clone()),
@@ -431,6 +437,7 @@ impl HcomConfig {
             "gemini_args" => self.gemini_args = value.to_string(),
             "codex_args" => self.codex_args = value.to_string(),
             "opencode_args" => self.opencode_args = value.to_string(),
+            "cursor_args" => self.cursor_args = value.to_string(),
             "codex_sandbox_mode" => {
                 // Normalize legacy value
                 self.codex_sandbox_mode = if value == "full-auto" {
@@ -545,6 +552,7 @@ impl HcomConfig {
             "gemini_args",
             "codex_args",
             "opencode_args",
+            "cursor_args",
             "codex_sandbox_mode",
             "gemini_system_prompt",
             "codex_system_prompt",
@@ -890,6 +898,9 @@ sandbox_mode = "workspace"
 system_prompt = ""
 
 [launch.opencode]
+args = ""
+
+[launch.cursor]
 args = ""
 
 [preferences]

--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -531,6 +531,10 @@ impl ToolConfig {
     pub fn antigravity() -> Self {
         Self::for_tool(crate::tool::Tool::Antigravity)
     }
+    #[cfg(test)]
+    pub fn cursor() -> Self {
+        Self::for_tool(crate::tool::Tool::Cursor)
+    }
 }
 
 /// Gate evaluation result
@@ -1194,8 +1198,18 @@ pub fn run_delivery_loop(
                     // Capture wall clock before wait to detect system sleep
                     let wall_before = crate::shared::time::now_epoch_i64() as u64;
 
-                    // Wait for notification or timeout
-                    let notified = notify.wait(IDLE_WAIT);
+                    // Recheck launch readiness promptly while the TUI is still
+                    // painting its initial screen. Some tools can start the
+                    // delivery loop just before their input prompt appears.
+                    let idle_wait = if matches!(
+                        launch_outcome,
+                        LaunchOutcome::Pending | LaunchOutcome::Blocked
+                    ) {
+                        RETRY_DELAY
+                    } else {
+                        IDLE_WAIT
+                    };
+                    let notified = notify.wait(idle_wait);
 
                     if !running.load(Ordering::Acquire) {
                         log_info(
@@ -1335,7 +1349,9 @@ pub fn run_delivery_loop(
                         let cols = state.screen.read().map(|s| s.cols).unwrap_or(80);
                         let input_box_width = (cols as usize).saturating_sub(15).max(10);
                         let text = match parsed_tool {
-                            Some(Tool::Claude) | Some(Tool::Codex) => "<hcom>".to_string(),
+                            Some(Tool::Claude) | Some(Tool::Codex) | Some(Tool::Cursor) => {
+                                "<hcom>".to_string()
+                            }
                             _ => build_wake_inject_text(db, &current_name, input_box_width),
                         };
 
@@ -2101,6 +2117,7 @@ mod tests {
         assert!(launch_ready_observed(&ToolConfig::codex(), &state));
         assert!(launch_ready_observed(&ToolConfig::claude(), &state));
         assert!(!launch_ready_observed(&ToolConfig::opencode(), &state));
+        assert!(!launch_ready_observed(&ToolConfig::cursor(), &state));
 
         let state = make_state(screen.clone(), 500);
         assert!(!launch_ready_observed(&ToolConfig::gemini(), &state));
@@ -2108,10 +2125,12 @@ mod tests {
         screen.ready = true;
         let state = make_state(screen.clone(), 500);
         assert!(launch_ready_observed(&ToolConfig::opencode(), &state));
+        assert!(launch_ready_observed(&ToolConfig::cursor(), &state));
 
         screen.prompt_empty = false;
         let state = make_state(screen, 500);
         assert!(!launch_ready_observed(&ToolConfig::codex(), &state));
+        assert!(!launch_ready_observed(&ToolConfig::cursor(), &state));
     }
 
     #[test]

--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -626,6 +626,15 @@ pub struct ScreenState {
     /// race window where the gate sees
     /// `listening` + `prompt_empty`). See `SUBMIT_SETTLE_COOLDOWN_MS`.
     pub last_prompt_submit: Option<Instant>,
+    /// Latched cursor screen-scraped approval signal. Screen scraping reads a
+    /// partial frame mid-redraw as "no approval", which would flicker `approval`
+    /// false while the prompt is still up and let the gate fall through to
+    /// `prompt_has_text` (wrong "uncommitted text" status). Latch true on any
+    /// positive scrape and only clear once output has settled, so a transient
+    /// partial render can't drop the signal. Codex's OSC9 approval is event-based
+    /// (already stable) and antigravity keeps its immediate scrape; both bypass
+    /// this latch. See `APPROVAL_SCRAPE_CLEAR_MS`.
+    pub approval_scrape_latched: bool,
 }
 
 impl Default for ScreenState {
@@ -640,6 +649,7 @@ impl Default for ScreenState {
             last_output: Instant::now(),
             cols: 80,
             last_prompt_submit: None,
+            approval_scrape_latched: false,
         }
     }
 }
@@ -649,6 +659,28 @@ impl Default for ScreenState {
 /// hook's `status=active` update. Tuned from PTY test traces where the gap was
 /// about 1s; round up for headroom.
 pub(crate) const SUBMIT_SETTLE_COOLDOWN_MS: u64 = 1500;
+
+/// How long screen output must be quiet before a negative approval scrape is
+/// trusted to clear the latched signal. Redraw bursts (cursor's approval prompt
+/// animating its selection / spinner) emit partial frames that scrape as "no
+/// approval"; requiring a settled screen before clearing keeps the latch up
+/// through the burst so the gate reports `approval`, not `prompt_has_text`.
+pub(crate) const APPROVAL_SCRAPE_CLEAR_MS: u64 = 400;
+
+/// Latch decision for screen-scraped approval (cursor). A partial-render frame
+/// mid-redraw scrapes as "no approval"; holding the previous latch through such
+/// transient false reads keeps the gate reporting `approval` instead of falling
+/// through to `prompt_has_text`. The latch only clears once `output_settled`
+/// (no redraw churn) confirms the prompt has genuinely left the screen.
+pub(crate) fn latch_scraped_approval(prev: bool, scraped: bool, output_settled: bool) -> bool {
+    if scraped {
+        true
+    } else if output_settled {
+        false
+    } else {
+        prev
+    }
+}
 
 impl DeliveryState {
     /// Check if user is actively typing (within cooldown)
@@ -1970,6 +2002,7 @@ mod tests {
             last_output: Instant::now() - Duration::from_secs(10),
             cols: 80,
             last_prompt_submit: None,
+            approval_scrape_latched: false,
         }
     }
 
@@ -2155,6 +2188,24 @@ mod tests {
         // not idle + approval + not ready → not_idle wins
         let result = evaluate_gate(&config, &state, false);
         assert_eq!(result.reason, "not_idle");
+    }
+
+    // ---- Screen-scraped approval latch ----
+
+    #[test]
+    fn latch_holds_through_transient_false_scrape() {
+        // A positive scrape latches true regardless of prior state.
+        assert!(latch_scraped_approval(false, true, false));
+        assert!(latch_scraped_approval(false, true, true));
+        // Latched true survives a transient false scrape while output is still
+        // churning (a partial-render frame, not a real dismissal).
+        assert!(latch_scraped_approval(true, false, false));
+        // Once output settles and the scrape is still false, the prompt has
+        // genuinely left the screen -> clear.
+        assert!(!latch_scraped_approval(true, false, true));
+        // Never spuriously latches from a clean idle state.
+        assert!(!latch_scraped_approval(false, false, false));
+        assert!(!latch_scraped_approval(false, false, true));
     }
 
     // ---- Lookup functions ----

--- a/src/hooks/antigravity.rs
+++ b/src/hooks/antigravity.rs
@@ -68,9 +68,11 @@ pub enum SetupError {
 /// Resolve the path to the Antigravity `hooks.json` file.
 /// Under the split-config design, this resides at `~/.gemini/config/hooks.json`.
 pub fn get_antigravity_hooks_path() -> PathBuf {
-    crate::runtime_env::gemini_family_config_dir()
-        .join("config")
-        .join("hooks.json")
+    antigravity_hooks_path(&crate::runtime_env::gemini_family_config_dir())
+}
+
+fn antigravity_hooks_path(gemini_dir: &Path) -> PathBuf {
+    gemini_dir.join("config").join("hooks.json")
 }
 
 /// Shell wrapper for a single hcom hook subcommand (`gemini-beforeagent`, etc.).
@@ -256,19 +258,19 @@ pub fn verify_antigravity_hooks_installed(check_permissions: bool) -> bool {
 /// hooks.json is missing, unreadable, or invalid \u2014 so a partially broken
 /// install does not leave stale `command(hcom ...)` allow-rules behind.
 pub fn remove_antigravity_hooks() -> bool {
-    let hooks_ok = remove_hooks_lifecycle_block();
-    let perms_ok = remove_antigravity_permissions();
-    hooks_ok && perms_ok
+    antigravity_cleanup_dirs().iter().all(|dir| {
+        remove_hooks_lifecycle_block_at(&antigravity_hooks_path(dir))
+            && remove_antigravity_permissions_at(&antigravity_settings_path(dir))
+    })
 }
 
 /// Strip just the `"hcom-lifecycle"` block from hooks.json. Returns true on
 /// success, including the "file absent" case. Does not touch permissions.
-fn remove_hooks_lifecycle_block() -> bool {
-    let path = get_antigravity_hooks_path();
+fn remove_hooks_lifecycle_block_at(path: &Path) -> bool {
     if !path.exists() {
         return true;
     }
-    let content = match std::fs::read_to_string(&path) {
+    let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(_) => return false,
     };
@@ -282,13 +284,13 @@ fn remove_hooks_lifecycle_block() -> bool {
     };
     obj.remove("hcom-lifecycle");
     if obj.is_empty() {
-        return std::fs::remove_file(&path).is_ok();
+        return std::fs::remove_file(path).is_ok();
     }
     let json_str = match serde_json::to_string_pretty(&Value::Object(obj.clone())) {
         Ok(s) => s,
         Err(_) => return false,
     };
-    crate::paths::atomic_write_io(&path, &json_str).is_ok()
+    crate::paths::atomic_write_io(path, &json_str).is_ok()
 }
 
 fn verify_hooks_at(path: &Path, check_permissions: bool) -> Result<(), VerifyFailReason> {
@@ -626,9 +628,33 @@ fn verify_hooks_at(path: &Path, check_permissions: bool) -> Result<(), VerifyFai
 
 /// Path to the Antigravity CLI's settings.json (under `~/.gemini/antigravity-cli/`).
 fn get_antigravity_settings_path() -> PathBuf {
-    crate::runtime_env::gemini_family_config_dir()
-        .join("antigravity-cli")
-        .join("settings.json")
+    antigravity_settings_path(&crate::runtime_env::gemini_family_config_dir())
+}
+
+fn antigravity_settings_path(gemini_dir: &Path) -> PathBuf {
+    gemini_dir.join("antigravity-cli").join("settings.json")
+}
+
+fn antigravity_cleanup_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    let mut push_unique = |dir: PathBuf| {
+        if dir.is_absolute() && !dirs.contains(&dir) {
+            dirs.push(dir);
+        }
+    };
+    if let Some(home) = dirs::home_dir() {
+        push_unique(home.join(".gemini"));
+    }
+    if let Ok(dir) = std::env::var("GEMINI_CLI_HOME")
+        && !dir.is_empty()
+    {
+        // GEMINI_CLI_HOME is a raw prefix; gemini_family_config_dir() appends
+        // .gemini, so mirror that here.
+        let p = PathBuf::from(dir);
+        push_unique(p.join(".gemini"));
+    }
+    push_unique(crate::runtime_env::gemini_family_config_dir());
+    dirs
 }
 
 /// Build the list of `command(...)` rules for safe hcom commands.
@@ -698,11 +724,14 @@ fn setup_antigravity_permissions() -> bool {
 /// Remove hcom rules from agy settings.json. Cleans `permissions.allow` and
 /// `permissions` if they become empty. Leaves the file otherwise untouched.
 fn remove_antigravity_permissions() -> bool {
-    let path = get_antigravity_settings_path();
+    remove_antigravity_permissions_at(&get_antigravity_settings_path())
+}
+
+fn remove_antigravity_permissions_at(path: &Path) -> bool {
     if !path.exists() {
         return true;
     }
-    let content = match std::fs::read_to_string(&path) {
+    let content = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(_) => return false,
     };
@@ -745,7 +774,7 @@ fn remove_antigravity_permissions() -> bool {
         Ok(s) => s,
         Err(_) => return false,
     };
-    crate::paths::atomic_write(&path, &json_str)
+    crate::paths::atomic_write(path, &json_str)
 }
 
 /// Check that every hcom rule we install is present in agy settings.json.
@@ -1094,6 +1123,62 @@ mod tests {
         std::fs::write(&hooks_path, "{not json").unwrap();
 
         assert!(!remove_antigravity_hooks());
+    }
+
+    #[test]
+    #[serial]
+    fn test_remove_cleans_default_and_active_hcom_dir_local_paths() {
+        let _guard = EnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let workspace = dir.path().join("workspace");
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("HCOM_DIR", workspace.join(".hcom"));
+            std::env::remove_var("GEMINI_CLI_HOME");
+        }
+        let gemini_dirs = [home.join(".gemini"), workspace.join(".gemini")];
+        for gemini_dir in &gemini_dirs {
+            let hooks = antigravity_hooks_path(gemini_dir);
+            let settings = antigravity_settings_path(gemini_dir);
+            std::fs::create_dir_all(hooks.parent().unwrap()).unwrap();
+            std::fs::create_dir_all(settings.parent().unwrap()).unwrap();
+            std::fs::write(
+                &hooks,
+                serde_json::to_string_pretty(&json!({
+                    "hcom-lifecycle": {},
+                    "custom": true
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+            std::fs::write(
+                &settings,
+                serde_json::to_string_pretty(&json!({
+                    "permissions": {
+                        "allow": ["command(hcom send)", "custom"]
+                    }
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        }
+
+        assert!(remove_antigravity_hooks());
+
+        for gemini_dir in gemini_dirs {
+            let hooks: Value = serde_json::from_str(
+                &std::fs::read_to_string(antigravity_hooks_path(&gemini_dir)).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(hooks, json!({ "custom": true }));
+            let settings: Value = serde_json::from_str(
+                &std::fs::read_to_string(antigravity_settings_path(&gemini_dir)).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(settings["permissions"]["allow"], json!(["custom"]));
+        }
     }
 
     #[test]

--- a/src/hooks/claude.rs
+++ b/src/hooks/claude.rs
@@ -2336,7 +2336,7 @@ pub fn try_setup_claude_hooks(include_permissions: bool) -> Result<(), SetupErro
             .and_then(|v| v.as_object_mut())
         {
             if let Some(allow) = perms.get_mut("allow").and_then(|v| v.as_array_mut()) {
-                let hcom_perms = build_claude_permissions();
+                let hcom_perms = build_all_claude_permission_patterns();
                 allow.retain(|p| {
                     let s = p.as_str().unwrap_or("");
                     !hcom_perms.iter().any(|pat| pat == s)

--- a/src/hooks/claude_args.rs
+++ b/src/hooks/claude_args.rs
@@ -69,6 +69,7 @@ const OPTIONAL_VALUE_FLAGS: &[&str] = &[
     "--worktree",
     "--tmux",
     "--remote-control",
+    "--prompt-suggestions",
 ];
 
 /// Alias groups for optional value flags.

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -1999,7 +1999,7 @@ fn remove_codex_hooks_from_dir(base: &std::path::Path) -> bool {
 
 /// Remove hcom hooks from Codex config.
 ///
-/// Cleans both the default (~/.codex) and env-var (CODEX_HOME) paths.
+/// Cleans the default (~/.codex), env-var (CODEX_HOME), and active HCOM_DIR-local paths.
 pub fn remove_codex_hooks() -> bool {
     let default_dir = dirs::home_dir()
         .map(|h| h.join(".codex"))
@@ -2008,20 +2008,26 @@ pub fn remove_codex_hooks() -> bool {
         .ok()
         .filter(|d| !d.is_empty())
         .map(PathBuf::from);
+    let local_dir = codex_config_dir();
 
     let default_ok = remove_codex_hooks_from_dir(&default_dir);
     let env_ok = match env_dir {
         Some(ref d) if *d != default_dir => remove_codex_hooks_from_dir(d),
         _ => true,
     };
+    let local_ok = if local_dir != default_dir && Some(&local_dir) != env_dir.as_ref() {
+        remove_codex_hooks_from_dir(&local_dir)
+    } else {
+        true
+    };
 
-    default_ok && env_ok
+    default_ok && env_ok && local_ok
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hooks::test_helpers::isolated_test_env;
+    use crate::hooks::test_helpers::{EnvGuard, isolated_test_env};
     use serial_test::serial;
 
     #[test]
@@ -2792,5 +2798,35 @@ mod tests {
             content.contains("codex-userpromptsubmit"),
             "hcom hook must be present"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn remove_codex_hooks_cleans_active_hcom_dir_local_path() {
+        let _guard = EnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let workspace = dir.path().join("workspace");
+        let local_dir = workspace.join(".codex");
+        std::fs::create_dir_all(local_dir.join("rules")).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("HCOM_DIR", workspace.join(".hcom"));
+            std::env::remove_var("CODEX_HOME");
+        }
+        std::fs::write(
+            local_dir.join("hooks.json"),
+            serde_json::to_string_pretty(&build_expected_hook_json()).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(local_dir.join("rules/hcom.rules"), "allow").unwrap();
+
+        assert!(remove_codex_hooks());
+        assert!(!local_dir.join("rules/hcom.rules").exists());
+        if local_dir.join("hooks.json").exists() {
+            let content = std::fs::read_to_string(local_dir.join("hooks.json")).unwrap();
+            assert!(!content.contains("codex-"));
+        }
     }
 }

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -1,0 +1,695 @@
+//! Cursor Agent native hook handlers and hooks.json management.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde_json::{Value, json};
+
+use crate::db::{HcomDb, InstanceRow};
+use crate::hooks::{DeliveryAck, HookPayload, common};
+use crate::instance_binding;
+use crate::instance_lifecycle as lifecycle;
+use crate::instances;
+use crate::log;
+use crate::paths;
+use crate::shared::context::HcomContext;
+use crate::shared::{ST_ACTIVE, ST_LISTENING};
+
+const HCOM_TRIGGER: &str = "<hcom>";
+const HOOK_TIMEOUT_SECS: u64 = 15;
+const CURSOR_HOOK_COMMANDS: &[(&str, &str)] = &[
+    ("sessionStart", "cursor-sessionstart"),
+    ("beforeSubmitPrompt", "cursor-beforesubmitprompt"),
+    ("preToolUse", "cursor-pretooluse"),
+    ("postToolUse", "cursor-posttooluse"),
+    ("stop", "cursor-stop"),
+    ("sessionEnd", "cursor-sessionend"),
+];
+
+#[derive(Debug, thiserror::Error)]
+pub enum SetupError {
+    #[error("existing Cursor config at {} could not be read: {source}", path.display())]
+    ExistingReadFailed {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("existing Cursor config at {} is not valid JSON: {source}", path.display())]
+    ExistingParseFailed {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("existing Cursor config at {} must be a JSON object", path.display())]
+    ExistingRootNotObject { path: PathBuf },
+    #[error("failed to create Cursor config directory {}: {source}", path.display())]
+    DirCreateFailed {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("JSON serialization failed: {0}")]
+    SerializationFailed(#[from] serde_json::Error),
+    #[error("atomic write to {} failed: {source}", path.display())]
+    AtomicWriteFailed {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("post-write Cursor hook verification failed for {}", .0.display())]
+    PostWriteVerifyFailed(PathBuf),
+    #[error("Cursor permissions setup failed for {}", .0.display())]
+    PermissionsSetupFailed(PathBuf),
+}
+
+fn cursor_config_dir() -> PathBuf {
+    crate::runtime_env::tool_config_root().join(".cursor")
+}
+
+pub fn get_cursor_hooks_path() -> PathBuf {
+    cursor_config_dir().join("hooks.json")
+}
+
+pub fn get_cursor_permissions_path() -> PathBuf {
+    let root = crate::runtime_env::tool_config_root();
+    let filename = if dirs::home_dir().as_deref() == Some(root.as_path()) {
+        "cli-config.json"
+    } else {
+        "cli.json"
+    };
+    root.join(".cursor").join(filename)
+}
+
+fn build_cursor_hook_command(command: &str) -> String {
+    let mut parts = crate::runtime_env::get_hcom_prefix();
+    parts.push(command.to_string());
+    parts.join(" ")
+}
+
+fn is_hcom_cursor_command(command: &str) -> bool {
+    CURSOR_HOOK_COMMANDS
+        .iter()
+        .any(|(_, suffix)| command == build_cursor_hook_command(suffix))
+}
+
+fn expected_hook(event: &str, command: &str) -> Value {
+    let mut obj = serde_json::Map::from_iter([
+        (
+            "command".to_string(),
+            Value::String(build_cursor_hook_command(command)),
+        ),
+        ("timeout".to_string(), json!(HOOK_TIMEOUT_SECS)),
+    ]);
+    if event == "stop" {
+        obj.insert("loop_limit".to_string(), Value::Null);
+    }
+    Value::Object(obj)
+}
+
+fn merge_hcom_hooks(root: &mut Value) {
+    if !root.is_object() {
+        *root = json!({});
+    }
+    let obj = root.as_object_mut().unwrap();
+    obj.entry("version".to_string()).or_insert_with(|| json!(1));
+    let hooks = obj.entry("hooks".to_string()).or_insert_with(|| json!({}));
+    if !hooks.is_object() {
+        *hooks = json!({});
+    }
+    let hooks = hooks.as_object_mut().unwrap();
+
+    for (event, command) in CURSOR_HOOK_COMMANDS {
+        let entries = hooks
+            .entry((*event).to_string())
+            .or_insert_with(|| json!([]));
+        if !entries.is_array() {
+            *entries = json!([]);
+        }
+        let entries = entries.as_array_mut().unwrap();
+        entries.retain(|entry| {
+            !entry
+                .get("command")
+                .and_then(Value::as_str)
+                .is_some_and(is_hcom_cursor_command)
+        });
+        entries.push(expected_hook(event, command));
+    }
+}
+
+fn remove_hcom_hooks(root: &mut Value) {
+    let Some(hooks) = root.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return;
+    };
+    for entries in hooks.values_mut() {
+        let Some(entries) = entries.as_array_mut() else {
+            continue;
+        };
+        entries.retain(|entry| {
+            !entry
+                .get("command")
+                .and_then(Value::as_str)
+                .is_some_and(is_hcom_cursor_command)
+        });
+    }
+    hooks.retain(|_, entries| {
+        entries
+            .as_array()
+            .is_some_and(|entries| !entries.is_empty())
+    });
+}
+
+fn read_json_object(path: &Path) -> Result<serde_json::Map<String, Value>, SetupError> {
+    if !path.exists() {
+        return Ok(serde_json::Map::new());
+    }
+    let content =
+        std::fs::read_to_string(path).map_err(|source| SetupError::ExistingReadFailed {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let value = serde_json::from_str::<Value>(&content).map_err(|source| {
+        SetupError::ExistingParseFailed {
+            path: path.to_path_buf(),
+            source,
+        }
+    })?;
+    value
+        .as_object()
+        .cloned()
+        .ok_or_else(|| SetupError::ExistingRootNotObject {
+            path: path.to_path_buf(),
+        })
+}
+
+fn write_json(path: &Path, value: &Value) -> Result<(), SetupError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| SetupError::DirCreateFailed {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let content = serde_json::to_string_pretty(value)?;
+    paths::atomic_write_io(path, &content).map_err(|source| SetupError::AtomicWriteFailed {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn verify_hooks_at(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(root) = serde_json::from_str::<Value>(&content) else {
+        return false;
+    };
+    let Some(hooks) = root.get("hooks").and_then(Value::as_object) else {
+        return false;
+    };
+    CURSOR_HOOK_COMMANDS.iter().all(|(event, command)| {
+        hooks
+            .get(*event)
+            .and_then(Value::as_array)
+            .is_some_and(|entries| {
+                entries.iter().any(|entry| {
+                    entry.get("command").and_then(Value::as_str)
+                        == Some(build_cursor_hook_command(command).as_str())
+                        && entry.get("timeout").and_then(Value::as_u64).is_some()
+                        && (*event != "stop" || entry.get("loop_limit").is_some_and(Value::is_null))
+                })
+            })
+    })
+}
+
+fn cursor_permission_rule() -> String {
+    format!("Shell({})", crate::runtime_env::build_hcom_command())
+}
+
+fn update_cursor_permissions(add: bool) -> Result<(), SetupError> {
+    let path = get_cursor_permissions_path();
+    if !add && !path.exists() {
+        return Ok(());
+    }
+    let mut root = read_json_object(&path)?;
+    if !add {
+        if let Some(permissions) = root.get_mut("permissions").and_then(Value::as_object_mut)
+            && let Some(allow) = permissions.get_mut("allow").and_then(Value::as_array_mut)
+        {
+            let rule = cursor_permission_rule();
+            allow.retain(|entry| entry.as_str() != Some(rule.as_str()));
+            if allow.is_empty() {
+                permissions.remove("allow");
+            }
+        }
+        if root
+            .get("permissions")
+            .and_then(Value::as_object)
+            .is_some_and(|permissions| permissions.is_empty())
+        {
+            root.remove("permissions");
+        }
+        return write_json(&path, &Value::Object(root));
+    }
+    if path.file_name().and_then(|name| name.to_str()) == Some("cli-config.json") {
+        root.entry("version".to_string())
+            .or_insert_with(|| json!(1));
+        root.entry("editor".to_string())
+            .or_insert_with(|| json!({ "vimMode": false }));
+    }
+    let permissions = root
+        .entry("permissions".to_string())
+        .or_insert_with(|| json!({ "allow": [], "deny": [] }));
+    if !permissions.is_object() {
+        *permissions = json!({ "allow": [], "deny": [] });
+    }
+    let permissions = permissions.as_object_mut().unwrap();
+    let allow = permissions
+        .entry("allow".to_string())
+        .or_insert_with(|| json!([]));
+    if !allow.is_array() {
+        *allow = json!([]);
+    }
+    let allow = allow.as_array_mut().unwrap();
+    let rule = cursor_permission_rule();
+    allow.retain(|entry| entry.as_str() != Some(rule.as_str()));
+    allow.push(Value::String(rule));
+    permissions
+        .entry("deny".to_string())
+        .or_insert_with(|| json!([]));
+    write_json(&path, &Value::Object(root))
+}
+
+fn verify_cursor_permissions() -> bool {
+    let Ok(content) = std::fs::read_to_string(get_cursor_permissions_path()) else {
+        return false;
+    };
+    let Ok(root) = serde_json::from_str::<Value>(&content) else {
+        return false;
+    };
+    let rule = cursor_permission_rule();
+    root.pointer("/permissions/allow")
+        .and_then(Value::as_array)
+        .is_some_and(|allow| {
+            allow
+                .iter()
+                .any(|entry| entry.as_str() == Some(rule.as_str()))
+        })
+}
+
+pub fn try_setup_cursor_hooks(include_permissions: bool) -> Result<(), SetupError> {
+    let hooks_path = get_cursor_hooks_path();
+    let mut hooks = Value::Object(read_json_object(&hooks_path)?);
+    merge_hcom_hooks(&mut hooks);
+    write_json(&hooks_path, &hooks)?;
+    if !verify_hooks_at(&hooks_path) {
+        return Err(SetupError::PostWriteVerifyFailed(hooks_path));
+    }
+    if include_permissions {
+        update_cursor_permissions(true)?;
+        if !verify_cursor_permissions() {
+            return Err(SetupError::PermissionsSetupFailed(
+                get_cursor_permissions_path(),
+            ));
+        }
+    } else {
+        update_cursor_permissions(false)?;
+    }
+    Ok(())
+}
+
+pub fn verify_cursor_hooks_installed(check_permissions: bool) -> bool {
+    verify_hooks_at(&get_cursor_hooks_path()) && (!check_permissions || verify_cursor_permissions())
+}
+
+pub fn remove_cursor_hooks() -> bool {
+    let hooks_path = get_cursor_hooks_path();
+    let hooks_ok = if hooks_path.exists() {
+        match read_json_object(&hooks_path) {
+            Ok(root) => {
+                let mut value = Value::Object(root);
+                remove_hcom_hooks(&mut value);
+                write_json(&hooks_path, &value).is_ok()
+            }
+            Err(_) => false,
+        }
+    } else {
+        true
+    };
+    hooks_ok && update_cursor_permissions(false).is_ok()
+}
+
+fn resolve_instance(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> Option<InstanceRow> {
+    instance_binding::resolve_instance_from_binding(
+        db,
+        payload.session_id.as_deref(),
+        ctx.process_id.as_deref(),
+    )
+}
+
+fn update_position(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload, instance_name: &str) {
+    let mut updates = serde_json::Map::new();
+    if let Some(session_id) = payload.session_id.as_ref().filter(|s| !s.is_empty()) {
+        updates.insert("session_id".into(), Value::String(session_id.clone()));
+    }
+    if let Some(path) = payload.transcript_path.as_ref().filter(|s| !s.is_empty()) {
+        updates.insert("transcript_path".into(), Value::String(path.clone()));
+    }
+    let cwd = payload
+        .raw
+        .get("cwd")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            payload
+                .raw
+                .get("workspace_roots")
+                .and_then(Value::as_array)
+                .and_then(|roots| roots.first())
+                .and_then(Value::as_str)
+        })
+        .unwrap_or_else(|| ctx.cwd.to_str().unwrap_or(""));
+    if !cwd.is_empty() {
+        updates.insert("directory".into(), Value::String(cwd.to_string()));
+    }
+    instances::update_instance_position(db, instance_name, &updates);
+}
+
+fn cursor_session_env(ctx: &HcomContext) -> Value {
+    const KEYS: &[&str] = &[
+        "HCOM_PROCESS_ID",
+        "HCOM_INSTANCE_NAME",
+        "HCOM_TOOL",
+        "HCOM_DIR",
+        "HCOM_LAUNCHED",
+        "HCOM_PTY_MODE",
+        "HCOM_BACKGROUND",
+        "HCOM_LAUNCHED_BY",
+        "HCOM_LAUNCH_BATCH_ID",
+        "HCOM_LAUNCH_EVENT_ID",
+    ];
+    Value::Object(
+        KEYS.iter()
+            .filter_map(|key| {
+                ctx.raw_env
+                    .get(*key)
+                    .map(|value| ((*key).to_string(), Value::String(value.clone())))
+            })
+            .collect(),
+    )
+}
+
+fn handle_sessionstart(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> Value {
+    let Some(session_id) = payload.session_id.as_deref().filter(|sid| !sid.is_empty()) else {
+        return json!({ "env": cursor_session_env(ctx) });
+    };
+    let instance_name = ctx
+        .process_id
+        .as_deref()
+        .and_then(|pid| instance_binding::bind_session_to_process(db, session_id, Some(pid)))
+        .or_else(|| resolve_instance(db, ctx, payload).map(|instance| instance.name));
+    let Some(instance_name) = instance_name else {
+        return json!({ "env": cursor_session_env(ctx) });
+    };
+    let _ = db.rebind_instance_session(&instance_name, session_id);
+    instance_binding::capture_and_store_launch_context(db, &instance_name);
+    let Some(instance) = db.get_instance_full(&instance_name).ok().flatten() else {
+        return json!({ "env": cursor_session_env(ctx) });
+    };
+    update_position(db, ctx, payload, &instance_name);
+    lifecycle::set_status(
+        db,
+        &instance_name,
+        ST_LISTENING,
+        "start",
+        Default::default(),
+    );
+    crate::runtime_env::set_terminal_title(&instance_name);
+    crate::relay::worker::ensure_worker(true);
+    common::notify_hook_instance_with_db(db, &instance_name);
+    let mut output = serde_json::Map::from_iter([("env".into(), cursor_session_env(ctx))]);
+    if let Some(bootstrap) =
+        common::inject_bootstrap_once(db, ctx, &instance_name, &instance, "cursor")
+    {
+        output.insert("additional_context".into(), Value::String(bootstrap));
+    }
+    Value::Object(output)
+}
+
+fn resolved_instance(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> Option<InstanceRow> {
+    let instance = resolve_instance(db, ctx, payload)?;
+    update_position(db, ctx, payload, &instance.name);
+    Some(instance)
+}
+
+fn handle_beforesubmitprompt(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> Value {
+    if let Some(instance) = resolved_instance(db, ctx, payload) {
+        let prompt = payload
+            .raw
+            .get("prompt")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let context = if prompt.trim() == HCOM_TRIGGER {
+            "trigger"
+        } else {
+            "prompt"
+        };
+        lifecycle::set_status(db, &instance.name, ST_ACTIVE, context, Default::default());
+    }
+    json!({ "continue": true })
+}
+
+fn handle_pretooluse(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> Value {
+    if let Some(instance) = resolved_instance(db, ctx, payload) {
+        common::update_tool_status(
+            db,
+            &instance.name,
+            "cursor",
+            &payload.tool_name,
+            &payload.tool_input,
+        );
+    }
+    json!({})
+}
+
+fn handle_posttooluse(
+    db: &HcomDb,
+    ctx: &HcomContext,
+    payload: &HookPayload,
+) -> (Value, Option<DeliveryAck>) {
+    let Some(instance) = resolved_instance(db, ctx, payload) else {
+        return (json!({}), None);
+    };
+    match common::prepare_pending_messages(db, &instance.name) {
+        Some(prepared) => (
+            json!({ "additional_context": prepared.formatted }),
+            Some(prepared.ack),
+        ),
+        None => (json!({}), None),
+    }
+}
+
+fn handle_stop(
+    db: &HcomDb,
+    ctx: &HcomContext,
+    payload: &HookPayload,
+) -> (Value, Option<DeliveryAck>) {
+    let Some(instance) = resolved_instance(db, ctx, payload) else {
+        return (json!({}), None);
+    };
+    lifecycle::set_status(db, &instance.name, ST_LISTENING, "", Default::default());
+    common::notify_hook_instance_with_db(db, &instance.name);
+    if payload.raw.get("status").and_then(Value::as_str) != Some("completed") {
+        return (json!({}), None);
+    }
+    match common::prepare_pending_messages(db, &instance.name) {
+        Some(prepared) => (
+            json!({ "followup_message": prepared.formatted }),
+            Some(prepared.ack),
+        ),
+        None => (json!({}), None),
+    }
+}
+
+fn handle_sessionend(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> Value {
+    if let Some(instance) = resolved_instance(db, ctx, payload) {
+        let reason = payload
+            .raw
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        common::finalize_session(db, &instance.name, reason, None);
+    }
+    json!({})
+}
+
+/// Dispatch one Cursor JSON-on-stdin hook.
+pub fn dispatch_cursor_hook_native(hook_name: &str) -> i32 {
+    let raw: Value = match serde_json::from_reader(std::io::stdin().lock()) {
+        Ok(value) => value,
+        Err(err) => {
+            log::log_warn(
+                "hooks",
+                "cursor.parse_error",
+                &format!("hook={hook_name} err={err}"),
+            );
+            return 0;
+        }
+    };
+    let db = match HcomDb::open() {
+        Ok(db) => db,
+        Err(err) => {
+            log::log_warn(
+                "hooks",
+                "cursor.db_error",
+                &format!("hook={hook_name} err={err}"),
+            );
+            return 0;
+        }
+    };
+    let ctx = HcomContext::from_os();
+    if !common::hook_gate_check(&ctx, &db) {
+        return 0;
+    }
+    let payload = HookPayload::from_cursor_native(hook_name, raw);
+    let (output, delivery_ack) = common::dispatch_with_panic_guard(
+        "cursor",
+        hook_name,
+        (json!({}), None),
+        || match hook_name {
+            "cursor-sessionstart" => (handle_sessionstart(&db, &ctx, &payload), None),
+            "cursor-beforesubmitprompt" => (handle_beforesubmitprompt(&db, &ctx, &payload), None),
+            "cursor-pretooluse" => (handle_pretooluse(&db, &ctx, &payload), None),
+            "cursor-posttooluse" => handle_posttooluse(&db, &ctx, &payload),
+            "cursor-stop" => handle_stop(&db, &ctx, &payload),
+            "cursor-sessionend" => (handle_sessionend(&db, &ctx, &payload), None),
+            _ => (json!({}), None),
+        },
+    );
+    let mut stdout = std::io::stdout().lock();
+    if serde_json::to_writer(&mut stdout, &output).is_ok()
+        && stdout.flush().is_ok()
+        && let Some(ack) = delivery_ack.as_ref()
+    {
+        common::commit_delivery_ack(&db, ack);
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hooks::test_helpers::EnvGuard;
+    use serial_test::serial;
+
+    fn cursor_test_env() -> (tempfile::TempDir, PathBuf, EnvGuard) {
+        let guard = EnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().join("workspace");
+        let home = dir.path().join("home");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("HCOM_DIR", workspace.join(".hcom"));
+        }
+        (dir, workspace, guard)
+    }
+
+    #[test]
+    #[serial]
+    fn setup_is_idempotent_and_preserves_existing_hooks() {
+        let (_dir, workspace, _guard) = cursor_test_env();
+        let hooks_path = workspace.join(".cursor/hooks.json");
+        std::fs::create_dir_all(hooks_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &hooks_path,
+            serde_json::to_string_pretty(&json!({
+                "version": 1,
+                "hooks": {
+                    "sessionStart": [{ "command": "./custom-start.sh" }]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        try_setup_cursor_hooks(false).unwrap();
+        let first = std::fs::read_to_string(&hooks_path).unwrap();
+        try_setup_cursor_hooks(false).unwrap();
+        let second = std::fs::read_to_string(&hooks_path).unwrap();
+
+        assert_eq!(first, second);
+        assert!(verify_cursor_hooks_installed(false));
+        let root: Value = serde_json::from_str(&second).unwrap();
+        assert!(
+            root["hooks"]["sessionStart"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|hook| hook["command"] == "./custom-start.sh")
+        );
+        assert!(!workspace.join(".cursor/cli.json").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn permissions_are_project_local_and_cleanup_preserves_other_rules() {
+        let (_dir, workspace, _guard) = cursor_test_env();
+        let permissions_path = workspace.join(".cursor/cli.json");
+        std::fs::create_dir_all(permissions_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &permissions_path,
+            serde_json::to_string_pretty(&json!({
+                "permissions": {
+                    "allow": ["Shell(custom)"]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        try_setup_cursor_hooks(true).unwrap();
+        assert!(verify_cursor_hooks_installed(true));
+        try_setup_cursor_hooks(false).unwrap();
+
+        let root: Value =
+            serde_json::from_str(&std::fs::read_to_string(permissions_path).unwrap()).unwrap();
+        assert_eq!(root["permissions"]["allow"], json!(["Shell(custom)"]));
+        assert!(root.get("version").is_none());
+        assert!(root.get("editor").is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn remove_preserves_unrelated_hooks() {
+        let (_dir, workspace, _guard) = cursor_test_env();
+        let hooks_path = workspace.join(".cursor/hooks.json");
+        std::fs::create_dir_all(hooks_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &hooks_path,
+            serde_json::to_string_pretty(&json!({
+                "version": 1,
+                "hooks": {
+                    "sessionEnd": [{ "command": "./custom-end.sh" }]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        try_setup_cursor_hooks(false).unwrap();
+        assert!(remove_cursor_hooks());
+
+        let root: Value =
+            serde_json::from_str(&std::fs::read_to_string(hooks_path).unwrap()).unwrap();
+        assert_eq!(
+            root["hooks"]["sessionEnd"],
+            json!([{ "command": "./custom-end.sh" }])
+        );
+        assert!(
+            root["hooks"]
+                .as_object()
+                .unwrap()
+                .get("sessionStart")
+                .is_none()
+        );
+    }
+}

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -549,10 +549,14 @@ pub fn dispatch_cursor_hook_native(hook_name: &str) -> i32 {
         return 0;
     }
     let payload = HookPayload::from_cursor_native(hook_name, raw);
+    // Fail-open panic fallback: `continue: true` guarantees a handler panic never
+    // blocks the user's prompt on beforeSubmitPrompt. The extra key is ignored by
+    // every other cursor hook (sessionStart accepts it explicitly; stop/sessionEnd/
+    // postToolUse/pretooluse ignore unknown output fields), so one fallback is safe.
     let (output, delivery_ack) = common::dispatch_with_panic_guard(
         "cursor",
         hook_name,
-        (json!({}), None),
+        (json!({ "continue": true }), None),
         || match hook_name {
             "cursor-sessionstart" => (handle_sessionstart(&db, &ctx, &payload), None),
             "cursor-beforesubmitprompt" => (handle_beforesubmitprompt(&db, &ctx, &payload), None),

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -66,18 +66,36 @@ fn cursor_config_dir() -> PathBuf {
     crate::runtime_env::tool_config_root().join(".cursor")
 }
 
+fn default_cursor_config_dir() -> PathBuf {
+    dirs::home_dir().unwrap_or_default().join(".cursor")
+}
+
 pub fn get_cursor_hooks_path() -> PathBuf {
     cursor_config_dir().join("hooks.json")
 }
 
 pub fn get_cursor_permissions_path() -> PathBuf {
     let root = crate::runtime_env::tool_config_root();
-    let filename = if dirs::home_dir().as_deref() == Some(root.as_path()) {
-        "cli-config.json"
-    } else {
-        "cli.json"
-    };
-    root.join(".cursor").join(filename)
+    if dirs::home_dir().as_deref() != Some(root.as_path()) {
+        return root.join(".cursor").join("cli.json");
+    }
+    if let Ok(dir) = std::env::var("CURSOR_CONFIG_DIR")
+        && !dir.is_empty()
+    {
+        return PathBuf::from(dir).join("cli-config.json");
+    }
+    if cfg!(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    )) && let Ok(dir) = std::env::var("XDG_CONFIG_HOME")
+        && !dir.is_empty()
+    {
+        return PathBuf::from(dir).join("cursor").join("cli-config.json");
+    }
+    default_cursor_config_dir().join("cli-config.json")
 }
 
 fn build_cursor_hook_command(command: &str) -> String {
@@ -87,9 +105,11 @@ fn build_cursor_hook_command(command: &str) -> String {
 }
 
 fn is_hcom_cursor_command(command: &str) -> bool {
-    CURSOR_HOOK_COMMANDS
-        .iter()
-        .any(|(_, suffix)| command == build_cursor_hook_command(suffix))
+    ["hcom", "uvx hcom"].iter().any(|prefix| {
+        CURSOR_HOOK_COMMANDS
+            .iter()
+            .any(|(_, suffix)| command == format!("{prefix} {suffix}"))
+    })
 }
 
 fn expected_hook(event: &str, command: &str) -> Value {
@@ -220,26 +240,44 @@ fn verify_hooks_at(path: &Path) -> bool {
     })
 }
 
-fn cursor_permission_rule() -> String {
-    format!("Shell({})", crate::runtime_env::build_hcom_command())
+fn cursor_permission_rules() -> Vec<String> {
+    let prefix = crate::runtime_env::build_hcom_command();
+    common::SAFE_HCOM_COMMANDS
+        .iter()
+        .map(|command| format!("Shell({prefix} {command})"))
+        .collect()
 }
 
-fn update_cursor_permissions(add: bool) -> Result<(), SetupError> {
-    let path = get_cursor_permissions_path();
+fn all_cursor_permission_rules() -> Vec<String> {
+    let mut rules = Vec::new();
+    for prefix in ["hcom", "uvx hcom"] {
+        rules.push(format!("Shell({prefix})"));
+        for command in common::SAFE_HCOM_COMMANDS {
+            rules.push(format!("Shell({prefix} {command})"));
+        }
+    }
+    rules
+}
+
+fn update_cursor_permissions_at(path: &Path, add: bool) -> Result<(), SetupError> {
     if !add && !path.exists() {
         return Ok(());
     }
-    let mut root = read_json_object(&path)?;
-    if !add {
-        if let Some(permissions) = root.get_mut("permissions").and_then(Value::as_object_mut)
-            && let Some(allow) = permissions.get_mut("allow").and_then(Value::as_array_mut)
-        {
-            let rule = cursor_permission_rule();
-            allow.retain(|entry| entry.as_str() != Some(rule.as_str()));
-            if allow.is_empty() {
-                permissions.remove("allow");
-            }
+    let mut root = read_json_object(path)?;
+    if let Some(permissions) = root.get_mut("permissions").and_then(Value::as_object_mut)
+        && let Some(allow) = permissions.get_mut("allow").and_then(Value::as_array_mut)
+    {
+        let managed = all_cursor_permission_rules();
+        allow.retain(|entry| {
+            !entry
+                .as_str()
+                .is_some_and(|entry| managed.iter().any(|rule| rule == entry))
+        });
+        if allow.is_empty() {
+            permissions.remove("allow");
         }
+    }
+    if !add {
         if root
             .get("permissions")
             .and_then(Value::as_object)
@@ -247,7 +285,7 @@ fn update_cursor_permissions(add: bool) -> Result<(), SetupError> {
         {
             root.remove("permissions");
         }
-        return write_json(&path, &Value::Object(root));
+        return write_json(path, &Value::Object(root));
     }
     if path.file_name().and_then(|name| name.to_str()) == Some("cli-config.json") {
         root.entry("version".to_string())
@@ -269,13 +307,19 @@ fn update_cursor_permissions(add: bool) -> Result<(), SetupError> {
         *allow = json!([]);
     }
     let allow = allow.as_array_mut().unwrap();
-    let rule = cursor_permission_rule();
-    allow.retain(|entry| entry.as_str() != Some(rule.as_str()));
-    allow.push(Value::String(rule));
+    for rule in cursor_permission_rules() {
+        if !allow.iter().any(|entry| entry.as_str() == Some(&rule)) {
+            allow.push(Value::String(rule));
+        }
+    }
     permissions
         .entry("deny".to_string())
         .or_insert_with(|| json!([]));
-    write_json(&path, &Value::Object(root))
+    write_json(path, &Value::Object(root))
+}
+
+fn update_cursor_permissions(add: bool) -> Result<(), SetupError> {
+    update_cursor_permissions_at(&get_cursor_permissions_path(), add)
 }
 
 fn verify_cursor_permissions() -> bool {
@@ -285,14 +329,95 @@ fn verify_cursor_permissions() -> bool {
     let Ok(root) = serde_json::from_str::<Value>(&content) else {
         return false;
     };
-    let rule = cursor_permission_rule();
+    let expected = cursor_permission_rules();
+    let managed = all_cursor_permission_rules();
     root.pointer("/permissions/allow")
         .and_then(Value::as_array)
         .is_some_and(|allow| {
-            allow
+            expected
                 .iter()
-                .any(|entry| entry.as_str() == Some(rule.as_str()))
+                .all(|rule| allow.iter().any(|entry| entry.as_str() == Some(rule)))
+                && allow.iter().all(|entry| {
+                    entry.as_str().is_none_or(|entry| {
+                        !managed.iter().any(|rule| rule == entry)
+                            || expected.iter().any(|rule| rule == entry)
+                    })
+                })
         })
+}
+
+fn remove_cursor_hooks_at(path: &Path) -> bool {
+    if !path.exists() {
+        return true;
+    }
+    match read_json_object(path) {
+        Ok(root) => {
+            let mut value = Value::Object(root);
+            remove_hcom_hooks(&mut value);
+            write_json(path, &value).is_ok()
+        }
+        Err(_) => false,
+    }
+}
+
+fn push_unique(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if path.is_absolute() && !paths.contains(&path) {
+        paths.push(path);
+    }
+}
+
+fn cursor_hooks_cleanup_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        push_unique(&mut paths, home.join(".cursor").join("hooks.json"));
+    }
+    push_unique(&mut paths, get_cursor_hooks_path());
+    paths
+}
+
+fn cursor_permissions_cleanup_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        push_unique(
+            &mut paths,
+            home.join(".cursor").join("cli-config.json"),
+        );
+    }
+    let root = crate::runtime_env::tool_config_root();
+    if dirs::home_dir().as_deref() != Some(root.as_path()) {
+        push_unique(&mut paths, root.join(".cursor").join("cli.json"));
+    }
+    if let Ok(dir) = std::env::var("CURSOR_CONFIG_DIR")
+        && !dir.is_empty()
+    {
+        push_unique(&mut paths, PathBuf::from(dir).join("cli-config.json"));
+    }
+    if cfg!(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    )) && let Ok(dir) = std::env::var("XDG_CONFIG_HOME")
+        && !dir.is_empty()
+    {
+        push_unique(
+            &mut paths,
+            PathBuf::from(dir).join("cursor").join("cli-config.json"),
+        );
+    }
+    push_unique(&mut paths, get_cursor_permissions_path());
+    paths
+}
+
+pub fn remove_cursor_hooks() -> bool {
+    let hooks_ok = cursor_hooks_cleanup_paths()
+        .iter()
+        .all(|path| remove_cursor_hooks_at(path));
+    let permissions_ok = cursor_permissions_cleanup_paths()
+        .iter()
+        .all(|path| update_cursor_permissions_at(path, false).is_ok());
+    hooks_ok && permissions_ok
 }
 
 pub fn try_setup_cursor_hooks(include_permissions: bool) -> Result<(), SetupError> {
@@ -318,23 +443,6 @@ pub fn try_setup_cursor_hooks(include_permissions: bool) -> Result<(), SetupErro
 
 pub fn verify_cursor_hooks_installed(check_permissions: bool) -> bool {
     verify_hooks_at(&get_cursor_hooks_path()) && (!check_permissions || verify_cursor_permissions())
-}
-
-pub fn remove_cursor_hooks() -> bool {
-    let hooks_path = get_cursor_hooks_path();
-    let hooks_ok = if hooks_path.exists() {
-        match read_json_object(&hooks_path) {
-            Ok(root) => {
-                let mut value = Value::Object(root);
-                remove_hcom_hooks(&mut value);
-                write_json(&hooks_path, &value).is_ok()
-            }
-            Err(_) => false,
-        }
-    } else {
-        true
-    };
-    hooks_ok && update_cursor_permissions(false).is_ok()
 }
 
 fn resolve_instance(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> Option<InstanceRow> {
@@ -593,6 +701,8 @@ mod tests {
         unsafe {
             std::env::set_var("HOME", &home);
             std::env::set_var("HCOM_DIR", workspace.join(".hcom"));
+            std::env::remove_var("CURSOR_CONFIG_DIR");
+            std::env::remove_var("XDG_CONFIG_HOME");
         }
         (dir, workspace, guard)
     }
@@ -663,6 +773,144 @@ mod tests {
 
     #[test]
     #[serial]
+    fn setup_replaces_legacy_prefixes_with_scoped_permissions() {
+        let (_dir, workspace, _guard) = cursor_test_env();
+        let permissions_path = workspace.join(".cursor/cli.json");
+        std::fs::create_dir_all(permissions_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &permissions_path,
+            serde_json::to_string_pretty(&json!({
+                "permissions": {
+                    "allow": [
+                        "Shell(custom)",
+                        "Shell(hcom)",
+                        "Shell(uvx hcom)",
+                        "Shell(uvx hcom send)"
+                    ]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        try_setup_cursor_hooks(true).unwrap();
+
+        let root: Value =
+            serde_json::from_str(&std::fs::read_to_string(permissions_path).unwrap()).unwrap();
+        let allow = root["permissions"]["allow"].as_array().unwrap();
+        assert!(allow.iter().any(|rule| rule == "Shell(custom)"));
+        assert!(!allow.iter().any(|rule| rule == "Shell(hcom)"));
+        assert!(!allow.iter().any(|rule| rule == "Shell(uvx hcom)"));
+        for rule in cursor_permission_rules() {
+            assert!(allow.iter().any(|entry| entry == &rule), "missing {rule}");
+        }
+        assert!(!allow.iter().any(|rule| rule == "Shell(hcom kill)"));
+        assert!(!allow.iter().any(|rule| rule == "Shell(hcom reset)"));
+    }
+
+    #[test]
+    #[serial]
+    fn setup_removes_stale_hook_prefixes() {
+        let (_dir, workspace, _guard) = cursor_test_env();
+        let hooks_path = workspace.join(".cursor/hooks.json");
+        std::fs::create_dir_all(hooks_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &hooks_path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "stop": [
+                        { "command": "hcom cursor-stop" },
+                        { "command": "uvx hcom cursor-stop" },
+                        { "command": "./custom-stop.sh" }
+                    ]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        try_setup_cursor_hooks(false).unwrap();
+
+        let root: Value =
+            serde_json::from_str(&std::fs::read_to_string(hooks_path).unwrap()).unwrap();
+        let stop = root["hooks"]["stop"].as_array().unwrap();
+        assert_eq!(
+            stop.iter()
+                .filter(|hook| hook["command"] == build_cursor_hook_command("cursor-stop"))
+                .count(),
+            1
+        );
+        assert!(
+            stop.iter()
+                .any(|hook| hook["command"] == "./custom-stop.sh")
+        );
+        assert_eq!(
+            stop.iter()
+                .filter(|hook| hook["command"].as_str().is_some_and(is_hcom_cursor_command))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn normal_mode_permissions_honor_cursor_config_dir() {
+        let (dir, _workspace, _guard) = cursor_test_env();
+        let home = dir.path().join("home");
+        let override_dir = dir.path().join("cursor-override");
+        unsafe {
+            std::env::set_var("HCOM_DIR", home.join(".hcom"));
+            std::env::set_var("CURSOR_CONFIG_DIR", &override_dir);
+        }
+
+        assert_eq!(
+            get_cursor_permissions_path(),
+            override_dir.join("cli-config.json")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn isolated_mode_permissions_ignore_global_override() {
+        let (dir, workspace, _guard) = cursor_test_env();
+        unsafe {
+            std::env::set_var("CURSOR_CONFIG_DIR", dir.path().join("cursor-override"));
+        }
+
+        assert_eq!(
+            get_cursor_permissions_path(),
+            workspace.join(".cursor/cli.json")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn normal_mode_permissions_honor_xdg_on_supported_platforms() {
+        if !cfg!(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "dragonfly"
+        )) {
+            return;
+        }
+        let (dir, _workspace, _guard) = cursor_test_env();
+        let home = dir.path().join("home");
+        let xdg = dir.path().join("xdg");
+        unsafe {
+            std::env::set_var("HCOM_DIR", home.join(".hcom"));
+            std::env::set_var("XDG_CONFIG_HOME", &xdg);
+        }
+
+        assert_eq!(
+            get_cursor_permissions_path(),
+            xdg.join("cursor/cli-config.json")
+        );
+    }
+
+    #[test]
+    #[serial]
     fn remove_preserves_unrelated_hooks() {
         let (_dir, workspace, _guard) = cursor_test_env();
         let hooks_path = workspace.join(".cursor/hooks.json");
@@ -695,5 +943,65 @@ mod tests {
                 .get("sessionStart")
                 .is_none()
         );
+    }
+
+    #[test]
+    #[serial]
+    fn remove_cleans_default_and_isolated_paths() {
+        let (dir, workspace, _guard) = cursor_test_env();
+        let home = dir.path().join("home");
+        let hooks_paths = [
+            home.join(".cursor/hooks.json"),
+            workspace.join(".cursor/hooks.json"),
+        ];
+        let permissions_paths = [
+            home.join(".cursor/cli-config.json"),
+            workspace.join(".cursor/cli.json"),
+        ];
+        for path in &hooks_paths {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(
+                path,
+                serde_json::to_string_pretty(&json!({
+                    "hooks": {
+                        "stop": [
+                            { "command": "hcom cursor-stop" },
+                            { "command": "./custom-stop.sh" }
+                        ]
+                    }
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        }
+        for path in &permissions_paths {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(
+                path,
+                serde_json::to_string_pretty(&json!({
+                    "permissions": {
+                        "allow": ["Shell(hcom)", "Shell(custom)"]
+                    }
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+        }
+
+        assert!(remove_cursor_hooks());
+
+        for path in hooks_paths {
+            let root: Value =
+                serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+            assert_eq!(
+                root["hooks"]["stop"],
+                json!([{ "command": "./custom-stop.sh" }])
+            );
+        }
+        for path in permissions_paths {
+            let root: Value =
+                serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+            assert_eq!(root["permissions"]["allow"], json!(["Shell(custom)"]));
+        }
     }
 }

--- a/src/hooks/family.rs
+++ b/src/hooks/family.rs
@@ -29,7 +29,8 @@ pub fn extract_tool_detail(tool: &str, tool_name: &str, tool_input: &serde_json:
     if detail.file.contains(&tool_name) {
         return tool_input
             .get("file_path")
-            .or_else(|| tool_input.get("TargetFile"))
+            .or_else(|| tool_input.get("TargetFile")) // antigravity
+            .or_else(|| tool_input.get("path")) // cursor (Write/StrReplace)
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
@@ -204,6 +205,44 @@ mod tests {
             extract_tool_detail("gemini", "delegate_to_agent", &input2),
             "do something"
         );
+    }
+
+    #[test]
+    fn test_extract_tool_detail_cursor() {
+        // Shell command (and the run_terminal_cmd variant) → command field.
+        let shell = serde_json::json!({"command": "cargo build", "description": "build"});
+        assert_eq!(
+            extract_tool_detail("cursor", "Shell", &shell),
+            "cargo build"
+        );
+        assert_eq!(
+            extract_tool_detail("cursor", "run_terminal_cmd", &shell),
+            "cargo build"
+        );
+        // Edit (StrReplace) and Write → `path` field (cursor uses `path`, not file_path).
+        let edit =
+            serde_json::json!({"path": "/src/main.rs", "old_string": "a", "new_string": "b"});
+        assert_eq!(
+            extract_tool_detail("cursor", "StrReplace", &edit),
+            "/src/main.rs"
+        );
+        let write = serde_json::json!({"path": "/src/lib.rs", "contents": "x"});
+        assert_eq!(
+            extract_tool_detail("cursor", "Write", &write),
+            "/src/lib.rs"
+        );
+        // Delegate (Task/Subagent) → prompt field.
+        let task = serde_json::json!({"prompt": "explore the codebase", "subagent_type": "x"});
+        assert_eq!(
+            extract_tool_detail("cursor", "Task", &task),
+            "explore the codebase"
+        );
+        assert_eq!(
+            extract_tool_detail("cursor", "Subagent", &task),
+            "explore the codebase"
+        );
+        // `Edit` is a Claude tool name, never emitted by cursor → no detail.
+        assert_eq!(extract_tool_detail("cursor", "Edit", &edit), "");
     }
 
     #[test]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -6,6 +6,7 @@ pub mod claude_args;
 pub mod codex;
 pub mod codex_file_edits;
 pub mod common;
+pub mod cursor;
 pub mod family;
 pub mod gemini;
 pub mod opencode;
@@ -291,6 +292,29 @@ impl HookPayload {
             tool_name: Self::str_field(&raw, &["tool_name"]),
             tool_input: Self::obj_field(&raw, &["tool_input"]),
             tool_result: match raw.get("tool_response") {
+                Some(Value::String(s)) => s.clone(),
+                Some(v) => v.to_string(),
+                None => String::new(),
+            },
+            notification_type: None,
+            raw,
+        }
+    }
+
+    /// Build from native Cursor Agent hook JSON.
+    ///
+    /// Cursor hooks use snake_case and include a common conversation ID on
+    /// every agent hook. `sessionStart` also includes the same value as
+    /// `session_id`.
+    pub fn from_cursor_native(hook_type: &str, raw: Value) -> Self {
+        Self {
+            session_id: Self::opt_str_field(&raw, &["session_id", "conversation_id"]),
+            transcript_path: Self::opt_str_field(&raw, &["transcript_path"]),
+            hook_name: hook_type.to_string(),
+            tool: "cursor".to_string(),
+            tool_name: Self::str_field(&raw, &["tool_name"]),
+            tool_input: Self::obj_field(&raw, &["tool_input"]),
+            tool_result: match raw.get("tool_output") {
                 Some(Value::String(s)) => s.clone(),
                 Some(v) => v.to_string(),
                 None => String::new(),

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -38,6 +38,10 @@ pub mod test_helpers {
     pub struct EnvGuard {
         saved_hcom: Option<String>,
         saved_home: Option<String>,
+        saved_cursor_config_dir: Option<String>,
+        saved_xdg_config_home: Option<String>,
+        saved_codex_home: Option<String>,
+        saved_gemini_cli_home: Option<String>,
         saved_test_codex_cli_version: Option<String>,
         // Declared last so it drops AFTER Drop::drop restores env vars,
         // releasing the lock only once this test's env state is gone.
@@ -56,6 +60,10 @@ pub mod test_helpers {
             Self {
                 saved_hcom: std::env::var("HCOM_DIR").ok(),
                 saved_home: std::env::var("HOME").ok(),
+                saved_cursor_config_dir: std::env::var("CURSOR_CONFIG_DIR").ok(),
+                saved_xdg_config_home: std::env::var("XDG_CONFIG_HOME").ok(),
+                saved_codex_home: std::env::var("CODEX_HOME").ok(),
+                saved_gemini_cli_home: std::env::var("GEMINI_CLI_HOME").ok(),
                 saved_test_codex_cli_version: std::env::var("HCOM_TEST_CODEX_CLI_VERSION").ok(),
                 _lock: lock,
             }
@@ -72,6 +80,22 @@ pub mod test_helpers {
                 match &self.saved_home {
                     Some(v) => std::env::set_var("HOME", v),
                     None => std::env::remove_var("HOME"),
+                }
+                match &self.saved_cursor_config_dir {
+                    Some(v) => std::env::set_var("CURSOR_CONFIG_DIR", v),
+                    None => std::env::remove_var("CURSOR_CONFIG_DIR"),
+                }
+                match &self.saved_xdg_config_home {
+                    Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+                match &self.saved_codex_home {
+                    Some(v) => std::env::set_var("CODEX_HOME", v),
+                    None => std::env::remove_var("CODEX_HOME"),
+                }
+                match &self.saved_gemini_cli_home {
+                    Some(v) => std::env::set_var("GEMINI_CLI_HOME", v),
+                    None => std::env::remove_var("GEMINI_CLI_HOME"),
                 }
                 match &self.saved_test_codex_cli_version {
                     Some(v) => std::env::set_var("HCOM_TEST_CODEX_CLI_VERSION", v),

--- a/src/instance_binding.rs
+++ b/src/instance_binding.rs
@@ -809,7 +809,7 @@ pub fn resolve_instance_from_binding(
 fn auto_subscribe_defaults(db: &HcomDb, instance_name: &str, tool: &str) {
     if !matches!(
         tool,
-        "claude" | "gemini" | "codex" | "opencode" | "antigravity"
+        "claude" | "gemini" | "codex" | "opencode" | "antigravity" | "cursor"
     ) {
         return;
     }

--- a/src/integration_spec.rs
+++ b/src/integration_spec.rs
@@ -221,6 +221,15 @@ const OPENCODE_HOOKS: &[&str] = &[
     "opencode-stop",
 ];
 
+const CURSOR_HOOKS: &[&str] = &[
+    "cursor-sessionstart",
+    "cursor-beforesubmitprompt",
+    "cursor-pretooluse",
+    "cursor-posttooluse",
+    "cursor-stop",
+    "cursor-sessionend",
+];
+
 // ── Help examples / extra-env tables ────────────────────────────────────
 
 const CLAUDE_HELP_EXAMPLES: &[HelpEntry] = &[
@@ -275,6 +284,14 @@ const AGY_HELP_EXAMPLES: &[HelpEntry] = &[
     ("hcom antigravity", "Long-form alias"),
     ("hcom agy --sandbox", "Flags forwarded to agy"),
     ("hcom r <name>", "Resume a stopped agy session"),
+];
+
+const CURSOR_HELP_EXAMPLES: &[HelpEntry] = &[
+    ("hcom cursor --model sonnet-4", "Use a specific model"),
+    (
+        "hcom cursor --force",
+        "Allow commands unless explicitly denied",
+    ),
 ];
 
 // ── Per-tool integration constants ──────────────────────────────────────
@@ -527,6 +544,54 @@ pub static ANTIGRAVITY: IntegrationSpec = IntegrationSpec {
     },
 };
 
+pub static CURSOR: IntegrationSpec = IntegrationSpec {
+    tool: Tool::Cursor,
+    name: "cursor",
+    label: "Cursor",
+    aliases: &["cursor-agent"],
+    cli_binary: "cursor-agent",
+    tui_prefix: "cur ",
+    adhoc_icon: None,
+    released: true,
+    // Cursor's input placeholder is styled rather than a stable ASCII footer.
+    // Prompt-empty detection is the readiness signal for the MVP.
+    ready_pattern: b"",
+    hooks: HooksSpec {
+        names: CURSOR_HOOKS,
+        shared_hooks_with: None,
+        invocation: HookInvocation::JsonStdin,
+    },
+    gates: GatesSpec {
+        require_idle: true,
+        require_ready_prompt: false,
+        require_prompt_empty: true,
+        block_on_user_activity: true,
+        block_on_approval: true,
+        launch_requires_ready: true,
+    },
+    launch: LaunchSpec {
+        args_env: Some("HCOM_CURSOR_ARGS"),
+        config_dir_env: None,
+        initial_prompt: InitialPromptShape::Positional,
+        uses_pty_default: true,
+        max_launch_count: 10,
+        background: BackgroundMode::HeadlessPty,
+    },
+    resume: Some(ResumeSpec {
+        resume: ResumeArgs::Flag("--resume"),
+        fork: None,
+    }),
+    help: HelpSpec {
+        unique_examples: CURSOR_HELP_EXAMPLES,
+        extra_env: &[],
+    },
+    status_detail: StatusDetailSpec {
+        bash: &["Shell"],
+        file: &["Write", "Edit"],
+        delegate: &["Task"],
+    },
+};
+
 pub static ADHOC: IntegrationSpec = IntegrationSpec {
     tool: Tool::Adhoc,
     name: "adhoc",
@@ -574,7 +639,15 @@ pub static ADHOC: IntegrationSpec = IntegrationSpec {
 
 /// All specs in canonical order. `Tool::spec` indexes into this implicitly via
 /// match — exposed for iteration (released-list helpers, hook-name routing).
-pub static ALL: &[&IntegrationSpec] = &[&CLAUDE, &GEMINI, &CODEX, &OPENCODE, &ANTIGRAVITY, &ADHOC];
+pub static ALL: &[&IntegrationSpec] = &[
+    &CLAUDE,
+    &GEMINI,
+    &CODEX,
+    &OPENCODE,
+    &ANTIGRAVITY,
+    &CURSOR,
+    &ADHOC,
+];
 
 impl Tool {
     /// Return this tool's integration spec.
@@ -585,6 +658,7 @@ impl Tool {
             Tool::Codex => &CODEX,
             Tool::OpenCode => &OPENCODE,
             Tool::Antigravity => &ANTIGRAVITY,
+            Tool::Cursor => &CURSOR,
             Tool::Adhoc => &ADHOC,
         }
     }
@@ -620,6 +694,7 @@ mod tests {
             Tool::Codex,
             Tool::OpenCode,
             Tool::Antigravity,
+            Tool::Cursor,
             Tool::Adhoc,
         ] {
             let spec = tool.spec();
@@ -674,7 +749,8 @@ mod tests {
         assert!(names.contains(&"codex"));
         assert!(names.contains(&"opencode"));
         assert!(names.contains(&"antigravity"));
-        assert_eq!(names.len(), 5);
+        assert!(names.contains(&"cursor"));
+        assert_eq!(names.len(), 6);
     }
 
     #[test]

--- a/src/integration_spec.rs
+++ b/src/integration_spec.rs
@@ -579,6 +579,10 @@ pub static CURSOR: IntegrationSpec = IntegrationSpec {
     },
     resume: Some(ResumeSpec {
         resume: ResumeArgs::Flag("--resume"),
+        // O2: cursor-agent has no native fork/branch primitive (only `--resume`
+        // / `--continue` / `create-chat`). Leave `fork: None` like gemini/agy;
+        // simulating fork via resume+create-chat is deferred (not needed for
+        // parity).
         fork: None,
     }),
     help: HelpSpec {

--- a/src/integration_spec.rs
+++ b/src/integration_spec.rs
@@ -585,10 +585,14 @@ pub static CURSOR: IntegrationSpec = IntegrationSpec {
         unique_examples: CURSOR_HELP_EXAMPLES,
         extra_env: &[],
     },
+    // Empirically verified against real cursor transcripts: cursor's edit tool
+    // is `StrReplace` (not `Edit`, which never appears) and its file/edit tools
+    // key the path off `path` (not `file_path` — see extract_tool_detail). Shell
+    // also has the `run_terminal_cmd` variant; delegates are `Task`/`Subagent`.
     status_detail: StatusDetailSpec {
-        bash: &["Shell"],
-        file: &["Write", "Edit"],
-        delegate: &["Task"],
+        bash: &["Shell", "run_terminal_cmd"],
+        file: &["Write", "StrReplace"],
+        delegate: &["Task", "Subagent"],
     },
 };
 

--- a/src/integration_spec.rs
+++ b/src/integration_spec.rs
@@ -287,9 +287,9 @@ const AGY_HELP_EXAMPLES: &[HelpEntry] = &[
 ];
 
 const CURSOR_HELP_EXAMPLES: &[HelpEntry] = &[
-    ("hcom cursor --model sonnet-4", "Use a specific model"),
+    ("hcom cursor-agent --model sonnet-4", "Use a specific model"),
     (
-        "hcom cursor --force",
+        "hcom cursor-agent --force",
         "Allow commands unless explicitly denied",
     ),
 ];

--- a/src/integration_spec.rs
+++ b/src/integration_spec.rs
@@ -571,7 +571,7 @@ pub static CURSOR: IntegrationSpec = IntegrationSpec {
     },
     launch: LaunchSpec {
         args_env: Some("HCOM_CURSOR_ARGS"),
-        config_dir_env: None,
+        config_dir_env: Some("CURSOR_CONFIG_DIR"),
         initial_prompt: InitialPromptShape::Positional,
         uses_pty_default: true,
         max_launch_count: 10,

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -21,7 +21,7 @@ use crate::instances;
 use crate::paths;
 use crate::shared::constants::{HCOM_IDENTITY_VARS, TOOL_MARKER_VARS};
 use crate::terminal;
-use crate::tools::{codex_preprocessing, opencode_preprocessing};
+use crate::tools::{codex_preprocessing, cursor_preprocessing, opencode_preprocessing};
 
 /// Canonical tool types for launch.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,6 +32,7 @@ pub enum LaunchTool {
     Codex,
     OpenCode,
     Antigravity,
+    Cursor,
 }
 
 impl LaunchTool {
@@ -44,6 +45,7 @@ impl LaunchTool {
             "codex" => Ok(LaunchTool::Codex),
             "opencode" => Ok(LaunchTool::OpenCode),
             "antigravity" | "agy" => Ok(LaunchTool::Antigravity),
+            "cursor" | "cursor-agent" => Ok(LaunchTool::Cursor),
             _ => bail!("Unknown tool: {}", s),
         }
     }
@@ -56,6 +58,7 @@ impl LaunchTool {
             LaunchTool::Codex => "codex",
             LaunchTool::OpenCode => "opencode",
             LaunchTool::Antigravity => "antigravity",
+            LaunchTool::Cursor => "cursor",
         }
     }
 
@@ -70,6 +73,7 @@ impl LaunchTool {
             LaunchTool::Codex => crate::tool::Tool::Codex,
             LaunchTool::OpenCode => crate::tool::Tool::OpenCode,
             LaunchTool::Antigravity => crate::tool::Tool::Antigravity,
+            LaunchTool::Cursor => crate::tool::Tool::Cursor,
         }
     }
 
@@ -132,7 +136,8 @@ impl LaunchBackend {
             LaunchTool::Gemini
             | LaunchTool::Codex
             | LaunchTool::OpenCode
-            | LaunchTool::Antigravity => LaunchBackend::HeadlessPty,
+            | LaunchTool::Antigravity
+            | LaunchTool::Cursor => LaunchBackend::HeadlessPty,
         }
     }
 }
@@ -436,6 +441,23 @@ fn ensure_hooks_installed(tool: &LaunchTool) -> Result<()> {
                 bail!(
                     "Failed to setup Antigravity hooks: {e}\n\
                      Run: hcom hooks add antigravity\n\
+                     {diag}"
+                );
+            }
+            Ok(())
+        }
+        LaunchTool::Cursor => {
+            if crate::hooks::cursor::verify_cursor_hooks_installed(include_permissions) {
+                return Ok(());
+            }
+            if let Err(e) = crate::hooks::cursor::try_setup_cursor_hooks(include_permissions) {
+                let diag = install_diag_context(
+                    tool,
+                    &[("hooks_path", crate::hooks::cursor::get_cursor_hooks_path())],
+                );
+                bail!(
+                    "Failed to setup Cursor hooks: {e}\n\
+                     Run: hcom hooks add cursor\n\
                      {diag}"
                 );
             }
@@ -936,6 +958,9 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
     }
 
     let working_dir = params.cwd.as_deref().unwrap_or(".");
+    if matches!(normalized, LaunchTool::Cursor) {
+        cursor_preprocessing::ensure_cursor_workspace_trusted(Path::new(working_dir))?;
+    }
     let launcher_name: String = params.launcher.take().unwrap_or_else(|| {
         // Try to resolve caller identity from the live process binding.
         let process_id = std::env::var("HCOM_PROCESS_ID").ok();
@@ -1408,6 +1433,33 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
                         inside_ai_tool,
                     )
                 }
+                LaunchTool::Cursor => {
+                    instances::update_instance_position(
+                        db,
+                        &instance_name,
+                        &serde_json::Map::from_iter([(
+                            "launch_args".to_string(),
+                            json!(params.args),
+                        )]),
+                    );
+                    launch_pty_or_background(
+                        &mut BackgroundLaunchCtx {
+                            db,
+                            tool: "cursor",
+                            instance_name: &instance_name,
+                            process_id: &process_id,
+                            terminal_mode,
+                            tag: params.tag.as_deref().unwrap_or(""),
+                            working_dir,
+                            log_files: &mut log_files,
+                            handles: &mut handles,
+                        },
+                        &mut instance_env,
+                        &params.args,
+                        &params,
+                        inside_ai_tool,
+                    )
+                }
             }
         })();
 
@@ -1507,7 +1559,7 @@ fn validate_tool_args(tool: &LaunchTool, args: &[String]) -> Vec<String> {
             errs.extend(crate::tools::codex_args::validate_conflicts(&spec));
             errs
         }
-        LaunchTool::OpenCode | LaunchTool::Antigravity => Vec::new(),
+        LaunchTool::OpenCode | LaunchTool::Antigravity | LaunchTool::Cursor => Vec::new(),
     }
 }
 

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -330,8 +330,7 @@ fn install_diag_context(tool: &LaunchTool, paths: &[(&str, std::path::PathBuf)])
 ///
 /// Uses verify-first pattern: read-only check first, only write if needed.
 /// Strict gate: refuses to launch if hooks can't be installed.
-fn ensure_hooks_installed(tool: &LaunchTool) -> Result<()> {
-    let include_permissions = true;
+fn ensure_hooks_installed(tool: &LaunchTool, include_permissions: bool) -> Result<()> {
     match tool {
         LaunchTool::Claude | LaunchTool::ClaudePty => {
             if crate::hooks::claude::verify_claude_hooks_installed(None, include_permissions) {
@@ -890,6 +889,27 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
         );
     }
 
+    let tool_binary = normalized.cli_binary();
+    if !is_tool_installed(tool_binary) {
+        bail!("'{}' is not installed or not in PATH", tool_binary);
+    }
+
+    if !params.skip_validation {
+        let validation_errors = validate_tool_args(&normalized, &params.args);
+        if !validation_errors.is_empty() {
+            bail!("{}", validation_errors.join("\n"));
+        }
+    }
+
+    // Load config before hook setup so auto_approve is authoritative for
+    // wrapped launches as well as manual `hcom hooks add`.
+    let hcom_config = HcomConfig::load(None).unwrap_or_else(|e| {
+        eprintln!("[hcom] warn: config load failed, using defaults: {e}");
+        let mut c = HcomConfig::default();
+        c.normalize();
+        c
+    });
+
     // For Codex: probe CODEX_HOME writability synchronously. Sandboxed parent
     // codex would otherwise spawn a child that hangs on the readonly-state-DB
     // repair prompt. Failing here lets the parent's sandbox-escalation flow
@@ -899,15 +919,7 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
     }
 
     // Ensure hooks are installed (strict: refuse to launch without hooks)
-    ensure_hooks_installed(&normalized)?;
-
-    // Load config
-    let hcom_config = HcomConfig::load(None).unwrap_or_else(|e| {
-        eprintln!("[hcom] warn: config load failed, using defaults: {e}");
-        let mut c = HcomConfig::default();
-        c.normalize();
-        c
-    });
+    ensure_hooks_installed(&normalized, hcom_config.auto_approve)?;
 
     // Build base environment
     let mut base_env = build_launch_env(&hcom_config);
@@ -939,14 +951,6 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
             );
         }
         resolve_explicit_name_conflict(db, name)?;
-    }
-
-    // Tool args validation
-    if !params.skip_validation {
-        let validation_errors = validate_tool_args(&normalized, &params.args);
-        if !validation_errors.is_empty() {
-            bail!("{}", validation_errors.join("\n"));
-        }
     }
 
     // System prompt file for Gemini/Codex
@@ -1125,16 +1129,6 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
             Ok(())
         })() {
             errors.push(json!({"tool": normalized.as_str(), "error": e.to_string()}));
-            continue;
-        }
-
-        // Check tool binary exists before launching
-        let tool_binary = normalized.cli_binary();
-        if !is_tool_installed(tool_binary) {
-            eprintln!("Error: '{}' is not installed or not in PATH", tool_binary);
-            errors.push(
-                json!({"tool": normalized.as_str(), "error": format!("{} not found", tool_binary)}),
-            );
             continue;
         }
 
@@ -1373,6 +1367,7 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
                     opencode_preprocessing::preprocess_opencode_env(
                         &mut instance_env,
                         &instance_name,
+                        hcom_config.auto_approve,
                     );
 
                     instances::update_instance_position(
@@ -1559,7 +1554,8 @@ fn validate_tool_args(tool: &LaunchTool, args: &[String]) -> Vec<String> {
             errs.extend(crate::tools::codex_args::validate_conflicts(&spec));
             errs
         }
-        LaunchTool::OpenCode | LaunchTool::Antigravity | LaunchTool::Cursor => Vec::new(),
+        LaunchTool::Cursor => crate::tools::cursor_preprocessing::validate_cursor_args(args),
+        LaunchTool::OpenCode | LaunchTool::Antigravity => Vec::new(),
     }
 }
 
@@ -1604,6 +1600,13 @@ mod tests {
             LaunchTool::Antigravity
         );
         assert!(LaunchTool::from_str("unknown", false).is_err());
+    }
+
+    #[test]
+    fn validate_cursor_print_mode_fails_fast() {
+        let errors = validate_tool_args(&LaunchTool::Cursor, &["--print".to_string()]);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("not supported"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ pub fn run_pty(args: &[String]) -> Result<()> {
         eprintln!();
         eprintln!("Usage: hcom pty <tool> [args...]");
         eprintln!();
-        eprintln!("Tools: claude, gemini, codex, opencode, antigravity (agy)");
+        eprintln!("Tools: claude, gemini, codex, opencode, antigravity (agy), cursor");
         eprintln!();
         eprintln!("The PTY wrapper provides:");
         eprintln!("  - Text injection via TCP port (INJECT_PORT)");

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -732,7 +732,7 @@ impl Proxy {
         use std::str::FromStr;
 
         let delivery_start_timeout = match Tool::from_str(&self.config.tool) {
-            Ok(Tool::Claude) | Ok(Tool::Codex) | Ok(Tool::Antigravity) => {
+            Ok(Tool::Claude) | Ok(Tool::Codex) | Ok(Tool::Antigravity) | Ok(Tool::Cursor) => {
                 Duration::from_secs(5) // ? for shortcuts footer (Claude/Codex/agy)
             }
             Ok(Tool::OpenCode) => Duration::from_secs(5), // Empty ready_pattern fires immediately; 5s fallback

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -1282,7 +1282,8 @@ impl Proxy {
             state.ready = self.screen.is_ready();
             state.approval = self.screen.is_waiting_approval()
                 || (self.config.tool == "antigravity"
-                    && self.screen.is_antigravity_approval_visible());
+                    && self.screen.is_antigravity_approval_visible())
+                || (self.config.tool == "cursor" && self.screen.is_cursor_approval_visible());
             let input_text = self.screen.get_input_box_text(&self.config.tool);
             let new_prompt_empty = input_text.as_ref().is_some_and(|t| t.is_empty());
             // Stamp submit-edge cooldown when input transitions from a known

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -1017,11 +1017,24 @@ impl Proxy {
                         }
                         Ok(n) => {
                             self.last_user_input = Instant::now();
-                            self.screen.clear_approval();
+                            // Genuine keystrokes answering an OSC9-latched approval
+                            // (codex) clear it. Cursor's approval is screen-scraped
+                            // and authoritative-by-prompt: terminal chatter on stdin
+                            // (focus events, kitty-keyboard / cursor-position reports
+                            // — cursor enables `CSI > 1 u`) is NOT a user response and
+                            // must not force-clear it, or the status flickers off
+                            // "blocked: approval pending". The update_delivery_state
+                            // latch clears once the prompt actually leaves the screen.
+                            let cursor_scrape = self.config.tool == "cursor";
+                            if !cursor_scrape {
+                                self.screen.clear_approval();
+                            }
                             // Update delivery state for user activity
                             if let Ok(mut state) = self.delivery_state.write() {
                                 state.last_user_input = Instant::now();
-                                state.approval = false;
+                                if !cursor_scrape {
+                                    state.approval = false;
+                                }
                             }
                             write_all(&self.pty_master, &buf[..n])?;
                         }
@@ -1280,10 +1293,23 @@ impl Proxy {
     fn update_delivery_state(&self) {
         if let Ok(mut state) = self.delivery_state.write() {
             state.ready = self.screen.is_ready();
+            // Cursor's screen-scraped approval flickers false on partial-render
+            // frames mid-redraw. Latch it true and only clear once output settles,
+            // so a transient bad frame can't drop the signal and let the gate fall
+            // through to `prompt_has_text` ("uncommitted text"). Codex (OSC9) and
+            // antigravity keep their existing immediate signals below.
+            let cursor_approval =
+                self.config.tool == "cursor" && self.screen.is_cursor_approval_visible();
+            state.approval_scrape_latched = crate::delivery::latch_scraped_approval(
+                state.approval_scrape_latched,
+                cursor_approval,
+                self.screen
+                    .is_output_stable(crate::delivery::APPROVAL_SCRAPE_CLEAR_MS),
+            );
             state.approval = self.screen.is_waiting_approval()
                 || (self.config.tool == "antigravity"
                     && self.screen.is_antigravity_approval_visible())
-                || (self.config.tool == "cursor" && self.screen.is_cursor_approval_visible());
+                || state.approval_scrape_latched;
             let input_text = self.screen.get_input_box_text(&self.config.tool);
             let new_prompt_empty = input_text.as_ref().is_some_and(|t| t.is_empty());
             // Stamp submit-edge cooldown when input transitions from a known

--- a/src/pty/screen.rs
+++ b/src/pty/screen.rs
@@ -370,6 +370,7 @@ impl ScreenTracker {
             Ok(Tool::Codex) => self.get_codex_input_text(),
             Ok(Tool::OpenCode) => None, // OpenCode: plugin handles delivery, no PTY input detection needed
             Ok(Tool::Antigravity) => self.get_antigravity_input_text(),
+            Ok(Tool::Cursor) => self.get_cursor_input_text(),
             Ok(Tool::Adhoc) => None,
             Err(_) => None,
         }
@@ -634,6 +635,29 @@ impl ScreenTracker {
         None
     }
 
+    /// Extract Cursor Agent input text.
+    ///
+    /// Cursor renders a `→` prompt with dim placeholder text while idle.
+    /// Submitted or user-entered text uses normal intensity.
+    fn get_cursor_input_text(&self) -> Option<String> {
+        let lines = self.get_screen_lines();
+        for (row_idx, line) in lines.iter().enumerate().rev() {
+            let trimmed = line.trim_start();
+            if let Some(text) = trimmed.strip_prefix("→ ") {
+                let text = trim_with_nbsp(text);
+                if text.is_empty() {
+                    return Some(String::new());
+                }
+                return match self.is_dim_after_prompt(row_idx as u16, "→") {
+                    Some(true) => Some(String::new()),
+                    Some(false) => Some(text.to_string()),
+                    None => Some(text.to_string()),
+                };
+            }
+        }
+        None
+    }
+
     /// Check and perform periodic dump if 5 seconds elapsed
     /// Returns true if dump was performed
     pub fn check_periodic_dump(&mut self, tool: &str, inject_port: u16, label: &str) -> bool {
@@ -695,6 +719,7 @@ impl ScreenTracker {
                     Ok(Tool::Codex) => Some("›"),
                     Ok(Tool::Gemini) => Some(">"),
                     Ok(Tool::Antigravity) => Some(">"),
+                    Ok(Tool::Cursor) => Some("→"),
                     _ => None,
                 };
                 if let Some(pc) = prompt_char {
@@ -958,6 +983,27 @@ mod tests {
             t.get_codex_input_text(),
             Some("<hcom>test message</hcom>".to_string())
         );
+    }
+
+    // ---- Cursor input extraction ----
+
+    #[test]
+    fn cursor_extracts_non_dim_text_after_prompt() {
+        let mut t = make_tracker(24, 80, "");
+        t.process("→ <hcom>\r\n".as_bytes());
+        assert_eq!(t.get_cursor_input_text(), Some("<hcom>".to_string()));
+    }
+
+    #[test]
+    fn cursor_dim_placeholder_returns_empty() {
+        let mut t = make_tracker(24, 80, "");
+        let mut data = Vec::new();
+        data.extend_from_slice("→ ".as_bytes());
+        data.extend_from_slice(b"\x1b[2mPlan, search, build anything\x1b[0m");
+        data.extend_from_slice(b"\r\n");
+        t.process(&data);
+        assert_eq!(t.get_cursor_input_text(), Some(String::new()));
+        assert!(t.is_prompt_empty("cursor"));
     }
 
     // ---- Gemini input extraction ----

--- a/src/pty/screen.rs
+++ b/src/pty/screen.rs
@@ -265,6 +265,28 @@ impl ScreenTracker {
         has_marker && (has_question || has_footer)
     }
 
+    /// Cursor-specific approval detection: cursor renders a shell-command
+    /// permission prompt as plain text ("Run this command?" + a "Run (once) /
+    /// Add … to allowlist / Auto-run everything / Skip (esc or n)" menu). No
+    /// OSC9 fires, so scrape the screen. Require the question marker AND a menu
+    /// footer option so a stray "Run this command?" in scrollback can't flip it.
+    /// (File edits auto-apply by default and don't prompt — verified live.)
+    pub fn is_cursor_approval_visible(&self) -> bool {
+        let screen = self.parser.screen();
+        let (_rows, cols) = screen.size();
+        let mut has_question = false;
+        let mut has_footer = false;
+        for line in screen.rows(0, cols) {
+            if line.contains("Run this command?") {
+                has_question = true;
+            }
+            if line.contains("Auto-run everything") || line.contains("Skip (esc") {
+                has_footer = true;
+            }
+        }
+        has_question && has_footer
+    }
+
     /// Check if output has been stable for N milliseconds
     /// Note: ms=0 returns true (always stable), which is valid for tools that skip stability check
     pub fn is_output_stable(&self, ms: u64) -> bool {
@@ -930,6 +952,35 @@ mod tests {
             b"Requesting permission for: rm -rf /tmp/x\r\n  1. Yes\r\n  2. No\r\n  tab Amend . e edit command\r\n",
         );
         assert!(t.is_antigravity_approval_visible());
+    }
+
+    // ---- Cursor approval detection ----
+
+    #[test]
+    fn cursor_detects_approval_prompt() {
+        let mut t = make_tracker(24, 80, "");
+        assert!(!t.is_cursor_approval_visible());
+        // Real cursor shell-approval menu (captured live).
+        t.process(
+            b"Run this command?\r\nNot in allowlist: uptime\r\n  Run (once) (y)\r\n  Auto-run everything (shift+tab)\r\n  Skip (esc or n)\r\n",
+        );
+        assert!(t.is_cursor_approval_visible());
+    }
+
+    #[test]
+    fn cursor_question_alone_does_not_trigger() {
+        // The question text in narration/scrollback without the menu footer
+        // must not flip approval on.
+        let mut t = make_tracker(24, 80, "");
+        t.process(b"I'll ask: Run this command? then proceed.\r\n> idle\r\n");
+        assert!(!t.is_cursor_approval_visible());
+    }
+
+    #[test]
+    fn cursor_no_false_positive_without_question() {
+        let mut t = make_tracker(24, 80, "");
+        t.process(b"> hello world\r\nrunning a build\r\n");
+        assert!(!t.is_cursor_approval_visible());
     }
 
     // ---- Codex input extraction ----

--- a/src/pty/screen.rs
+++ b/src/pty/screen.rs
@@ -786,38 +786,6 @@ impl ScreenTracker {
             }
         }
 
-        // Cursor approval predicate breakdown (temporary diagnostic for the
-        // approval-status false-negative). Shows which sub-condition fails on
-        // the LIVE delivery parser, plus the raw rows that did/didn't match.
-        {
-            use crate::tool::Tool;
-            use std::str::FromStr;
-            if matches!(Tool::from_str(tool), Ok(Tool::Cursor)) {
-                let mut has_question = false;
-                let mut has_footer = false;
-                let mut q_rows: Vec<String> = Vec::new();
-                let mut f_rows: Vec<String> = Vec::new();
-                for line in screen.rows(0, cols) {
-                    if line.contains("Run this command?") {
-                        has_question = true;
-                        q_rows.push(line.clone());
-                    }
-                    if line.contains("Auto-run everything") || line.contains("Skip (esc") {
-                        has_footer = true;
-                        f_rows.push(line.clone());
-                    }
-                }
-                output.push_str(&format!(
-                    "[cursor-approval] is_visible={} has_question={} has_footer={}\n",
-                    has_question && has_footer,
-                    has_question,
-                    has_footer
-                ));
-                output.push_str(&format!("[cursor-approval]   q_rows={:?}\n", q_rows));
-                output.push_str(&format!("[cursor-approval]   f_rows={:?}\n", f_rows));
-            }
-        }
-
         // Status checks
         output.push_str(&format!("is_ready(): {}\n", self.is_ready()));
         output.push_str(&format!(

--- a/src/pty/screen.rs
+++ b/src/pty/screen.rs
@@ -786,6 +786,38 @@ impl ScreenTracker {
             }
         }
 
+        // Cursor approval predicate breakdown (temporary diagnostic for the
+        // approval-status false-negative). Shows which sub-condition fails on
+        // the LIVE delivery parser, plus the raw rows that did/didn't match.
+        {
+            use crate::tool::Tool;
+            use std::str::FromStr;
+            if matches!(Tool::from_str(tool), Ok(Tool::Cursor)) {
+                let mut has_question = false;
+                let mut has_footer = false;
+                let mut q_rows: Vec<String> = Vec::new();
+                let mut f_rows: Vec<String> = Vec::new();
+                for line in screen.rows(0, cols) {
+                    if line.contains("Run this command?") {
+                        has_question = true;
+                        q_rows.push(line.clone());
+                    }
+                    if line.contains("Auto-run everything") || line.contains("Skip (esc") {
+                        has_footer = true;
+                        f_rows.push(line.clone());
+                    }
+                }
+                output.push_str(&format!(
+                    "[cursor-approval] is_visible={} has_question={} has_footer={}\n",
+                    has_question && has_footer,
+                    has_question,
+                    has_footer
+                ));
+                output.push_str(&format!("[cursor-approval]   q_rows={:?}\n", q_rows));
+                output.push_str(&format!("[cursor-approval]   f_rows={:?}\n", f_rows));
+            }
+        }
+
         // Status checks
         output.push_str(&format!("is_ready(): {}\n", self.is_ready()));
         output.push_str(&format!(

--- a/src/router.rs
+++ b/src/router.rs
@@ -50,6 +50,8 @@ const LAUNCH_TOOLS: &[&str] = &[
     "opencode",
     "antigravity",
     "agy",
+    "cursor",
+    "cursor-agent",
     "f",
     "r",
 ];
@@ -103,6 +105,10 @@ fn dispatch_hook_for_tool(tool: Tool, hook: &str, args: &[String]) -> (i32, Stri
         Tool::OpenCode => crate::hooks::opencode::dispatch_opencode_hook(hook, args),
         Tool::Antigravity => (
             crate::hooks::gemini::dispatch_gemini_hook(hook),
+            String::new(),
+        ),
+        Tool::Cursor => (
+            crate::hooks::cursor::dispatch_cursor_hook_native(hook),
             String::new(),
         ),
         Tool::Adhoc => unreachable!("adhoc has no hooks"),

--- a/src/shared/constants.rs
+++ b/src/shared/constants.rs
@@ -62,6 +62,8 @@ pub const TOOL_MARKER_VARS: &[&str] = &[
     "CODEX_MANAGED_BY_BUN",
     "CODEX_THREAD_ID",
     "OPENCODE",
+    "CURSOR_AGENT",
+    "CURSOR_PROJECT_DIR",
 ];
 
 /// HCOM identity vars — set per-instance, cleared to prevent parent identity leakage.

--- a/src/shared/context.rs
+++ b/src/shared/context.rs
@@ -49,6 +49,7 @@ pub struct HcomContext {
     pub is_gemini: bool,
     pub is_codex: bool,
     pub is_opencode: bool,
+    pub is_cursor: bool,
     /// HCOM_IS_FORK=1 (--fork-session launch).
     pub is_fork: bool,
     /// Codex thread ID (session equivalent).
@@ -99,6 +100,7 @@ impl HcomContext {
             || is_set("CODEX_MANAGED_BY_BUN")
             || is_set("CODEX_THREAD_ID");
         let is_opencode = is_eq("OPENCODE", "1");
+        let is_cursor = is_set("CURSOR_AGENT") || is_set("CURSOR_PROJECT_DIR");
 
         // Determine tool type
         let tool = if is_claude {
@@ -111,6 +113,8 @@ impl HcomContext {
             Tool::Codex
         } else if is_opencode {
             Tool::OpenCode
+        } else if is_cursor {
+            Tool::Cursor
         } else {
             Tool::Adhoc
         };
@@ -134,6 +138,7 @@ impl HcomContext {
             is_gemini,
             is_codex,
             is_opencode,
+            is_cursor,
             is_fork: is_eq("HCOM_IS_FORK", "1"),
             codex_thread_id: get_nonempty("CODEX_THREAD_ID"),
             launched_by: get_nonempty("HCOM_LAUNCHED_BY"),
@@ -192,6 +197,7 @@ impl HcomContext {
             || self.is_gemini
             || self.is_codex
             || self.is_opencode
+            || self.is_cursor
     }
 
     /// Detect current tool name, or "adhoc".

--- a/src/shared/platform.rs
+++ b/src/shared/platform.rs
@@ -126,6 +126,9 @@ pub fn is_inside_ai_tool() -> bool {
         || is_set("CODEX_THREAD_ID")
         // OpenCode
         || is_eq("OPENCODE", "1")
+        // Cursor Agent
+        || is_set("CURSOR_AGENT")
+        || is_set("CURSOR_PROJECT_DIR")
         // hcom-launched
         || is_eq("HCOM_LAUNCHED", "1")
 }
@@ -153,6 +156,8 @@ pub fn detect_current_tool_from_env() -> &'static str {
         "codex"
     } else if is_eq("OPENCODE", "1") {
         "opencode"
+    } else if is_set("CURSOR_AGENT") || is_set("CURSOR_PROJECT_DIR") {
+        "cursor"
     } else {
         "adhoc"
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -405,6 +405,7 @@ pub fn which_bin(name: &str) -> Option<String> {
                 home.join(".claude").join("bin").join("claude"),
             ],
             "opencode" => &[home.join(".opencode").join("bin").join("opencode")],
+            "cursor-agent" => &[home.join(".local").join("bin").join("cursor-agent")],
             _ => &[],
         };
         for fallback in fallbacks {
@@ -624,6 +625,8 @@ pub fn create_bash_script(
         let cmd_lower = command_str.to_lowercase();
         if cmd_lower.contains("opencode") {
             "OpenCode"
+        } else if cmd_lower.contains("cursor-agent") {
+            "Cursor Agent"
         } else if cmd_lower.contains("gemini") {
             "Gemini"
         } else if cmd_lower.contains("codex") {

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -16,6 +16,7 @@ pub enum Tool {
     Codex,
     OpenCode,
     Antigravity,
+    Cursor,
     Adhoc,
 }
 
@@ -89,6 +90,9 @@ impl Tool {
             Tool::Antigravity => {
                 crate::hooks::antigravity::verify_antigravity_hooks_installed(include_permissions)
             }
+            Tool::Cursor => {
+                crate::hooks::cursor::verify_cursor_hooks_installed(include_permissions)
+            }
             Tool::Adhoc => false,
         }
     }
@@ -112,6 +116,8 @@ impl Tool {
                 crate::hooks::antigravity::try_setup_antigravity_hooks(include_permissions)
                     .map_err(|e| e.to_string())
             }
+            Tool::Cursor => crate::hooks::cursor::try_setup_cursor_hooks(include_permissions)
+                .map_err(|e| e.to_string()),
             Tool::Adhoc => Err("Adhoc has no hooks to install".to_string()),
         }
     }
@@ -128,6 +134,7 @@ impl Tool {
                 .map(|_| true)
                 .map_err(|e| e.to_string()),
             Tool::Antigravity => Ok(crate::hooks::antigravity::remove_antigravity_hooks()),
+            Tool::Cursor => Ok(crate::hooks::cursor::remove_cursor_hooks()),
             Tool::Adhoc => Ok(false),
         }
     }
@@ -141,6 +148,7 @@ impl Tool {
             Tool::Codex => crate::hooks::codex::get_codex_config_path(),
             Tool::OpenCode => crate::hooks::opencode::get_opencode_plugin_path(),
             Tool::Antigravity => crate::hooks::antigravity::get_antigravity_hooks_path(),
+            Tool::Cursor => crate::hooks::cursor::get_cursor_hooks_path(),
             Tool::Adhoc => return String::new(),
         };
         path_buf.to_string_lossy().to_string()
@@ -189,7 +197,13 @@ mod tests {
         // Antigravity shares Gemini hooks, but every gemini-* name resolves to
         // Gemini because Antigravity declares Gemini as the hook owner.
         let mut owners = HashMap::new();
-        for tool in [Tool::Claude, Tool::Gemini, Tool::Codex, Tool::OpenCode] {
+        for tool in [
+            Tool::Claude,
+            Tool::Gemini,
+            Tool::Codex,
+            Tool::OpenCode,
+            Tool::Cursor,
+        ] {
             for hook in tool.hooks() {
                 assert_eq!(
                     owners.insert(*hook, tool),

--- a/src/tools/cursor_preprocessing.rs
+++ b/src/tools/cursor_preprocessing.rs
@@ -1,0 +1,85 @@
+//! Cursor launch preprocessing: workspace trust markers.
+
+use std::path::{Path, PathBuf};
+
+/// Cursor stores per-workspace state under `~/.cursor/projects/<slug>`.
+///
+/// This mirrors Cursor's path slugging: path separators and punctuation become
+/// dashes while ASCII letters, digits, underscores, and existing dashes survive.
+pub(crate) fn cursor_project_slug(workspace: &Path) -> String {
+    workspace
+        .to_string_lossy()
+        .split(std::path::MAIN_SEPARATOR)
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            part.chars()
+                .map(|ch| {
+                    if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+                        ch
+                    } else {
+                        '-'
+                    }
+                })
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn cursor_projects_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".cursor")
+        .join("projects")
+}
+
+pub(crate) fn cursor_trust_marker_path(workspace: &Path) -> PathBuf {
+    let normalized = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.to_path_buf());
+    cursor_projects_dir()
+        .join(cursor_project_slug(&normalized))
+        .join(".workspace-trusted")
+}
+
+/// Pre-seed Cursor's workspace trust marker for PTY launches.
+///
+/// Cursor's `--trust` flag only works in print mode. hcom keeps Cursor
+/// interactive inside a PTY, so the marker must exist before process startup.
+pub(crate) fn ensure_cursor_workspace_trusted(workspace: &Path) -> anyhow::Result<()> {
+    let normalized = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.to_path_buf());
+    let marker = cursor_trust_marker_path(&normalized);
+    if marker.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = marker.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let trusted_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let content = serde_json::to_string_pretty(&serde_json::json!({
+        "trustedAt": trusted_at,
+        "workspacePath": normalized.to_string_lossy(),
+        "trustMethod": "hcom-launch",
+    }))?;
+    crate::paths::atomic_write_io(&marker, &content)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_project_slug_matches_cursor_layout() {
+        assert_eq!(
+            cursor_project_slug(Path::new("/private/tmp/cursor-hook-probe.sdxJ")),
+            "private-tmp-cursor-hook-probe-sdxJ"
+        );
+        assert_eq!(
+            cursor_project_slug(Path::new("/Users/anno/Dev/hook-comms-public")),
+            "Users-anno-Dev-hook-comms-public"
+        );
+    }
+}

--- a/src/tools/cursor_preprocessing.rs
+++ b/src/tools/cursor_preprocessing.rs
@@ -26,6 +26,28 @@ pub(crate) fn cursor_project_slug(workspace: &Path) -> String {
         .join("-")
 }
 
+/// Print/headless flags that would break hcom's PTY delivery model.
+///
+/// hcom always runs cursor-agent inside a PTY (interactive, or HeadlessPty for
+/// background) — never `--print`. The `beforeSubmitPrompt`/`stop` hooks that
+/// carry message delivery do **not** fire in `--print` mode, so a stray
+/// `-p`/`--print` leaking in from `HCOM_CURSOR_ARGS` or a resumed instance's
+/// baked `launch_args` would silently break delivery. `--stream-partial-output`
+/// only works with `--print` + stream-json, so it's dead weight once `--print`
+/// is gone. All three are booleans (no value token), so a plain filter is safe.
+const CURSOR_PRINT_FLAGS: &[&str] = &["-p", "--print", "--stream-partial-output"];
+
+/// Strip print/headless flags from a cursor-agent arg list (see
+/// [`CURSOR_PRINT_FLAGS`]). Applied to both the launch-time arg merge and the
+/// resume merge so neither path can drop cursor into one-shot `--print` mode.
+pub(crate) fn strip_cursor_print_flags(tokens: &[String]) -> Vec<String> {
+    tokens
+        .iter()
+        .filter(|t| !CURSOR_PRINT_FLAGS.contains(&t.as_str()))
+        .cloned()
+        .collect()
+}
+
 fn cursor_projects_dir() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_default()
@@ -80,6 +102,29 @@ mod tests {
         assert_eq!(
             cursor_project_slug(Path::new("/Users/anno/Dev/hook-comms-public")),
             "Users-anno-Dev-hook-comms-public"
+        );
+    }
+
+    #[test]
+    fn strip_cursor_print_flags_drops_print_and_companions_keeps_rest() {
+        let tokens: Vec<String> = [
+            "--model",
+            "composer-2.5",
+            "-p",
+            "--print",
+            "--stream-partial-output",
+            "--force",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(
+            strip_cursor_print_flags(&tokens),
+            vec![
+                "--model".to_string(),
+                "composer-2.5".to_string(),
+                "--force".to_string()
+            ]
         );
     }
 }

--- a/src/tools/cursor_preprocessing.rs
+++ b/src/tools/cursor_preprocessing.rs
@@ -2,6 +2,8 @@
 
 use std::path::{Path, PathBuf};
 
+use anyhow::{Context, bail};
+
 /// Cursor stores per-workspace state under `~/.cursor/projects/<slug>`.
 ///
 /// This mirrors Cursor's path slugging: path separators and punctuation become
@@ -32,20 +34,25 @@ pub(crate) fn cursor_project_slug(workspace: &Path) -> String {
 /// background) — never `--print`. The `beforeSubmitPrompt`/`stop` hooks that
 /// carry message delivery do **not** fire in `--print` mode, so a stray
 /// `-p`/`--print` leaking in from `HCOM_CURSOR_ARGS` or a resumed instance's
-/// baked `launch_args` would silently break delivery. `--stream-partial-output`
-/// only works with `--print` + stream-json, so it's dead weight once `--print`
-/// is gone. All three are booleans (no value token), so a plain filter is safe.
+/// baked `launch_args` would silently break delivery unless rejected.
+/// `--stream-partial-output` only works with `--print` + stream-json, so reject
+/// that companion flag as well.
 const CURSOR_PRINT_FLAGS: &[&str] = &["-p", "--print", "--stream-partial-output"];
 
-/// Strip print/headless flags from a cursor-agent arg list (see
-/// [`CURSOR_PRINT_FLAGS`]). Applied to both the launch-time arg merge and the
-/// resume merge so neither path can drop cursor into one-shot `--print` mode.
-pub(crate) fn strip_cursor_print_flags(tokens: &[String]) -> Vec<String> {
-    tokens
+/// Reject print/headless flags that would break hcom's PTY delivery model.
+pub(crate) fn validate_cursor_args(tokens: &[String]) -> Vec<String> {
+    let found: Vec<&str> = tokens
         .iter()
-        .filter(|t| !CURSOR_PRINT_FLAGS.contains(&t.as_str()))
-        .cloned()
-        .collect()
+        .map(String::as_str)
+        .filter(|token| CURSOR_PRINT_FLAGS.contains(token))
+        .collect();
+    if found.is_empty() {
+        return Vec::new();
+    }
+    vec![format!(
+        "Cursor print mode is not supported by `hcom cursor-agent`: {} would disable the PTY hooks used for message delivery. Remove the print flag and launch the interactive or `--headless` PTY session instead.",
+        found.join(", ")
+    )]
 }
 
 fn cursor_projects_dir() -> PathBuf {
@@ -64,6 +71,37 @@ pub(crate) fn cursor_trust_marker_path(workspace: &Path) -> PathBuf {
         .join(".workspace-trusted")
 }
 
+fn validate_existing_cursor_trust_marker(marker: &Path, workspace: &Path) -> anyhow::Result<()> {
+    let content = std::fs::read_to_string(marker).with_context(|| {
+        format!(
+            "failed to read Cursor workspace trust marker {}",
+            marker.display()
+        )
+    })?;
+    let value: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("invalid Cursor workspace trust marker {}", marker.display()))?;
+    let recorded = value
+        .get("workspacePath")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Cursor workspace trust marker {} has no workspacePath",
+                marker.display()
+            )
+        })?;
+    let recorded_path = PathBuf::from(recorded);
+    let normalized_recorded = recorded_path.canonicalize().unwrap_or(recorded_path);
+    if normalized_recorded != workspace {
+        bail!(
+            "Cursor workspace trust marker collision at {}: marker records workspacePath '{}' but launch requested '{}'. Cursor's native project slug maps both paths to the same directory; remove or relocate the stale marker only after confirming which workspace should be trusted.",
+            marker.display(),
+            normalized_recorded.display(),
+            workspace.display()
+        );
+    }
+    Ok(())
+}
+
 /// Pre-seed Cursor's workspace trust marker for PTY launches.
 ///
 /// Cursor's `--trust` flag only works in print mode. hcom keeps Cursor
@@ -74,11 +112,16 @@ pub(crate) fn ensure_cursor_workspace_trusted(workspace: &Path) -> anyhow::Resul
         .unwrap_or_else(|_| workspace.to_path_buf());
     let marker = cursor_trust_marker_path(&normalized);
     if marker.exists() {
-        return Ok(());
+        return validate_existing_cursor_trust_marker(&marker, &normalized);
     }
     if let Some(parent) = marker.parent() {
         std::fs::create_dir_all(parent)?;
     }
+    eprintln!(
+        "[hcom] Cursor Agent PTY hooks require a trusted workspace; recording trust for {} at {}",
+        normalized.display(),
+        marker.display()
+    );
     let trusted_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
     let content = serde_json::to_string_pretty(&serde_json::json!({
         "trustedAt": trusted_at,
@@ -106,7 +149,7 @@ mod tests {
     }
 
     #[test]
-    fn strip_cursor_print_flags_drops_print_and_companions_keeps_rest() {
+    fn validate_cursor_args_rejects_print_and_companions() {
         let tokens: Vec<String> = [
             "--model",
             "composer-2.5",
@@ -118,13 +161,37 @@ mod tests {
         .iter()
         .map(|s| s.to_string())
         .collect();
+        let errors = validate_cursor_args(&tokens);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("-p, --print, --stream-partial-output"));
+        assert!(errors[0].contains("not supported"));
+    }
+
+    #[test]
+    fn existing_trust_marker_accepts_matching_workspace_and_rejects_slug_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        let trusted = dir.path().join("acme.prod");
+        let colliding = dir.path().join("acme-prod");
+        std::fs::create_dir_all(&trusted).unwrap();
+        std::fs::create_dir_all(&colliding).unwrap();
         assert_eq!(
-            strip_cursor_print_flags(&tokens),
-            vec![
-                "--model".to_string(),
-                "composer-2.5".to_string(),
-                "--force".to_string()
-            ]
+            cursor_project_slug(&trusted),
+            cursor_project_slug(&colliding)
         );
+        let marker = dir.path().join(".workspace-trusted");
+        std::fs::write(
+            &marker,
+            serde_json::json!({ "workspacePath": trusted.canonicalize().unwrap() }).to_string(),
+        )
+        .unwrap();
+
+        assert!(
+            validate_existing_cursor_trust_marker(&marker, &trusted.canonicalize().unwrap())
+                .is_ok()
+        );
+        let error =
+            validate_existing_cursor_trust_marker(&marker, &colliding.canonicalize().unwrap())
+                .unwrap_err();
+        assert!(error.to_string().contains("trust marker collision"));
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -7,5 +7,6 @@
 pub mod args_common;
 pub mod codex_args;
 pub mod codex_preprocessing;
+pub mod cursor_preprocessing;
 pub mod gemini_args;
 pub mod opencode_preprocessing;

--- a/src/tools/opencode_preprocessing.rs
+++ b/src/tools/opencode_preprocessing.rs
@@ -3,20 +3,35 @@
 
 use std::collections::HashMap;
 
-/// Auto-approve JSON for hcom bash commands.
-/// Value for OPENCODE_PERMISSION env var.
-const OPENCODE_PERMISSION_JSON: &str = r#"{"bash":{"hcom *":"allow"}}"#;
+fn opencode_permission_json() -> String {
+    let prefix = crate::runtime_env::build_hcom_command();
+    let bash = crate::hooks::common::SAFE_HCOM_COMMANDS
+        .iter()
+        .map(|command| (format!("{prefix} {command}*"), serde_json::json!("allow")))
+        .collect();
+    serde_json::Value::Object(serde_json::Map::from_iter([(
+        "bash".to_string(),
+        serde_json::Value::Object(bash),
+    )]))
+    .to_string()
+}
 
 /// Preprocess environment variables for OpenCode launch.
 ///
 /// Sets:
-/// - `OPENCODE_PERMISSION`: Auto-approve all `hcom *` bash commands
+/// - `OPENCODE_PERMISSION`: Auto-approve safe hcom bash commands when enabled
 /// - `HCOM_NAME`: Instance name for plugin diagnostics (set before identity binding)
-pub fn preprocess_opencode_env(env: &mut HashMap<String, String>, instance_name: &str) {
-    env.insert(
-        "OPENCODE_PERMISSION".to_string(),
-        OPENCODE_PERMISSION_JSON.to_string(),
-    );
+pub fn preprocess_opencode_env(
+    env: &mut HashMap<String, String>,
+    instance_name: &str,
+    auto_approve: bool,
+) {
+    if auto_approve {
+        env.insert(
+            "OPENCODE_PERMISSION".to_string(),
+            opencode_permission_json(),
+        );
+    }
     env.insert("HCOM_NAME".to_string(), instance_name.to_string());
 }
 
@@ -27,16 +42,25 @@ mod tests {
     #[test]
     fn test_preprocess_sets_permission() {
         let mut env = HashMap::new();
-        preprocess_opencode_env(&mut env, "luna");
+        preprocess_opencode_env(&mut env, "luna", true);
         let perm = env.get("OPENCODE_PERMISSION").unwrap();
-        assert!(perm.contains("hcom *"));
-        assert!(perm.contains("allow"));
+        let prefix = crate::runtime_env::build_hcom_command();
+        assert!(perm.contains(&format!("{prefix} send*")));
+        assert!(!perm.contains(&format!("\"{prefix} *\"")));
+        assert!(!perm.contains("hcom kill"));
+    }
+
+    #[test]
+    fn test_preprocess_skips_permission_when_disabled() {
+        let mut env = HashMap::new();
+        preprocess_opencode_env(&mut env, "luna", false);
+        assert!(!env.contains_key("OPENCODE_PERMISSION"));
     }
 
     #[test]
     fn test_preprocess_sets_hcom_name() {
         let mut env = HashMap::new();
-        preprocess_opencode_env(&mut env, "nova");
+        preprocess_opencode_env(&mut env, "nova", true);
         assert_eq!(env.get("HCOM_NAME").unwrap(), "nova");
     }
 
@@ -44,14 +68,15 @@ mod tests {
     fn test_preprocess_overwrites_existing() {
         let mut env = HashMap::new();
         env.insert("HCOM_NAME".to_string(), "old".to_string());
-        preprocess_opencode_env(&mut env, "nova");
+        preprocess_opencode_env(&mut env, "nova", true);
         assert_eq!(env.get("HCOM_NAME").unwrap(), "nova");
     }
 
     #[test]
     fn test_permission_json_is_valid() {
         let parsed: serde_json::Value =
-            serde_json::from_str(OPENCODE_PERMISSION_JSON).expect("valid JSON");
-        assert!(parsed["bash"]["hcom *"].is_string());
+            serde_json::from_str(&opencode_permission_json()).expect("valid JSON");
+        let prefix = crate::runtime_env::build_hcom_command();
+        assert!(parsed["bash"][format!("{prefix} send*")].is_string());
     }
 }

--- a/src/transcript/cursor.rs
+++ b/src/transcript/cursor.rs
@@ -1,0 +1,345 @@
+//! Cursor-agent transcript parser (.jsonl).
+//!
+//! cursor-agent writes one JSON object per line at
+//! `~/.cursor/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl` (the path
+//! the hook hands hcom verbatim as `transcript_path`). Each line is
+//! Anthropic-shaped:
+//!
+//! ```jsonc
+//! {"role": "user",      "message": {"content": [{"type": "text", "text": "…"}]}}
+//! {"role": "assistant", "message": {"content": [
+//!     {"type": "text", "text": "…"},
+//!     {"type": "tool_use", "name": "Shell", "input": {"command": "…"}}
+//! ]}}
+//! ```
+//!
+//! Notable differences from the Claude/Codex transcripts:
+//! - **No timestamps, no `sessionId`/`cwd`, no `id` on tool_use blocks.**
+//! - **Tool outputs are not recorded** (no `tool_result` blocks), so error
+//!   detection has nothing to read — every tool use is reported non-error.
+//! - User prompts are wrapped in `<user_query>…</user_query>`; we unwrap it.
+
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::shared::{
+    Exchange, ToolUse, dedup_sorted_capped, finalize_action_text, normalize_tool_name,
+    read_file_lossy, same_trimmed_text, truncate_str,
+};
+
+/// Map cursor's tool names onto hcom's canonical (Claude) names. cursor already
+/// uses Claude-style CamelCase for most tools (`Read`, `Write`, `Grep`, `Glob`,
+/// `WebFetch`, `TodoWrite`, `Shell`), so only its two divergent names need
+/// remapping before falling through to the shared normalizer.
+fn normalize_cursor_tool(name: &str) -> &str {
+    match name {
+        "StrReplace" => "Edit",
+        "ReadFile" => "Read",
+        other => normalize_tool_name(other),
+    }
+}
+
+/// Strip cursor's `<user_query>…</user_query>` wrapper from a user prompt,
+/// returning the inner text trimmed. Leaves unwrapped text untouched.
+fn unwrap_user_query(text: &str) -> String {
+    let trimmed = text.trim();
+    if let Some(inner) = trimmed
+        .strip_prefix("<user_query>")
+        .and_then(|s| s.strip_suffix("</user_query>"))
+    {
+        return inner.trim().to_string();
+    }
+    trimmed.to_string()
+}
+
+/// Join the text blocks of a `message.content` array, skipping non-text blocks
+/// (tool_use / any future block types). Tolerates a bare-string `content`.
+fn content_text(message: &Value) -> String {
+    match message.get("content") {
+        Some(Value::String(s)) => s.trim().to_string(),
+        Some(Value::Array(blocks)) => {
+            let mut parts = Vec::new();
+            for block in blocks {
+                if block.get("type").and_then(Value::as_str) == Some("text")
+                    && let Some(text) = block.get("text").and_then(Value::as_str)
+                {
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() {
+                        parts.push(trimmed.to_string());
+                    }
+                }
+            }
+            parts.join("\n")
+        }
+        _ => String::new(),
+    }
+}
+
+/// Basename of a tool-input path field, if any of `path`/`file_path`/`file`.
+fn tool_file(input: &Value) -> Option<String> {
+    let obj = input.as_object()?;
+    for field in ["path", "file_path", "file"] {
+        if let Some(val) = obj.get(field).and_then(Value::as_str)
+            && !val.is_empty()
+        {
+            return Some(
+                Path::new(val)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(val)
+                    .to_string(),
+            );
+        }
+    }
+    None
+}
+
+/// Parse a cursor-agent JSONL transcript into the shared `Exchange` model.
+pub(crate) fn parse_cursor_jsonl(
+    path: &Path,
+    last: usize,
+    _detailed: bool,
+) -> Result<Vec<Exchange>, String> {
+    let content = read_file_lossy(path)?;
+
+    let mut exchanges: Vec<Exchange> = Vec::new();
+    let mut current_user = String::new();
+    let mut current_action = String::new();
+    let mut current_tools: Vec<ToolUse> = Vec::new();
+    let mut current_files: Vec<String> = Vec::new();
+    let mut assistant_chunks: Vec<String> = Vec::new();
+    let mut position = 0usize;
+    let mut in_exchange = false;
+
+    // Flush the in-progress exchange (if any user/assistant content accrued).
+    let flush = |exchanges: &mut Vec<Exchange>,
+                 position: &mut usize,
+                 in_exchange: &mut bool,
+                 user: &mut String,
+                 action: &mut String,
+                 tools: &mut Vec<ToolUse>,
+                 files: &mut Vec<String>,
+                 chunks: &mut Vec<String>| {
+        if !user.is_empty() || !action.is_empty() {
+            *position += 1;
+            let final_action = finalize_action_text(action, tools, &[], false);
+            exchanges.push(Exchange {
+                position: *position,
+                user: std::mem::take(user),
+                action: final_action,
+                files: dedup_sorted_capped(files, 5),
+                timestamp: String::new(),
+                tools: std::mem::take(tools),
+                edits: Vec::new(),
+                errors: Vec::new(),
+                ended_on_error: false,
+            });
+            action.clear();
+            files.clear();
+            chunks.clear();
+        }
+        *in_exchange = false;
+    };
+
+    for line in content.lines() {
+        let entry: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let role = entry.get("role").and_then(Value::as_str).unwrap_or("");
+        let Some(message) = entry.get("message") else {
+            continue;
+        };
+
+        match role {
+            "user" => {
+                let text = unwrap_user_query(&content_text(message));
+                // A user message with no text (e.g. a tool_result-only turn)
+                // must not start a new exchange.
+                if text.is_empty() {
+                    continue;
+                }
+                // Repeated identical user line before any assistant reply (e.g.
+                // a re-submitted prompt): keep the open exchange, don't split.
+                if in_exchange
+                    && current_action.is_empty()
+                    && same_trimmed_text(&current_user, &text)
+                {
+                    continue;
+                }
+                flush(
+                    &mut exchanges,
+                    &mut position,
+                    &mut in_exchange,
+                    &mut current_user,
+                    &mut current_action,
+                    &mut current_tools,
+                    &mut current_files,
+                    &mut assistant_chunks,
+                );
+                current_user = text;
+                in_exchange = true;
+            }
+            "assistant" => {
+                let text = content_text(message);
+                if !text.is_empty()
+                    && !assistant_chunks
+                        .iter()
+                        .any(|chunk| same_trimmed_text(chunk, &text))
+                {
+                    if !current_action.is_empty() {
+                        current_action.push('\n');
+                    }
+                    current_action.push_str(&text);
+                    assistant_chunks.push(text);
+                }
+                if let Some(blocks) = message.get("content").and_then(Value::as_array) {
+                    for block in blocks {
+                        if block.get("type").and_then(Value::as_str) != Some("tool_use") {
+                            continue;
+                        }
+                        let raw_name = block
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or("unknown");
+                        let name = normalize_cursor_tool(raw_name).to_string();
+                        let input = block.get("input").cloned().unwrap_or(Value::Null);
+                        let file = tool_file(&input);
+                        if let Some(ref f) = file
+                            && !current_files.contains(f)
+                        {
+                            current_files.push(f.clone());
+                        }
+                        let command = input.get("command").and_then(Value::as_str).map(|s| {
+                            if s.len() > 80 {
+                                format!("{}...", truncate_str(s, 77))
+                            } else {
+                                s.to_string()
+                            }
+                        });
+                        current_tools.push(ToolUse {
+                            name,
+                            is_error: false,
+                            file,
+                            command,
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    flush(
+        &mut exchanges,
+        &mut position,
+        &mut in_exchange,
+        &mut current_user,
+        &mut current_action,
+        &mut current_tools,
+        &mut current_files,
+        &mut assistant_chunks,
+    );
+
+    if exchanges.len() > last {
+        let start = exchanges.len() - last;
+        exchanges = exchanges[start..].to_vec();
+    }
+
+    Ok(exchanges)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+
+    fn write_jsonl(lines: &[Value]) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("chat.jsonl");
+        fs::write(
+            &path,
+            lines
+                .iter()
+                .map(Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+        .unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn parses_user_query_unwrap_and_tool_use() {
+        let (_d, path) = write_jsonl(&[
+            json!({"role": "user", "message": {"content": [
+                {"type": "text", "text": "<user_query>\nfix the parser\n</user_query>"}
+            ]}}),
+            json!({"role": "assistant", "message": {"content": [
+                {"type": "text", "text": "On it."},
+                {"type": "tool_use", "name": "Shell", "input": {"command": "cargo build", "description": "build"}}
+            ]}}),
+            json!({"role": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "StrReplace", "input": {"path": "/repo/src/main.rs", "old_string": "a", "new_string": "b"}}
+            ]}}),
+        ]);
+        let ex = parse_cursor_jsonl(&path, 10, true).unwrap();
+        assert_eq!(ex.len(), 1);
+        assert_eq!(ex[0].user, "fix the parser");
+        assert_eq!(ex[0].action, "On it.");
+        // Two tool_use blocks across two assistant lines, one exchange.
+        assert_eq!(ex[0].tools.len(), 2);
+        assert_eq!(ex[0].tools[0].name, "Shell");
+        assert_eq!(ex[0].tools[0].command.as_deref(), Some("cargo build"));
+        // StrReplace → canonical Edit; file basename captured.
+        assert_eq!(ex[0].tools[1].name, "Edit");
+        assert_eq!(ex[0].files, vec!["main.rs".to_string()]);
+    }
+
+    #[test]
+    fn tool_only_turn_and_empty_user_turn_handled() {
+        let (_d, path) = write_jsonl(&[
+            // user turn with no text (tool_result-only shape) must not split.
+            json!({"role": "user", "message": {"content": [
+                {"type": "text", "text": "first"}
+            ]}}),
+            json!({"role": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Read", "input": {"path": "a.txt"}}
+            ]}}),
+            json!({"role": "user", "message": {"content": []}}),
+            json!({"role": "assistant", "message": {"content": [
+                {"type": "text", "text": "done"}
+            ]}}),
+        ]);
+        let ex = parse_cursor_jsonl(&path, 10, false).unwrap();
+        // The empty user turn did not open a new exchange; assistant text
+        // accrued onto the first (tool-only) exchange.
+        assert_eq!(ex.len(), 1);
+        assert_eq!(ex[0].user, "first");
+        assert_eq!(ex[0].action, "done");
+        assert_eq!(ex[0].tools.len(), 1);
+        assert_eq!(ex[0].tools[0].name, "Read");
+    }
+
+    #[test]
+    fn last_truncates_to_most_recent() {
+        let mut lines = Vec::new();
+        for i in 0..5 {
+            lines.push(json!({"role": "user", "message": {"content": [
+                {"type": "text", "text": format!("q{i}")}
+            ]}}));
+            lines.push(json!({"role": "assistant", "message": {"content": [
+                {"type": "text", "text": format!("a{i}")}
+            ]}}));
+        }
+        let (_d, path) = write_jsonl(&lines);
+        let ex = parse_cursor_jsonl(&path, 2, false).unwrap();
+        assert_eq!(ex.len(), 2);
+        assert_eq!(ex[0].user, "q3");
+        assert_eq!(ex[1].user, "q4");
+        // Positions are 1-based and contiguous after truncation.
+        assert_eq!(ex[1].position, 5);
+    }
+}

--- a/src/transcript/cursor.rs
+++ b/src/transcript/cursor.rs
@@ -28,14 +28,18 @@ use super::shared::{
     read_file_lossy, same_trimmed_text, truncate_str,
 };
 
-/// Map cursor's tool names onto hcom's canonical (Claude) names. cursor already
-/// uses Claude-style CamelCase for most tools (`Read`, `Write`, `Grep`, `Glob`,
-/// `WebFetch`, `TodoWrite`, `Shell`), so only its two divergent names need
-/// remapping before falling through to the shared normalizer.
+/// Map cursor's tool names onto hcom's canonical (Claude) names. cursor uses
+/// Claude-style CamelCase for most tools (`Read`, `Write`, `Grep`, `Glob`,
+/// `WebFetch`, `TodoWrite`, `Shell`, `Task`), so only its divergent names need
+/// remapping before falling through to the shared normalizer:
+/// `StrReplace`→`Edit`, `ReadFile`→`Read`, `run_terminal_cmd`→`Shell`,
+/// `Subagent`→`Task`.
 fn normalize_cursor_tool(name: &str) -> &str {
     match name {
         "StrReplace" => "Edit",
         "ReadFile" => "Read",
+        "run_terminal_cmd" => "Shell",
+        "Subagent" => "Task",
         other => normalize_tool_name(other),
     }
 }
@@ -296,6 +300,18 @@ mod tests {
         // StrReplace → canonical Edit; file basename captured.
         assert_eq!(ex[0].tools[1].name, "Edit");
         assert_eq!(ex[0].files, vec!["main.rs".to_string()]);
+    }
+
+    #[test]
+    fn normalizes_cursor_divergent_tool_names() {
+        assert_eq!(normalize_cursor_tool("StrReplace"), "Edit");
+        assert_eq!(normalize_cursor_tool("ReadFile"), "Read");
+        assert_eq!(normalize_cursor_tool("run_terminal_cmd"), "Shell");
+        assert_eq!(normalize_cursor_tool("Subagent"), "Task");
+        // Already-canonical cursor names pass through unchanged.
+        assert_eq!(normalize_cursor_tool("Shell"), "Shell");
+        assert_eq!(normalize_cursor_tool("Task"), "Task");
+        assert_eq!(normalize_cursor_tool("Read"), "Read");
     }
 
     #[test]

--- a/src/transcript/mod.rs
+++ b/src/transcript/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod claude;
 pub mod codex;
+pub mod cursor;
 pub mod gemini;
 pub mod opencode;
 pub mod shared;
@@ -26,6 +27,7 @@ pub enum ToolKind {
     Gemini,
     Codex,
     OpenCode,
+    Cursor,
 }
 
 /// Options for reading a transcript.
@@ -61,6 +63,7 @@ pub fn read(path: &Path, kind: ToolKind, opts: &ReadOptions) -> Result<Vec<Excha
         ToolKind::Antigravity => claude::parse_claude_jsonl(path, opts.last, opts.detailed),
         ToolKind::Gemini => gemini::parse_gemini_json(path, opts.last),
         ToolKind::Codex => codex::parse_codex_jsonl(path, opts.last, opts.detailed),
+        ToolKind::Cursor => cursor::parse_cursor_jsonl(path, opts.last, opts.detailed),
         ToolKind::OpenCode => {
             let sid = opts.session_id.as_deref().unwrap_or("");
             if sid.is_empty() {
@@ -106,6 +109,7 @@ pub fn kind_from_agent_or_path(agent: &str, path: &str) -> ToolKind {
         "gemini" => ToolKind::Gemini,
         "codex" => ToolKind::Codex,
         "opencode" => ToolKind::OpenCode,
+        "cursor" | "cursor-agent" => ToolKind::Cursor,
         _ => detect_kind_from_path(path).unwrap_or(ToolKind::Claude),
     }
 }

--- a/src/transcript/mod.rs
+++ b/src/transcript/mod.rs
@@ -95,6 +95,11 @@ pub fn detect_kind_from_path(path: &str) -> Option<ToolKind> {
         Some(ToolKind::Gemini)
     } else if path.ends_with(".db") {
         Some(ToolKind::OpenCode)
+    } else if path.contains("agent-transcripts") {
+        // Cursor's `.jsonl` would otherwise fall through to Claude. Key off the
+        // cursor-unique `agent-transcripts` segment (not the `.jsonl` extension,
+        // which is shared with Claude/Codex).
+        Some(ToolKind::Cursor)
     } else {
         None
     }
@@ -167,4 +172,30 @@ pub fn format_exchanges_pub(
     };
     let exchanges = read(Path::new(q.path), kind, &opts)?;
     Ok(format_exchanges(&exchanges, instance, full, q.detailed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_kind_from_path_routes_cursor_jsonl_via_agent_transcripts() {
+        // Cursor `.jsonl` keys off the agent-transcripts segment, not the
+        // extension (shared with Claude/Codex), so it no longer falls through
+        // to Claude.
+        assert_eq!(
+            detect_kind_from_path("/h/.cursor/projects/r/agent-transcripts/u/u.jsonl"),
+            Some(ToolKind::Cursor)
+        );
+        // A plain Claude `.jsonl` stays ambiguous (None → caller defaults).
+        assert_eq!(detect_kind_from_path("/h/.claude/projects/r/u.jsonl"), None);
+        assert_eq!(
+            detect_kind_from_path("/x/session.json"),
+            Some(ToolKind::Gemini)
+        );
+        assert_eq!(
+            detect_kind_from_path("/x/opencode.db"),
+            Some(ToolKind::OpenCode)
+        );
+    }
 }

--- a/src/tui/db.rs
+++ b/src/tui/db.rs
@@ -240,6 +240,7 @@ fn parse_tool(s: &str) -> Tool {
         "codex" => Tool::Codex,
         "opencode" => Tool::OpenCode,
         "antigravity" => Tool::Antigravity,
+        "cursor" => Tool::Cursor,
         _ => Tool::Adhoc,
     }
 }

--- a/src/tui/model.rs
+++ b/src/tui/model.rs
@@ -82,6 +82,7 @@ pub enum Tool {
     Codex,
     OpenCode,
     Antigravity,
+    Cursor,
     Adhoc,
 }
 
@@ -94,6 +95,7 @@ impl Tool {
             Self::Codex => crate::tool::Tool::Codex,
             Self::OpenCode => crate::tool::Tool::OpenCode,
             Self::Antigravity => crate::tool::Tool::Antigravity,
+            Self::Cursor => crate::tool::Tool::Cursor,
             Self::Adhoc => crate::tool::Tool::Adhoc,
         }
     }
@@ -114,7 +116,8 @@ impl Tool {
             Self::Gemini => Self::Codex,
             Self::Codex => Self::OpenCode,
             Self::OpenCode => Self::Antigravity,
-            Self::Antigravity => Self::Claude,
+            Self::Antigravity => Self::Cursor,
+            Self::Cursor => Self::Claude,
             Self::Adhoc => Self::Adhoc,
         }
     }
@@ -122,11 +125,12 @@ impl Tool {
     /// Cycle backward (for launch panel). Adhoc is not launchable.
     pub fn prev(&self) -> Self {
         match self {
-            Self::Claude => Self::Antigravity,
+            Self::Claude => Self::Cursor,
             Self::Gemini => Self::Claude,
             Self::Codex => Self::Gemini,
             Self::OpenCode => Self::Codex,
             Self::Antigravity => Self::OpenCode,
+            Self::Cursor => Self::Antigravity,
             Self::Adhoc => Self::Adhoc,
         }
     }
@@ -1164,12 +1168,14 @@ mod tests {
         assert_eq!(Tool::Gemini.next(), Tool::Codex);
         assert_eq!(Tool::Codex.next(), Tool::OpenCode);
         assert_eq!(Tool::OpenCode.next(), Tool::Antigravity);
-        assert_eq!(Tool::Antigravity.next(), Tool::Claude);
+        assert_eq!(Tool::Antigravity.next(), Tool::Cursor);
+        assert_eq!(Tool::Cursor.next(), Tool::Claude);
     }
 
     #[test]
     fn tool_prev_cycles_backward() {
-        assert_eq!(Tool::Claude.prev(), Tool::Antigravity);
+        assert_eq!(Tool::Claude.prev(), Tool::Cursor);
+        assert_eq!(Tool::Cursor.prev(), Tool::Antigravity);
         assert_eq!(Tool::Antigravity.prev(), Tool::OpenCode);
         assert_eq!(Tool::OpenCode.prev(), Tool::Codex);
         assert_eq!(Tool::Codex.prev(), Tool::Gemini);

--- a/src/tui/rpc.rs
+++ b/src/tui/rpc.rs
@@ -54,6 +54,7 @@ fn first_non_empty_line(text: &str) -> Option<&str> {
 ///   codex:  bare positional (interactive)
 ///   opencode: `--prompt "prompt"`
 ///   antigravity: `--prompt-interactive "prompt"` (agy's documented interactive flag)
+///   cursor: bare positional
 ///
 /// Always includes `--no-run-here` so the launcher opens a new terminal window/tab
 /// instead of running the agent in the TUI's own terminal (which would cause the
@@ -80,8 +81,8 @@ pub fn build_launch_argv(
     // Tool-specific prompt flags
     if !prompt.is_empty() {
         match tool {
-            Tool::Claude | Tool::Codex => {
-                if headless {
+            Tool::Claude | Tool::Codex | Tool::Cursor => {
+                if headless && tool == Tool::Claude {
                     argv.push("-p".into());
                 }
                 argv.push(prompt.into());
@@ -99,7 +100,7 @@ pub fn build_launch_argv(
             }
             Tool::Adhoc => {}
         }
-    } else if headless {
+    } else if headless && tool == Tool::Claude {
         // headless without prompt (claude only)
         argv.push("-p".into());
     }
@@ -223,6 +224,22 @@ mod tests {
             vec![
                 "1",
                 "codex",
+                "--no-run-here",
+                "--terminal",
+                "tmux",
+                "do task"
+            ]
+        );
+    }
+
+    #[test]
+    fn launch_argv_cursor_prompt_is_positional() {
+        let argv = build_launch_argv(Tool::Cursor, 1, "", false, "tmux", "do task");
+        assert_eq!(
+            argv,
+            vec![
+                "1",
+                "cursor",
                 "--no-run-here",
                 "--terminal",
                 "tmux",

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -517,3 +517,166 @@ fn antigravity_e2e_hook_dispatch() {
         serde_json::from_str(after_stdout.trim()).expect("aftertool json");
     assert_eq!(parsed, serde_json::json!({}));
 }
+
+/// Pipe a JSON payload to a native cursor hook and return its parsed stdout.
+///
+/// Cursor hook command names route directly to `Tool::Cursor` (no shared-prefix
+/// disambiguation like Antigravity's `ANTIGRAVITY_AGENT`), so the only env the
+/// gate check needs is `HCOM_PROCESS_ID` to resolve the bound instance.
+fn run_cursor_hook(
+    h: &Hcom,
+    hook: &str,
+    process_id: &str,
+    payload: &serde_json::Value,
+) -> serde_json::Value {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut cmd = h.cmd();
+    cmd.args([hook]);
+    cmd.env("HCOM_PROCESS_ID", process_id);
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().unwrap_or_else(|e| panic!("spawn {hook}: {e}"));
+    {
+        let mut stdin = child.stdin.take().expect("open stdin");
+        stdin
+            .write_all(serde_json::to_string(payload).unwrap().as_bytes())
+            .unwrap();
+    }
+    let out = child
+        .wait_with_output()
+        .unwrap_or_else(|e| panic!("wait {hook}: {e}"));
+    assert_eq!(
+        out.status.code().unwrap_or(-1),
+        0,
+        "{hook} stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("{hook} json: {e}\nstdout={stdout}"))
+}
+
+/// End-to-end cursor-agent native hook lifecycle over JSON-on-stdin.
+///
+/// Mirrors `antigravity_e2e_hook_dispatch`, but exercises cursor's real payload
+/// shape (`conversation_id`/`tool_input`/`tool_output`) and its distinct
+/// delivery contract: unlike Antigravity (whose aftertool cannot inject and
+/// must return `{}`), cursor's `postToolUse` injects pending messages via
+/// `additional_context` and acks delivery.
+#[test]
+fn cursor_e2e_hook_dispatch() {
+    let h = Hcom::new();
+    let transcript = tempfile::NamedTempFile::new().expect("temp transcript");
+    let transcript_path = transcript.path().to_string_lossy().to_string();
+    let pid = "pid-cur-123";
+    let session_id = "sess-cur-1";
+
+    // Register a process binding so the hooks can resolve an instance.
+    let mut start_cmd = h.cmd();
+    start_cmd.arg("start");
+    start_cmd.env("HCOM_PROCESS_ID", pid);
+    let start_out = start_cmd.output().expect("failed to run hcom start");
+    let me = support::parse_hcom_marker(&String::from_utf8_lossy(&start_out.stdout))
+        .expect("no [hcom:NAME] marker");
+
+    // 1. sessionStart binds the conversation to the active instance. Cursor reads
+    //    the id from `conversation_id` (snake_case, per the docs' common schema)
+    //    and the handler always returns an `env` object.
+    let session_start = run_cursor_hook(
+        &h,
+        "cursor-sessionstart",
+        pid,
+        &serde_json::json!({
+            "conversation_id": session_id,
+            "transcript_path": transcript_path,
+            "workspace_roots": ["/tmp"],
+            "is_background_agent": false,
+            "composer_mode": "agent",
+        }),
+    );
+    assert!(
+        session_start.get("env").is_some(),
+        "sessionStart should emit env block: {session_start}"
+    );
+
+    // Binding is visible via list --json.
+    let (code, stdout, stderr) = h.run(["list", &me, "--json"]);
+    assert_eq!(code, 0, "stderr={stderr}");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("list json");
+    assert_eq!(v["session_id"].as_str(), Some(session_id));
+
+    // 2. beforeSubmitPrompt marks the instance active and must not block the
+    //    prompt (`continue: true`).
+    let before_submit = run_cursor_hook(
+        &h,
+        "cursor-beforesubmitprompt",
+        pid,
+        &serde_json::json!({
+            "conversation_id": session_id,
+            "transcript_path": transcript_path,
+            "prompt": "do a thing",
+        }),
+    );
+    assert_eq!(before_submit, serde_json::json!({ "continue": true }));
+
+    let (code, stdout, _) = h.run(["list", &me, "--json"]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("list json");
+    assert_eq!(v["status"].as_str(), Some("active"));
+
+    // 3. preToolUse records tool status and returns an empty object.
+    let pre_tool = run_cursor_hook(
+        &h,
+        "cursor-pretooluse",
+        pid,
+        &serde_json::json!({
+            "conversation_id": session_id,
+            "transcript_path": transcript_path,
+            "tool_name": "Shell",
+            "tool_input": { "command": "echo hello", "working_directory": "/tmp" },
+        }),
+    );
+    assert_eq!(pre_tool, serde_json::json!({}));
+
+    // 4. Queue a message, then postToolUse delivers it via additional_context.
+    //    Send from an external sender (bigboss), not `me`: the DB delivery
+    //    filter (`should_deliver_to`) drops any message whose `from` equals the
+    //    receiver, so a self-addressed send would never be pending and the
+    //    postToolUse assertion below would pass vacuously.
+    let (send_code, _, send_stderr) = h.run([
+        "send",
+        "--from",
+        "bigboss",
+        &format!("@{me}"),
+        "--intent",
+        "request",
+        "--",
+        "ping",
+    ]);
+    assert_eq!(send_code, 0, "send stderr={send_stderr}");
+
+    let post_tool = run_cursor_hook(
+        &h,
+        "cursor-posttooluse",
+        pid,
+        &serde_json::json!({
+            "conversation_id": session_id,
+            "transcript_path": transcript_path,
+            "tool_name": "Shell",
+            "tool_input": { "command": "echo hello" },
+            "tool_output": "{\"exitCode\":0,\"stdout\":\"hello\"}",
+        }),
+    );
+    let injected = post_tool
+        .get("additional_context")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("postToolUse should inject additional_context: {post_tool}"));
+    assert!(
+        injected.contains("ping"),
+        "delivered context should carry the message text: {injected:?}"
+    );
+}

--- a/tests/parser_help_drift.rs
+++ b/tests/parser_help_drift.rs
@@ -507,7 +507,7 @@ fn installed_opencode_help_crawls_but_hcom_keeps_opencode_args_pass_through() {
     let launch_command = parser_source("src/commands/launch.rs");
     assert!(
         launcher.contains(
-            "LaunchTool::OpenCode | LaunchTool::Antigravity | LaunchTool::Cursor => Vec::new()"
+            "LaunchTool::OpenCode | LaunchTool::Antigravity => Vec::new(),"
         ),
         "OpenCode has no hcom parser table; if validation is added, add opencode to this drift guard"
     );

--- a/tests/parser_help_drift.rs
+++ b/tests/parser_help_drift.rs
@@ -506,7 +506,9 @@ fn installed_opencode_help_crawls_but_hcom_keeps_opencode_args_pass_through() {
     let launcher = parser_source("src/launcher.rs");
     let launch_command = parser_source("src/commands/launch.rs");
     assert!(
-        launcher.contains("LaunchTool::OpenCode | LaunchTool::Antigravity => Vec::new()"),
+        launcher.contains(
+            "LaunchTool::OpenCode | LaunchTool::Antigravity | LaunchTool::Cursor => Vec::new()"
+        ),
         "OpenCode has no hcom parser table; if validation is added, add opencode to this drift guard"
     );
     assert!(

--- a/tests/test_pty_delivery.rs
+++ b/tests/test_pty_delivery.rs
@@ -5,9 +5,9 @@
 //!
 //! Requires:
 //! - tmux installed and available by default, or another terminal preset via HCOM_TEST_TERMINAL
-//! - Target tool CLI installed (claude/gemini/codex/opencode)
+//! - Target tool CLI installed (claude/gemini/codex/opencode/cursor)
 //!
-//! Phases (claude/gemini/codex/antigravity):
+//! Phases (claude/gemini/codex/antigravity/cursor):
 //! 1. Launch tool via `hcom 1 <tool>` with HCOM_TERMINAL=<terminal>
 //! 2. Wait for ready event, capture and validate full screen state
 //! 3. Send message → verify delivery via events, capture post-delivery screen
@@ -76,6 +76,11 @@ fn ready_pattern(tool: &str) -> &'static str {
         "gemini" => "Type your message",
         "opencode" => "ctrl+p commands",
         "antigravity" => "? for shortcuts",
+        // Cursor has no stable ASCII ready footer (spec ready_pattern is empty,
+        // so is_ready() is always true); readiness is asserted via ready/
+        // prompt_empty directly. has_ready_pattern() gates the pattern check off
+        // for cursor so it isn't run vacuously against an empty needle.
+        "cursor" => "",
         _ => panic!("Unknown tool: {tool}"),
     }
 }
@@ -87,6 +92,7 @@ fn prompt_marker(tool: &str) -> &'static str {
         "codex" => "›",
         "gemini" => " > ",
         "antigravity" => ">",
+        "cursor" => "→",
         _ => panic!("No prompt marker for {tool}"),
     }
 }
@@ -98,6 +104,7 @@ fn frame_marker(tool: &str) -> Option<&'static str> {
         "codex" => None,
         "gemini" => None,
         "antigravity" => Some("─"),
+        "cursor" => None,
         _ => None,
     }
 }
@@ -109,6 +116,10 @@ fn gate_block_context(tool: &str) -> &'static str {
         "codex" => "tui:prompt-has-text",
         "gemini" => "tui:not-ready",
         "antigravity" => "tui:prompt-has-text",
+        // cursor: require_prompt_empty=true, so uncommitted text settles to
+        // prompt_has_text (may transiently report user-active first; validate
+        // only warns on mismatch).
+        "cursor" => "tui:prompt-has-text",
         _ => panic!("No gate block context for {tool}"),
     }
 }
@@ -116,6 +127,25 @@ fn gate_block_context(tool: &str) -> &'static str {
 /// Whether this tool gates on ready pattern
 fn require_ready(tool: &str) -> bool {
     matches!(tool, "gemini")
+}
+
+/// Timeout for the Phase 2 clean-prompt delivery wait.
+///
+/// hcom delivers to an idle agent by injecting only the `<hcom>` trigger (see
+/// `delivery.rs` build_wake_inject_text — Claude/Codex/Cursor all trigger-only);
+/// the message body is then surfaced by a hook *during the agent's turn*. For
+/// Claude/Codex/Gemini that hook fires fast, so 20s is ample. Cursor instead
+/// delivers when the turn ends (stop → followup_message) or on its first tool
+/// call (postToolUse → additional_context), so its first delivery is bounded by
+/// a full model turn on `--model auto` — empirically 9–25s. Use the same 60s
+/// budget Phase 4 already gives a turn-bounded delivery rather than letting a
+/// slow-but-healthy turn read as failure. The assertion stays strict: it still
+/// requires the real `deliver:` event, not merely the injected trigger.
+fn clean_prompt_delivery_timeout(tool: &str) -> Duration {
+    match tool {
+        "cursor" => Duration::from_secs(60),
+        _ => Duration::from_secs(20),
+    }
 }
 
 const SCREEN_FIELDS: &[&str] = &[
@@ -246,6 +276,52 @@ fn poll_until<T>(
     }
 }
 
+/// Wait until the agent is *stably* idle: the most recent status event is
+/// `listening` and no newer status event has appeared for `settle`.
+///
+/// A single `listening` event is terminal for claude/codex/gemini/antigravity,
+/// but not for cursor: its `stop` hook delivers via `followup_message`, which
+/// cursor auto-resubmits as the next user turn, so a delivery is followed by
+/// another active→listening cycle. Phase 3's premise — "while the PTY prompt
+/// holds uncommitted text, the queued message is not delivered" — only holds if
+/// the agent has *no turn in flight*. With a turn still running, the hook
+/// channel (postToolUse / stop), which by design bypasses the PTY prompt-empty
+/// gate, can legitimately deliver mid-turn and the test would misread that
+/// hook-channel delivery as a PTY gate failure. Draining to stable idle first
+/// keeps Phase 3 honest: it isolates the PTY-inject path it actually asserts on.
+fn wait_for_stable_idle(base_name: &str, settle: Duration, timeout: Duration, log: &TestLog) {
+    let start = Instant::now();
+    let mut last_status_id = -1i64;
+    let mut stable_since = Instant::now();
+    loop {
+        let latest_status = get_events(base_name, 30, false)
+            .into_iter()
+            .filter(|ev| ev["type"].as_str() == Some("status"))
+            .filter_map(|ev| ev["id"].as_i64().map(|id| (id, ev)))
+            .max_by_key(|(id, _)| *id);
+        if let Some((id, ev)) = latest_status {
+            if id != last_status_id {
+                last_status_id = id;
+                stable_since = Instant::now();
+            }
+            let listening = ev["data"]["status"].as_str() == Some("listening");
+            if listening && stable_since.elapsed() >= settle {
+                logln!(
+                    log,
+                    "  OK: Agent stably idle for {:?} (last status id={id})",
+                    settle
+                );
+                return;
+            }
+        }
+        assert!(
+            start.elapsed() < timeout,
+            "Timeout ({timeout:?}) waiting for stable idle (base={base_name}, last status id={last_status_id})"
+        );
+        thread::sleep(Duration::from_millis(500));
+    }
+}
+
 // ── Cleanup guard ──────────────────────────────────────────────────────
 
 struct InstanceGuard {
@@ -362,8 +438,21 @@ fn validate_screen_schema(screen: &serde_json::Value) {
     );
 }
 
+/// Returns true if this tool has an ASCII ready-pattern footer to match.
+/// Cursor signals readiness via prompt-empty instead (spec ready_pattern is
+/// empty), so there is no pattern to assert — callers check `ready`/`prompt_empty`
+/// directly rather than running a pattern match that would pass on `contains("")`.
+fn has_ready_pattern(tool: &str) -> bool {
+    !ready_pattern(tool).is_empty()
+}
+
 fn validate_ready_pattern(screen: &serde_json::Value, tool: &str) {
     let pattern = ready_pattern(tool);
+    assert!(
+        !pattern.is_empty(),
+        "validate_ready_pattern called for {tool}, which has no ready pattern; \
+         guard the call with has_ready_pattern() so the check isn't vacuous"
+    );
     let screen_text: String = screen["lines"]
         .as_array()
         .unwrap()
@@ -588,6 +677,9 @@ fn run_pty_test(tool: &str) {
         "claude" => " --model haiku",
         "codex" => " --model gpt-5.4-mini",
         "gemini" => " --model gemini-2.5-flash-lite",
+        // `auto` is the only model guaranteed to launch across cursor plan tiers
+        // (named models error on free plans).
+        "cursor" => " --model auto",
         _ => "",
     };
     let out = hcom(&format!("--go 1 {tool}{model_flag}"));
@@ -666,12 +758,19 @@ fn run_pty_test(tool: &str) {
     logln!(log, "\n[Validate] Initial screen state for {tool}...");
     validate_screen_schema(&screen);
     logln!(log, "  OK: Schema valid");
-    validate_ready_pattern(&screen, tool);
-    logln!(
-        log,
-        "  OK: Ready pattern '{}' consistent",
-        ready_pattern(tool)
-    );
+    if has_ready_pattern(tool) {
+        validate_ready_pattern(&screen, tool);
+        logln!(
+            log,
+            "  OK: Ready pattern '{}' consistent",
+            ready_pattern(tool)
+        );
+    } else {
+        logln!(
+            log,
+            "  SKIP: {tool} has no ready pattern; readiness asserted via ready/prompt_empty"
+        );
+    }
     assert_eq!(screen["ready"].as_bool(), Some(true));
     validate_prompt_consistency(&screen);
     logln!(
@@ -717,7 +816,7 @@ fn run_pty_test(tool: &str) {
             })
         },
         "delivery event",
-        Duration::from_secs(20),
+        clean_prompt_delivery_timeout(tool),
         Duration::from_secs(1),
     );
     let t_delivery = t1.elapsed();
@@ -765,6 +864,17 @@ fn run_pty_test(tool: &str) {
         Duration::from_secs(60),
         Duration::from_secs(1),
     );
+
+    // cursor only: drain the followup_message auto-continue loop to true
+    // quiescence so Phase 3 doesn't race a residual turn (see wait_for_stable_idle).
+    if tool == "cursor" {
+        wait_for_stable_idle(
+            &base_name,
+            Duration::from_secs(8),
+            Duration::from_secs(120),
+            &log,
+        );
+    }
 
     validate_delivery_events(&base_name, baseline_event, SENDER, &log);
 
@@ -832,7 +942,9 @@ fn run_pty_test(tool: &str) {
         "input_text={input_text:?}"
     );
     validate_prompt_consistency(&screen);
-    validate_ready_pattern(&screen, tool);
+    if has_ready_pattern(tool) {
+        validate_ready_pattern(&screen, tool);
+    }
     logln!(log, "  OK: Input text detected: {input_text:?}");
     log.log_screen(
         &screen,
@@ -1297,4 +1409,10 @@ fn test_pty_opencode() {
 #[ignore]
 fn test_pty_antigravity() {
     run_pty_test("antigravity");
+}
+
+#[test]
+#[ignore]
+fn test_pty_cursor() {
+    run_pty_test("cursor");
 }


### PR DESCRIPTION
## Summary

Adds first-class Cursor Agent support to hcom, including native hooks, launch and resume handling, hook-primary delivery, transcript parsing, approval-state detection, configuration, docs, and focused coverage.

The branch also incorporates the latest `main` Antigravity bootstrap fix so Cursor delivery remains additive without restoring the older Antigravity discovery-gag behavior.

## Release logistics

This PR is intentionally being squash-merged to keep the public `main` history concise while preserving the development history on `cursor-agent-integration`.

## Validation

Per release-logistics request, no new test run was performed during publication.