### PR TITLE
Add Kimi Code CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ uv tool install hcom  # or: pip install hcom
 Terminal 1:
 
 ```bash
-hcom claude   # codex / gemini / opencode / kilo / agy / cursor-agent
+hcom claude   # codex / gemini / opencode / kilo / agy / cursor-agent / kimi
 ```
 
 Terminal 2:
@@ -251,7 +251,7 @@ What you might type from a shell. Agents run their own commands that they learn 
 ### Spawn
 
 ```bash
-hcom [N] claude|gemini|codex|agy|opencode|kilo|cursor-agent   # launch N agents
+hcom [N] claude|gemini|codex|agy|opencode|kilo|cursor-agent|kimi   # launch N agents
 hcom r <name|session_id>                # resume agent
 hcom f <name|session_id>                # fork session
 hcom kill <name|tag:T|all>              # kill + close terminal pane

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -63,10 +63,10 @@ You MUST use `hcom <cmd+flags> --name {instance_name}` for all hcom commands:
   Filters (same flag=OR, different=AND): --agent NAME | --type message|status|life | --status listening|active|blocked | --cmd PATTERN (contains, ^prefix, =exact) | --file PATH (*.py for glob, file.py for contains)
   Event-based notifications, watch agents, subscribe, react: events sub [filters] | --help
 - Handoff context: bundle prepare
-- Spawn agents: [num] <claude|gemini|codex|opencode|kilo|antigravity|agy|cursor> [--tag labelOrGroup] [--terminal tmux|kitty|wezterm|etc]
+- Spawn agents: [num] <claude|gemini|codex|opencode|kilo|antigravity|agy|cursor|kimi> [--tag labelOrGroup] [--terminal tmux|kitty|wezterm|etc]
   Example: `hcom 1 claude --tag cool` -> automatic <hcom> msg when ready -> send it task via hcom send
   Resume: hcom r <name> [args] | Fork: hcom f <name> [args] | Kill: hcom kill <name(s)>
-  background, set prompt, system, forward args: <claude|gemini|codex|opencode|kilo|agy|cursor> --help
+  background, set prompt, system, forward args: <claude|gemini|codex|opencode|kilo|agy|cursor|kimi> --help
 - Run workflows: run <script> [args] [--help]
   {scripts}
 - View agent screen: term [name] | inject text/enter: term inject <name> ['text'] [--enter]
@@ -441,7 +441,8 @@ pub fn get_bootstrap(
             || tool == "gemini"
             || tool == "opencode"
             || tool == "kilo"
-            || tool == "antigravity")
+            || tool == "antigravity"
+            || tool == "kimi")
             && ctx.is_launched)
     {
         parts.push(DELIVERY_AUTO);

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -102,6 +102,11 @@ pub const CONFIG_KEYS: &[(&str, &str, &str)] = &[
         "string",
     ),
     (
+        "HCOM_KIMI_ARGS",
+        "Default args for kimi on launch",
+        "string",
+    ),
+    (
         "HCOM_CODEX_SANDBOX_MODE",
         "Codex permission profile (workspace | untrusted | danger-full-access | none)",
         "string",
@@ -197,6 +202,7 @@ fn toml_path_for_key(field_name: &str) -> Option<&'static str> {
         "opencode_args" => Some("launch.opencode.args"),
         "kilo_args" => Some("launch.kilo.args"),
         "cursor_args" => Some("launch.cursor.args"),
+        "kimi_args" => Some("launch.kimi.args"),
         "relay" => Some("relay.url"),
         "relay_id" => Some("relay.id"),
         "relay_token" => Some("relay.token"),
@@ -1491,7 +1497,7 @@ Example:
   # hcom send \"@$HCOM_NAME completed task\"
 
 Notes:
-  - Only affects hcom-launched instances (hcom N claude/gemini/codex/opencode/kilo/agy/cursor)
+  - Only affects hcom-launched instances (hcom N claude/gemini/codex/opencode/kilo/agy/cursor/kimi)
   - Variable name must be a valid shell identifier
   - Works alongside HCOM_PROCESS_ID (always set) for identity",
         ),
@@ -1522,6 +1528,16 @@ HCOM_CURSOR_ARGS - Default args passed to cursor-agent on launch
 
 Example: hcom config cursor_args \"--model auto\"
 Clear:   hcom config cursor_args \"\"
+
+Prepended to launch-time cli args.",
+        ),
+
+        "HCOM_KIMI_ARGS" => Some(
+            "\
+HCOM_KIMI_ARGS - Default args passed to kimi on launch
+
+Example: hcom config kimi_args \"--model kimi-k2.6\"
+Clear:   hcom config kimi_args \"\"
 
 Prepended to launch-time cli args.",
         ),

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -191,7 +191,7 @@ const LIST_HELP: &[HelpEntry] = &[
     ),
     (
         "",
-        "[claude] [gemini] [codex] [opencode] [kilo] [antigravity] [cursor]  vanilla (hooks only)",
+        "[claude] [gemini] [codex] [opencode] [kilo] [antigravity] [cursor] [kimi]  vanilla (hooks only)",
     ),
     ("", "[AD-HOC]                              manual polling"),
 ];
@@ -443,7 +443,7 @@ const RESET_HELP: &[HelpEntry] = &[
     ),
     (
         "",
-        "  HCOM_DIR=$PWD/.hcom -> $PWD/.claude, .gemini, .codex, .opencode, .kilo, .antigravity, .cursor",
+        "  HCOM_DIR=$PWD/.hcom -> $PWD/.claude, .gemini, .codex, .opencode, .kilo, .antigravity, .cursor, .kimi",
     ),
     ("", ""),
     ("", "To remove local setup:"),
@@ -477,7 +477,7 @@ const CONFIG_HELP: &[HelpEntry] = &[
         "Subagent keep-alive seconds after task",
     ),
     (
-        "  claude_args / gemini_args / codex_args / opencode_args / kilo_args / cursor_args",
+        "  claude_args / gemini_args / codex_args / opencode_args / kilo_args / cursor_args / kimi_args",
         "",
     ),
     ("  auto_approve", "Auto-approve safe hcom commands"),
@@ -545,7 +545,7 @@ const TRANSCRIPT_HELP: &[HelpEntry] = &[
     ("  --limit N", "Max results (default: 20)"),
     (
         "  --agent TYPE",
-        "Filter: claude | gemini | codex | opencode | kilo",
+        "Filter: claude | gemini | codex | opencode | kilo | kimi",
     ),
     (
         "  --exclude-self",
@@ -613,11 +613,11 @@ const HOOKS_HELP: &[HelpEntry] = &[
     ("hooks status", "Same as above"),
     (
         "hooks add [tool]",
-        "Add hooks (claude | gemini | codex | opencode | kilo | antigravity | cursor | all)",
+        "Add hooks (claude | gemini | codex | opencode | kilo | antigravity | cursor | kimi | all)",
     ),
     (
         "hooks remove [tool]",
-        "Remove hooks (claude | gemini | codex | opencode | kilo | antigravity | cursor | all)",
+        "Remove hooks (claude | gemini | codex | opencode | kilo | antigravity | cursor | kimi | all)",
     ),
     ("", ""),
     (
@@ -858,6 +858,7 @@ pub const COMMAND_NAMES: &[&str] = &[
     "agy",
     "cursor",
     "cursor-agent",
+    "kimi",
 ];
 
 /// Get the top-level help text as a String.
@@ -870,9 +871,9 @@ Usage:\n\
   hcom <command>                        Run command\n\
 \n\
 Launch:\n\
-  hcom [N] claude|gemini|codex|opencode|kilo|agy|cursor-agent [flags] [tool-args]\n\
+  hcom [N] claude|gemini|codex|opencode|kilo|agy|cursor-agent|kimi [flags] [tool-args]\n\
   hcom r <name>                         Resume stopped agent\n\
-  hcom f <name>                         Fork agent session (claude/codex/opencode/kilo)\n\
+  hcom f <name>                         Fork agent session (claude/codex/opencode/kilo/kimi)\n\
   hcom kill <name(s)|tag:T|all>         Kill + close terminal pane\n\
 \n\
 Commands:\n\
@@ -960,14 +961,14 @@ pub fn get_command_help(name: &str) -> String {
             "Adopting by UUID or thread-name reclaims the original hcom\n\
              identity if one existed; otherwise a new identity is assigned.\n\
              CWD is recovered from the session's transcript/DB.",
-            "hcom f <target>                   Fork an agent session (claude/codex/opencode/kilo)",
+            "hcom f <target>                   Fork an agent session (claude/codex/opencode/kilo/kimi)",
         );
     }
     if name == "f" || name == "fork" {
         return resume_fork_help(
             "hcom f <target> [tool-args...]    Fork an agent session (active or stopped)",
             "Creates a new agent that continues from the forked session.\n\
-             Supported tools: claude, codex, opencode, kilo. (gemini does not fork.)\n\
+             Supported tools: claude, codex, opencode, kilo, kimi. (gemini does not fork.)\n\
              Remote fork (`:<device>`) requires --dir to pin the target cwd.",
             "hcom r <target>                   Resume a stopped agent",
         );
@@ -1090,6 +1091,7 @@ mod tests {
             "opencode",
             "agy",
             "antigravity",
+            "kimi",
         ];
         for cmd in commands {
             let help = get_command_help(cmd);
@@ -1159,9 +1161,9 @@ mod tests {
     #[test]
     fn top_level_help_scopes_fork_to_supported_tools() {
         let help = get_help_text();
-        assert!(help.contains("claude|gemini|codex|opencode|kilo|agy"));
+        assert!(help.contains("claude|gemini|codex|opencode|kilo|agy|cursor-agent|kimi"));
         assert!(help.contains(
-            "hcom f <name>                         Fork agent session (claude/codex/opencode/kilo)"
+            "hcom f <name>                         Fork agent session (claude/codex/opencode/kilo/kimi)"
         ));
     }
 }

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -27,6 +27,7 @@ pub(crate) const HOOK_TOOLS: &[&str] = &[
     "kilo",
     "antigravity",
     "cursor",
+    "kimi",
 ];
 
 /// Refresh permission state for hook integrations that are already installed.
@@ -101,7 +102,7 @@ fn cmd_hooks_add(argv: &[String]) -> i32 {
         vec![argv[0].as_str()]
     } else {
         eprintln!("Error: Unknown tool: {}", argv[0]);
-        eprintln!("Valid options: claude, gemini, codex, opencode, kilo, antigravity, cursor, all");
+        eprintln!("Valid options: claude, gemini, codex, opencode, kilo, antigravity, cursor, kimi, all");
         return 1;
     };
 
@@ -168,6 +169,7 @@ fn cmd_hooks_add(argv: &[String]) -> i32 {
                 "kilo" => "Kilo Code",
                 "antigravity" => "Antigravity",
                 "cursor" => "Cursor Agent",
+                "kimi" => "Kimi Code",
                 other => other,
             };
             println!("Restart {tool_name} to activate hooks.");
@@ -188,7 +190,7 @@ pub fn cmd_hooks_remove(argv: &[String]) -> i32 {
         vec![argv[0].as_str()]
     } else {
         eprintln!("Error: Unknown tool: {}", argv[0]);
-        eprintln!("Valid options: claude, gemini, codex, opencode, kilo, antigravity, cursor, all");
+        eprintln!("Valid options: claude, gemini, codex, opencode, kilo, antigravity, cursor, kimi, all");
         return 1;
     };
 
@@ -249,8 +251,8 @@ pub fn cmd_hooks(_db: &HcomDb, args: &HooksArgs, _ctx: Option<&CommandContext>) 
              Usage:\n  \
              hcom hooks                  Show hook status for all tools\n  \
              hcom hooks status           Same as above\n  \
-             hcom hooks add [tool]       Add hooks (claude|gemini|codex|opencode|kilo|antigravity|cursor|all)\n  \
-             hcom hooks remove [tool]    Remove hooks (claude|gemini|codex|opencode|kilo|antigravity|cursor|all)\n\n\
+             hcom hooks add [tool]       Add hooks (claude|gemini|codex|opencode|kilo|antigravity|cursor|kimi|all)\n  \
+             hcom hooks remove [tool]    Remove hooks (claude|gemini|codex|opencode|kilo|antigravity|cursor|kimi|all)\n\n\
              Examples:\n  \
              hcom hooks add claude       Add Claude Code hooks only\n  \
              hcom hooks add              Auto-detect tool or add all\n  \

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -102,7 +102,9 @@ fn cmd_hooks_add(argv: &[String]) -> i32 {
         vec![argv[0].as_str()]
     } else {
         eprintln!("Error: Unknown tool: {}", argv[0]);
-        eprintln!("Valid options: claude, gemini, codex, opencode, kilo, antigravity, cursor, kimi, all");
+        eprintln!(
+            "Valid options: claude, gemini, codex, opencode, kilo, antigravity, cursor, kimi, all"
+        );
         return 1;
     };
 
@@ -190,7 +192,9 @@ pub fn cmd_hooks_remove(argv: &[String]) -> i32 {
         vec![argv[0].as_str()]
     } else {
         eprintln!("Error: Unknown tool: {}", argv[0]);
-        eprintln!("Valid options: claude, gemini, codex, opencode, kilo, antigravity, cursor, kimi, all");
+        eprintln!(
+            "Valid options: claude, gemini, codex, opencode, kilo, antigravity, cursor, kimi, all"
+        );
         return 1;
     };
 

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -437,6 +437,7 @@ pub(crate) fn print_launch_preview(preview: LaunchPreview<'_>) {
             "opencode" => preview.config.opencode_args.as_str(),
             "kilo" | "kilocode" => preview.config.kilo_args.as_str(),
             "cursor" | "cursor-agent" => preview.config.cursor_args.as_str(),
+            "kimi" => preview.config.kimi_args.as_str(),
             _ => "",
         }
     } else {

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -16,6 +16,7 @@ use crate::db::HcomDb;
 use crate::hooks::claude_args;
 use crate::hooks::codex::derive_codex_transcript_path;
 use crate::hooks::gemini::derive_gemini_transcript_path;
+use crate::hooks::kimi::derive_kimi_transcript_path;
 use crate::launcher::{self, LaunchParams, LaunchResult};
 use crate::log::log_info;
 use crate::router::GlobalFlags;
@@ -424,13 +425,13 @@ fn prepare_resume_plan_from_source(
 
     let mut merged_args = merged_cli_args.clone();
 
-    if launch_flags.headless && tool != "claude" {
-        bail!("--headless is only supported for Claude resume/fork launches");
+    if launch_flags.headless && tool != "claude" && tool != "kimi" {
+        bail!("--headless is only supported for Claude and Kimi resume/fork launches");
     }
 
     let is_headless =
         launch_flags.headless || is_background_from_args(&tool, &merged_args) || background;
-    let use_pty = tool == "claude" && !is_headless && cfg!(unix);
+    let use_pty = (tool == "claude" || tool == "kimi") && !is_headless && cfg!(unix);
 
     if tool == "claude" && is_headless {
         let spec = claude_args::resolve_claude_args(Some(&merged_args), None);
@@ -993,6 +994,7 @@ fn merge_resume_args(tool: &str, original: &[String], resume: &[String]) -> Vec<
         "opencode" | "kilo" => merge_opencode_args(original, resume),
         "antigravity" => merge_antigravity_args(original, resume),
         "cursor" => merge_cursor_args(original, resume),
+        "kimi" => merge_kimi_args(original, resume),
         _ => {
             // For unknown tools: resume args only.
             resume.to_vec()
@@ -1207,6 +1209,31 @@ fn merge_opencode_args(original: &[String], resume: &[String]) -> Vec<String> {
             continue;
         }
         if token == "--fork" || token.starts_with("--session=") || token.starts_with("--prompt=") {
+            i += 1;
+            continue;
+        }
+
+        preserved.push(token.clone());
+        i += 1;
+    }
+
+    let mut merged = resume.to_vec();
+    merged.extend(preserved);
+    merged
+}
+
+fn merge_kimi_args(original: &[String], resume: &[String]) -> Vec<String> {
+    let mut preserved = Vec::new();
+    let mut i = 0;
+
+    while i < original.len() {
+        let token = &original[i];
+
+        if token == "--resume" || token == "--fork" {
+            i += 1;
+            continue;
+        }
+        if token.starts_with("--resume=") || token.starts_with("--fork=") {
             i += 1;
             continue;
         }
@@ -1593,6 +1620,12 @@ fn find_session_on_disk(session_id: &str) -> Option<(String, Option<String>)> {
         return Some((tool, Some(path)));
     }
 
+    // 6. Kimi
+    if let Some(path) = derive_kimi_transcript_path(session_id) {
+        let tool = detect_agent_type(&path).to_string();
+        return Some((tool, Some(path)));
+    }
+
     None
 }
 
@@ -1671,6 +1704,7 @@ fn extract_cwd_from_transcript(path: &str, tool: &str) -> Option<String> {
         }),
         "gemini" => recover_gemini_cwd(path),
         "cursor" => recover_cursor_cwd(path),
+        "kimi" => None, // Kimi context.jsonl does not store cwd
         _ => None,
     }
 }

--- a/src/commands/transcript.rs
+++ b/src/commands/transcript.rs
@@ -72,7 +72,7 @@ pub struct TranscriptSearchArgs {
     /// Max results (default: 20)
     #[arg(long, default_value = "20")]
     pub limit: usize,
-    /// Filter by agent type (claude, gemini, codex, opencode, kilo)
+    /// Filter by agent type (claude, gemini, codex, opencode, kilo, kimi)
     #[arg(long)]
     pub agent: Option<String>,
 }
@@ -139,6 +139,8 @@ pub(crate) fn detect_agent_type(path: &str) -> &str {
         "opencode"
     } else if lower.contains("kilo") {
         "kilo"
+    } else if lower.contains("kimi") {
+        "kimi"
     } else {
         "unknown"
     }
@@ -1374,6 +1376,10 @@ mod tests {
             (
                 "/home/user/.cursor/projects/x/agent-transcripts/abc/abc.jsonl",
                 "cursor",
+            ),
+            (
+                "/home/user/.kimi/sessions/abc123/def456/context.jsonl",
+                "kimi",
             ),
         ];
         let expected: std::collections::HashSet<&str> =

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,7 @@ const TOML_KEY_MAP: &[(&str, &str)] = &[
     ("opencode_args", "launch.opencode.args"),
     ("kilo_args", "launch.kilo.args"),
     ("cursor_args", "launch.cursor.args"),
+    ("kimi_args", "launch.kimi.args"),
     ("relay", "relay.url"),
     ("relay_id", "relay.id"),
     ("relay_token", "relay.token"),
@@ -123,6 +124,7 @@ const FIELD_TO_ENV: &[(&str, &str)] = &[
     ("opencode_args", "HCOM_OPENCODE_ARGS"),
     ("kilo_args", "HCOM_KILO_ARGS"),
     ("cursor_args", "HCOM_CURSOR_ARGS"),
+    ("kimi_args", "HCOM_KIMI_ARGS"),
     ("relay", "HCOM_RELAY"),
     ("relay_id", "HCOM_RELAY_ID"),
     ("relay_token", "HCOM_RELAY_TOKEN"),
@@ -231,6 +233,7 @@ pub struct HcomConfig {
     pub opencode_args: String,
     pub kilo_args: String,
     pub cursor_args: String,
+    pub kimi_args: String,
     pub codex_sandbox_mode: String,
     pub gemini_system_prompt: String,
     pub codex_system_prompt: String,
@@ -260,6 +263,7 @@ impl Default for HcomConfig {
             opencode_args: String::new(),
             kilo_args: String::new(),
             cursor_args: String::new(),
+            kimi_args: String::new(),
             codex_sandbox_mode: "workspace".to_string(),
             gemini_system_prompt: String::new(),
             codex_system_prompt: String::new(),
@@ -351,6 +355,7 @@ impl HcomConfig {
             ("opencode_args", &self.opencode_args),
             ("kilo_args", &self.kilo_args),
             ("cursor_args", &self.cursor_args),
+            ("kimi_args", &self.kimi_args),
         ] {
             if !value.is_empty()
                 && let Err(e) = shell_words::split(value)
@@ -411,6 +416,7 @@ impl HcomConfig {
             "opencode_args" => Some(self.opencode_args.clone()),
             "kilo_args" => Some(self.kilo_args.clone()),
             "cursor_args" => Some(self.cursor_args.clone()),
+            "kimi_args" => Some(self.kimi_args.clone()),
             "codex_sandbox_mode" => Some(self.codex_sandbox_mode.clone()),
             "gemini_system_prompt" => Some(self.gemini_system_prompt.clone()),
             "codex_system_prompt" => Some(self.codex_system_prompt.clone()),
@@ -452,6 +458,7 @@ impl HcomConfig {
             "opencode_args" => self.opencode_args = value.to_string(),
             "kilo_args" => self.kilo_args = value.to_string(),
             "cursor_args" => self.cursor_args = value.to_string(),
+            "kimi_args" => self.kimi_args = value.to_string(),
             "codex_sandbox_mode" => {
                 // Normalize legacy value
                 self.codex_sandbox_mode = if value == "full-auto" {

--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -535,6 +535,10 @@ impl ToolConfig {
     pub fn cursor() -> Self {
         Self::for_tool(crate::tool::Tool::Cursor)
     }
+    #[cfg(test)]
+    pub fn kimi() -> Self {
+        Self::for_tool(crate::tool::Tool::Kimi)
+    }
 }
 
 /// Gate evaluation result
@@ -1389,7 +1393,7 @@ pub fn run_delivery_loop(
                         let cols = state.screen.read().map(|s| s.cols).unwrap_or(80);
                         let input_box_width = (cols as usize).saturating_sub(15).max(10);
                         let text = match parsed_tool {
-                            Some(Tool::Claude) | Some(Tool::Codex) | Some(Tool::Cursor) => {
+                            Some(Tool::Claude) | Some(Tool::Codex) | Some(Tool::Cursor) | Some(Tool::Kimi) => {
                                 "<hcom>".to_string()
                             }
                             _ => build_wake_inject_text(db, &current_name, input_box_width),

--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -535,10 +535,6 @@ impl ToolConfig {
     pub fn cursor() -> Self {
         Self::for_tool(crate::tool::Tool::Cursor)
     }
-    #[cfg(test)]
-    pub fn kimi() -> Self {
-        Self::for_tool(crate::tool::Tool::Kimi)
-    }
 }
 
 /// Gate evaluation result
@@ -1393,9 +1389,8 @@ pub fn run_delivery_loop(
                         let cols = state.screen.read().map(|s| s.cols).unwrap_or(80);
                         let input_box_width = (cols as usize).saturating_sub(15).max(10);
                         let text = match parsed_tool {
-                            Some(Tool::Claude) | Some(Tool::Codex) | Some(Tool::Cursor) | Some(Tool::Kimi) => {
-                                "<hcom>".to_string()
-                            }
+                            Some(Tool::Claude) | Some(Tool::Codex) | Some(Tool::Cursor)
+                            | Some(Tool::Kimi) => "<hcom>".to_string(),
                             _ => build_wake_inject_text(db, &current_name, input_box_width),
                         };
 

--- a/src/hooks/kimi.rs
+++ b/src/hooks/kimi.rs
@@ -19,7 +19,7 @@ use crate::instances;
 use crate::log;
 use crate::paths;
 use crate::shared::context::HcomContext;
-use crate::shared::{ST_ACTIVE, ST_LISTENING};
+use crate::shared::{ST_ACTIVE, ST_BLOCKED, ST_LISTENING};
 
 const HOOK_TIMEOUT_SECS: i64 = 30;
 const KIMI_HOOK_COMMANDS: &[(&str, &str)] = &[
@@ -27,6 +27,8 @@ const KIMI_HOOK_COMMANDS: &[(&str, &str)] = &[
     ("UserPromptSubmit", "kimi-userpromptsubmit"),
     ("PreToolUse", "kimi-pretooluse"),
     ("PostToolUse", "kimi-posttooluse"),
+    ("PermissionRequest", "kimi-permissionrequest"),
+    ("PermissionResult", "kimi-permissionresult"),
     ("Stop", "kimi-stop"),
     ("SessionEnd", "kimi-sessionend"),
     ("SubagentStart", "kimi-subagentstart"),
@@ -66,8 +68,11 @@ pub enum SetupError {
 
 // ── Config path helpers ─────────────────────────────────────────────────
 
+/// Kimi's data root: config.toml, sessions, credentials all live here.
+/// Overridden via `KIMI_CODE_HOME` (kimi does not honor any other dir variable),
+/// defaulting to `~/.kimi-code`.
 fn kimi_config_dir() -> PathBuf {
-    if let Ok(dir) = std::env::var("KIMI_CONFIG_DIR")
+    if let Ok(dir) = std::env::var("KIMI_CODE_HOME")
         && !dir.is_empty()
     {
         return PathBuf::from(dir);
@@ -86,11 +91,14 @@ fn build_kimi_hook_command(command: &str) -> String {
 }
 
 fn is_hcom_kimi_command(command: &str) -> bool {
-    let prefix = build_kimi_hook_command("");
-    command.starts_with(&prefix)
-        && KIMI_HOOK_COMMANDS
-            .iter()
-            .any(|(_, suffix)| command.trim() == format!("{}{}", prefix.trim_end(), suffix))
+    // Compare against the canonical command string for each hook suffix.
+    // (An earlier `format!("{}{}", prefix.trim_end(), suffix)` dropped the space
+    // between prefix and suffix, so this never matched — causing every re-setup
+    // to duplicate all hcom hooks instead of replacing them.)
+    let trimmed = command.trim();
+    KIMI_HOOK_COMMANDS
+        .iter()
+        .any(|(_, suffix)| trimmed == build_kimi_hook_command(suffix))
 }
 
 // ── TOML manipulation ───────────────────────────────────────────────────
@@ -104,10 +112,12 @@ fn read_toml_document(path: &Path) -> Result<DocumentMut, SetupError> {
             path: path.to_path_buf(),
             source,
         })?;
-    content.parse::<DocumentMut>().map_err(|source| SetupError::ExistingParseFailed {
-        path: path.to_path_buf(),
-        source,
-    })
+    content
+        .parse::<DocumentMut>()
+        .map_err(|source| SetupError::ExistingParseFailed {
+            path: path.to_path_buf(),
+            source,
+        })
 }
 
 fn write_toml(path: &Path, doc: &DocumentMut) -> Result<(), SetupError> {
@@ -148,7 +158,10 @@ fn merge_hcom_hooks(doc: &mut DocumentMut) {
         for (event, command_suffix) in KIMI_HOOK_COMMANDS {
             let mut table = Table::new();
             table.insert("event", toml_edit::value(*event));
-            table.insert("command", toml_edit::value(build_kimi_hook_command(command_suffix)));
+            table.insert(
+                "command",
+                toml_edit::value(build_kimi_hook_command(command_suffix)),
+            );
             table.insert("timeout", toml_edit::value(HOOK_TIMEOUT_SECS));
             arr.push(table);
         }
@@ -181,6 +194,139 @@ fn remove_hcom_hooks(doc: &mut DocumentMut) {
     }
 }
 
+// ── Permission allowlist (auto-approve hcom's own commands) ──────────────
+//
+// Kimi gates every tool call behind a permission check. Its `[[permission.rules]]`
+// are matched top-to-bottom, first match wins (config-files.md#permission). To let
+// a launched agent run its own `hcom` commands unattended — without `--yolo`, which
+// would also auto-approve unrelated tools — hcom prepends `decision = "allow"`
+// rules for its safe self-commands ahead of any user rules.
+
+/// Allow-rule patterns hcom installs (current hcom command prefix).
+fn kimi_permission_patterns() -> Vec<String> {
+    let prefix = crate::runtime_env::build_hcom_command();
+    common::SAFE_HCOM_COMMANDS
+        .iter()
+        .map(|command| format!("Bash({prefix} {command}*)"))
+        .collect()
+}
+
+/// All patterns hcom may have written (both `hcom` and `uvx hcom` prefixes), so
+/// removal/re-merge can recognize and strip stale managed rules.
+fn all_kimi_permission_patterns() -> Vec<String> {
+    let mut patterns = Vec::new();
+    for prefix in ["hcom", "uvx hcom"] {
+        for command in common::SAFE_HCOM_COMMANDS {
+            patterns.push(format!("Bash({prefix} {command}*)"));
+        }
+    }
+    patterns
+}
+
+fn is_hcom_permission_pattern(pattern: &str) -> bool {
+    all_kimi_permission_patterns()
+        .iter()
+        .any(|managed| managed == pattern)
+}
+
+/// Get a `&mut ArrayOfTables` for `[[permission.rules]]`, creating the parent
+/// `[permission]` table on demand. Returns `None` if `permission`/`rules` exist
+/// but are not tables of the expected shape (leave a user's odd config alone).
+fn permission_rules_mut(doc: &mut DocumentMut) -> Option<&mut ArrayOfTables> {
+    let permission = doc
+        .entry("permission")
+        .or_insert_with(|| Item::Table(Table::new()));
+    let Item::Table(permission) = permission else {
+        return None;
+    };
+    let rules = permission
+        .entry("rules")
+        .or_insert_with(|| Item::ArrayOfTables(ArrayOfTables::new()));
+    match rules {
+        Item::ArrayOfTables(arr) => Some(arr),
+        _ => None,
+    }
+}
+
+fn merge_hcom_permissions(doc: &mut DocumentMut) {
+    let Some(arr) = permission_rules_mut(doc) else {
+        return;
+    };
+
+    // Rebuild with hcom allow-rules first (first-match-wins ordering), then the
+    // user's existing non-hcom rules. This makes the merge idempotent and keeps
+    // hcom's allows ahead of any broad user `ask`/`deny` on `Bash`.
+    let mut rebuilt = ArrayOfTables::new();
+    for pattern in kimi_permission_patterns() {
+        let mut table = Table::new();
+        table.insert("decision", toml_edit::value("allow"));
+        table.insert("pattern", toml_edit::value(pattern));
+        table.insert("reason", toml_edit::value("hcom auto-approve"));
+        rebuilt.push(table);
+    }
+    for i in 0..arr.len() {
+        if let Some(table) = arr.get(i) {
+            let is_managed = table
+                .get("pattern")
+                .and_then(|v| v.as_str())
+                .map(is_hcom_permission_pattern)
+                .unwrap_or(false);
+            if !is_managed {
+                rebuilt.push(table.clone());
+            }
+        }
+    }
+    *arr = rebuilt;
+}
+
+fn remove_hcom_permissions(doc: &mut DocumentMut) {
+    let Some(Item::Table(permission)) = doc.get_mut("permission") else {
+        return;
+    };
+    if let Some(Item::ArrayOfTables(arr)) = permission.get_mut("rules") {
+        let mut filtered = ArrayOfTables::new();
+        for i in 0..arr.len() {
+            if let Some(table) = arr.get(i) {
+                let is_managed = table
+                    .get("pattern")
+                    .and_then(|v| v.as_str())
+                    .map(is_hcom_permission_pattern)
+                    .unwrap_or(false);
+                if !is_managed {
+                    filtered.push(table.clone());
+                }
+            }
+        }
+        *arr = filtered;
+        if arr.is_empty() {
+            permission.remove("rules");
+        }
+    }
+    if permission.is_empty() {
+        doc.remove("permission");
+    }
+}
+
+fn verify_permissions_at(path: &Path) -> bool {
+    let Ok(doc) = read_toml_document(path) else {
+        return false;
+    };
+    let Some(Item::Table(permission)) = doc.get("permission") else {
+        return false;
+    };
+    let Some(Item::ArrayOfTables(arr)) = permission.get("rules") else {
+        return false;
+    };
+    let present: Vec<&str> = (0..arr.len())
+        .filter_map(|i| arr.get(i))
+        .filter(|t| t.get("decision").and_then(|v| v.as_str()) == Some("allow"))
+        .filter_map(|t| t.get("pattern").and_then(|v| v.as_str()))
+        .collect();
+    kimi_permission_patterns()
+        .iter()
+        .all(|expected| present.iter().any(|p| p == expected))
+}
+
 fn verify_hooks_at(path: &Path) -> bool {
     let Ok(doc) = read_toml_document(path) else {
         return false;
@@ -210,34 +356,40 @@ pub fn remove_kimi_hooks() -> bool {
     match read_toml_document(&path) {
         Ok(mut doc) => {
             remove_hcom_hooks(&mut doc);
+            remove_hcom_permissions(&mut doc);
             write_toml(&path, &doc).is_ok()
         }
         Err(_) => false,
     }
 }
 
-pub fn try_setup_kimi_hooks(_include_permissions: bool) -> Result<(), SetupError> {
+pub fn try_setup_kimi_hooks(include_permissions: bool) -> Result<(), SetupError> {
     let path = get_kimi_settings_path();
     let mut doc = read_toml_document(&path)?;
     merge_hcom_hooks(&mut doc);
+    if include_permissions {
+        merge_hcom_permissions(&mut doc);
+    } else {
+        remove_hcom_permissions(&mut doc);
+    }
     write_toml(&path, &doc)?;
     if !verify_hooks_at(&path) {
+        return Err(SetupError::PostWriteVerifyFailed(path.clone()));
+    }
+    if include_permissions && !verify_permissions_at(&path) {
         return Err(SetupError::PostWriteVerifyFailed(path));
     }
     Ok(())
 }
 
-pub fn verify_kimi_hooks_installed(_check_permissions: bool) -> bool {
-    verify_hooks_at(&get_kimi_settings_path())
+pub fn verify_kimi_hooks_installed(check_permissions: bool) -> bool {
+    let path = get_kimi_settings_path();
+    verify_hooks_at(&path) && (!check_permissions || verify_permissions_at(&path))
 }
 
 // ── Instance helpers ────────────────────────────────────────────────────
 
-fn resolve_instance(
-    db: &HcomDb,
-    ctx: &HcomContext,
-    payload: &HookPayload,
-) -> Option<InstanceRow> {
+fn resolve_instance(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> Option<InstanceRow> {
     instance_binding::resolve_instance_from_binding(
         db,
         payload.session_id.as_deref(),
@@ -245,20 +397,31 @@ fn resolve_instance(
     )
 }
 
+/// Resolve a Kimi session's transcript file.
+///
+/// Kimi stores each session's wire log at:
+/// ```text
+///   $KIMI_CODE_HOME/sessions/wd_<dir>_<hash>/<session_id>/agents/main/wire.jsonl
+/// ```
+/// The working-directory bucket (`wd_*`) is unknown here, so scan the buckets
+/// for the one containing this session. `session_id` already carries the
+/// `session_` prefix (matching the on-disk directory name).
 pub fn derive_kimi_transcript_path(session_id: &str) -> Option<String> {
-    let base = dirs::home_dir()?.join(".kimi").join("sessions");
+    let base = kimi_config_dir().join("sessions");
     if !base.exists() {
         return None;
     }
-    let Ok(entries) = std::fs::read_dir(&base) else {
-        return None;
-    };
+    let entries = std::fs::read_dir(&base).ok()?;
     for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
+        let wd = entry.path();
+        if !wd.is_dir() {
             continue;
         }
-        let candidate = path.join(session_id).join("context.jsonl");
+        let candidate = wd
+            .join(session_id)
+            .join("agents")
+            .join("main")
+            .join("wire.jsonl");
         if candidate.exists() {
             return Some(candidate.to_string_lossy().to_string());
         }
@@ -352,25 +515,14 @@ fn handle_sessionstart(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) ->
     crate::runtime_env::set_terminal_title(&instance_name);
     crate::relay::worker::ensure_worker(true);
 
-    if let Ok(Some(inst)) = db.get_instance_full(&instance_name)
-        && let Some(bootstrap) =
-            common::inject_bootstrap_once(db, ctx, &instance_name, &inst, &inst.tool)
-    {
-        return HookResult::Allow {
-            additional_context: Some(bootstrap),
-            system_message: None,
-            delivery_ack: None,
-        };
-    }
-
+    // NOTE: bootstrap is intentionally NOT injected here. Kimi does not add
+    // SessionStart hook output to model context (it is an observation-only
+    // event), so bootstrapping happens on the first UserPromptSubmit instead
+    // (see handle_userpromptsubmit).
     hook_noop()
 }
 
-fn handle_userpromptsubmit(
-    db: &HcomDb,
-    ctx: &HcomContext,
-    payload: &HookPayload,
-) -> HookResult {
+fn handle_userpromptsubmit(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> HookResult {
     let instance = match resolve_instance(db, ctx, payload) {
         Some(inst) => inst,
         None => return hook_noop(),
@@ -378,11 +530,37 @@ fn handle_userpromptsubmit(
     let instance_name = &instance.name;
     update_position(db, ctx, payload, instance_name);
 
-    if let Some(prepared) = common::prepare_pending_messages(db, instance_name) {
+    // Bootstrap is delivered here, NOT at SessionStart: kimi only injects
+    // UserPromptSubmit hook output into model context — SessionStart output is
+    // not added to context (see kimi hooks docs). Prepend it to the first
+    // delivery so a launched agent learns it's on hcom.
+    //
+    // KNOWN LIMITATION (kimi 0.9.0): this makes the bootstrap *visible* — kimi
+    // wraps UserPromptSubmit output as a `<hook_result>` block in the turn,
+    // unlike codex/claude which inject it invisibly into the system prompt.
+    // Kimi has no per-instance invisible channel today: no `--system-prompt`
+    // flag, no `-c` config override, no `systemPrompt` config key, and AGENTS.md
+    // (its only invisible system-prompt source) loads from shared paths so it
+    // can't carry a per-instance name without polluting the workspace. Revisit
+    // and switch to an invisible launch-time injection (mirroring codex's
+    // developer_instructions path) if a future kimi release adds a system-prompt
+    // append flag or env var.
+    let bootstrap =
+        common::inject_bootstrap_once(db, ctx, instance_name, &instance, &instance.tool);
+    let pending = common::prepare_pending_messages(db, instance_name);
+
+    let additional_context = match (&bootstrap, &pending) {
+        (Some(boot), Some(p)) => Some(format!("{boot}\n\n{}", p.formatted)),
+        (Some(boot), None) => Some(boot.clone()),
+        (None, Some(p)) => Some(p.formatted.clone()),
+        (None, None) => None,
+    };
+
+    if let Some(additional_context) = additional_context {
         return HookResult::Allow {
-            additional_context: Some(prepared.formatted),
+            additional_context: Some(additional_context),
             system_message: None,
-            delivery_ack: Some(prepared.ack),
+            delivery_ack: pending.map(|p| p.ack),
         };
     }
 
@@ -396,19 +574,10 @@ fn handle_pretooluse(db: &HcomDb, _ctx: &HcomContext, payload: &HookPayload) -> 
     };
     let instance_name = &instance.name;
 
-    let detail = crate::hooks::family::extract_tool_detail(
-        "kimi",
-        &payload.tool_name,
-        &payload.tool_input,
-    );
+    let detail =
+        crate::hooks::family::extract_tool_detail("kimi", &payload.tool_name, &payload.tool_input);
     if !detail.is_empty() {
-        lifecycle::set_status(
-            db,
-            instance_name,
-            ST_ACTIVE,
-            &detail,
-            Default::default(),
-        );
+        lifecycle::set_status(db, instance_name, ST_ACTIVE, &detail, Default::default());
     }
 
     hook_noop()
@@ -432,6 +601,71 @@ fn handle_posttooluse(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> 
     hook_noop()
 }
 
+/// PermissionRequest (observation-only): kimi fires this just before it blocks
+/// waiting for the user to approve/reject a tool call. Mark the agent `blocked`
+/// so `hcom list` reflects the stall and the delivery gate (require_idle) holds
+/// off injecting until the user responds. `PermissionResult` clears it.
+///
+/// hcom's own `[[permission.rules]]` allow-rules mean an agent's `hcom send`
+/// etc. are auto-approved and never reach an `ask` — so this only fires for
+/// tool calls that genuinely need a human (mirrors claude's handle_permission_request).
+fn handle_permissionrequest(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> HookResult {
+    let instance = match resolve_instance(db, ctx, payload) {
+        Some(inst) => inst,
+        None => return hook_noop(),
+    };
+    let instance_name = &instance.name;
+
+    let detail =
+        crate::hooks::family::extract_tool_detail("kimi", &payload.tool_name, &payload.tool_input);
+    lifecycle::set_status(
+        db,
+        instance_name,
+        ST_BLOCKED,
+        "approval",
+        lifecycle::StatusUpdate {
+            detail: &detail,
+            ..Default::default()
+        },
+    );
+
+    hook_noop()
+}
+
+/// PermissionResult (observation-only): kimi fires this once approval resolves.
+/// In every case the agent is still mid-turn — an approved tool now runs, a
+/// declined one feeds rejection back to the model — so flip out of `blocked`
+/// back to `active`. The `Stop` hook sets `listening` when the turn actually
+/// ends. (PermissionResult carries no tool_input, so the tool name is the best
+/// available detail; mirrors claude's PostToolUse "approved:" restore.)
+///
+/// The payload's `decision` (`approved`/`rejected`/`cancelled`/`error`) drives a
+/// decision-aware context so a declined call isn't mislabeled as approved:
+/// `approved:<tool>` only when actually approved, `denied:<tool>` otherwise.
+fn handle_permissionresult(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> HookResult {
+    let instance = match resolve_instance(db, ctx, payload) {
+        Some(inst) => inst,
+        None => return hook_noop(),
+    };
+    let instance_name = &instance.name;
+
+    let decision = payload.raw.get("decision").and_then(Value::as_str);
+    let verb = if decision == Some("approved") {
+        "approved"
+    } else {
+        "denied"
+    };
+    lifecycle::set_status(
+        db,
+        instance_name,
+        ST_ACTIVE,
+        &format!("{verb}:{}", payload.tool_name),
+        Default::default(),
+    );
+
+    hook_noop()
+}
+
 fn handle_stop(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> HookResult {
     let instance = match resolve_instance(db, ctx, payload) {
         Some(inst) => inst,
@@ -440,6 +674,9 @@ fn handle_stop(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> HookRes
     let instance_name = &instance.name;
 
     if let Some(prepared) = common::prepare_pending_messages(db, instance_name) {
+        // The Stop hook delivers via Block{reason}, which cannot carry the ack
+        // back to the dispatch — commit inline so the cursor advances.
+        common::commit_delivery_ack(db, &prepared.ack);
         return HookResult::Block {
             reason: prepared.formatted,
         };
@@ -455,37 +692,20 @@ fn handle_sessionend(db: &HcomDb, _ctx: &HcomContext, payload: &HookPayload) -> 
     };
     let instance_name = &instance.name;
 
-    common::finalize_session(
-        db,
-        instance_name,
-        "sessionend",
-        None,
-    );
+    common::finalize_session(db, instance_name, "sessionend", None);
 
     hook_noop()
 }
 
-fn handle_subagentstart(
-    _db: &HcomDb,
-    _ctx: &HcomContext,
-    _payload: &HookPayload,
-) -> HookResult {
+fn handle_subagentstart(_db: &HcomDb, _ctx: &HcomContext, _payload: &HookPayload) -> HookResult {
     hook_noop()
 }
 
-fn handle_subagentstop(
-    _db: &HcomDb,
-    _ctx: &HcomContext,
-    _payload: &HookPayload,
-) -> HookResult {
+fn handle_subagentstop(_db: &HcomDb, _ctx: &HcomContext, _payload: &HookPayload) -> HookResult {
     hook_noop()
 }
 
-fn handle_notification(
-    db: &HcomDb,
-    ctx: &HcomContext,
-    payload: &HookPayload,
-) -> HookResult {
+fn handle_notification(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> HookResult {
     let instance = match resolve_instance(db, ctx, payload) {
         Some(inst) => inst,
         None => return hook_noop(),
@@ -511,14 +731,14 @@ fn hook_noop() -> HookResult {
     }
 }
 
-fn get_handler(
-    hook_name: &str,
-) -> Option<fn(&HcomDb, &HcomContext, &HookPayload) -> HookResult> {
+fn get_handler(hook_name: &str) -> Option<fn(&HcomDb, &HcomContext, &HookPayload) -> HookResult> {
     match hook_name {
         "kimi-sessionstart" => Some(handle_sessionstart),
         "kimi-userpromptsubmit" => Some(handle_userpromptsubmit),
         "kimi-pretooluse" => Some(handle_pretooluse),
         "kimi-posttooluse" => Some(handle_posttooluse),
+        "kimi-permissionrequest" => Some(handle_permissionrequest),
+        "kimi-permissionresult" => Some(handle_permissionresult),
         "kimi-stop" => Some(handle_stop),
         "kimi-sessionend" => Some(handle_sessionend),
         "kimi-subagentstart" => Some(handle_subagentstart),
@@ -622,6 +842,7 @@ pub fn dispatch_kimi_hook(hook_name: &str) -> i32 {
     match result {
         HookResult::Allow {
             additional_context: Some(ctx),
+            delivery_ack,
             ..
         } => {
             let output = json!({
@@ -630,6 +851,12 @@ pub fn dispatch_kimi_hook(hook_name: &str) -> i32 {
                 }
             });
             println!("{}", output);
+            // Advance the delivery cursor only after the message is handed to
+            // kimi (stdout). Without this the PTY delivery loop never observes
+            // the cursor advancing and keeps re-injecting `<hcom>`.
+            if let Some(ack) = delivery_ack {
+                common::commit_delivery_ack(&db, &ack);
+            }
         }
         HookResult::Block { reason } => {
             let output = json!({
@@ -655,4 +882,178 @@ pub fn dispatch_kimi_hook(hook_name: &str) -> i32 {
     );
 
     exit_code
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rules(doc: &DocumentMut) -> &ArrayOfTables {
+        match doc.get("permission").and_then(|p| p.get("rules")) {
+            Some(Item::ArrayOfTables(arr)) => arr,
+            _ => panic!("expected [[permission.rules]]"),
+        }
+    }
+
+    #[test]
+    fn is_hcom_kimi_command_matches_canonical_commands() {
+        // Each installed hook command must be recognized as hcom-managed, else
+        // re-setup duplicates them instead of replacing them.
+        for (_, suffix) in KIMI_HOOK_COMMANDS {
+            let cmd = build_kimi_hook_command(suffix);
+            assert!(
+                is_hcom_kimi_command(&cmd),
+                "should recognize installed hcom hook command: {cmd}"
+            );
+        }
+        assert!(!is_hcom_kimi_command("echo hello"));
+        assert!(!is_hcom_kimi_command("hcom send @x -- hi"));
+    }
+
+    #[test]
+    fn permission_events_are_registered_and_dispatchable() {
+        // Both observation-only permission events must be (a) installed into
+        // config.toml via KIMI_HOOK_COMMANDS and (b) routable to a handler,
+        // else the blocked-on-approval status transition never fires.
+        for (event, suffix) in [
+            ("PermissionRequest", "kimi-permissionrequest"),
+            ("PermissionResult", "kimi-permissionresult"),
+        ] {
+            assert!(
+                KIMI_HOOK_COMMANDS.contains(&(event, suffix)),
+                "{event}/{suffix} must be in KIMI_HOOK_COMMANDS"
+            );
+            assert!(
+                get_handler(suffix).is_some(),
+                "{suffix} must resolve to a handler"
+            );
+        }
+        // The spec's routing list (Tool::from_hook_name) must agree, or the
+        // installed hook command would never reach dispatch_kimi_hook.
+        let spec_names = crate::tool::Tool::Kimi.hooks();
+        assert!(spec_names.contains(&"kimi-permissionrequest"));
+        assert!(spec_names.contains(&"kimi-permissionresult"));
+    }
+
+    #[test]
+    fn merge_hooks_is_idempotent() {
+        let mut doc = DocumentMut::new();
+        merge_hcom_hooks(&mut doc);
+        let first = match doc.get("hooks") {
+            Some(Item::ArrayOfTables(arr)) => arr.len(),
+            _ => panic!("expected [[hooks]]"),
+        };
+        merge_hcom_hooks(&mut doc);
+        let second = match doc.get("hooks") {
+            Some(Item::ArrayOfTables(arr)) => arr.len(),
+            _ => panic!("expected [[hooks]]"),
+        };
+        assert_eq!(first, KIMI_HOOK_COMMANDS.len());
+        assert_eq!(
+            first, second,
+            "re-merging hooks must not duplicate existing hcom hooks"
+        );
+    }
+
+    #[test]
+    fn merge_prepends_allow_rules_for_all_safe_commands() {
+        let mut doc = DocumentMut::new();
+        merge_hcom_permissions(&mut doc);
+
+        let arr = rules(&doc);
+        let expected = kimi_permission_patterns();
+        // Our allow-rules come first, one per safe command, all decision=allow.
+        assert!(arr.len() >= expected.len());
+        for (i, pat) in expected.iter().enumerate() {
+            let table = arr.get(i).expect("rule present");
+            assert_eq!(
+                table.get("decision").and_then(|v| v.as_str()),
+                Some("allow")
+            );
+            assert_eq!(
+                table.get("pattern").and_then(|v| v.as_str()),
+                Some(pat.as_str())
+            );
+        }
+        assert!(verify_permissions_at_doc(&doc));
+    }
+
+    #[test]
+    fn merge_is_idempotent_and_keeps_user_rules_after_ours() {
+        let mut doc: DocumentMut = r#"
+[[permission.rules]]
+decision = "ask"
+pattern = "Bash"
+"#
+        .parse()
+        .unwrap();
+
+        merge_hcom_permissions(&mut doc);
+        let after_first = rules(&doc).len();
+        merge_hcom_permissions(&mut doc);
+        let after_second = rules(&doc).len();
+        assert_eq!(
+            after_first, after_second,
+            "re-merging must not duplicate managed rules"
+        );
+
+        // The user's broad `ask Bash` rule survives and sits AFTER our allows,
+        // so first-match-wins still auto-approves hcom commands.
+        let arr = rules(&doc);
+        let last = arr.get(arr.len() - 1).unwrap();
+        assert_eq!(last.get("decision").and_then(|v| v.as_str()), Some("ask"));
+        assert_eq!(last.get("pattern").and_then(|v| v.as_str()), Some("Bash"));
+        assert!(verify_permissions_at_doc(&doc));
+    }
+
+    #[test]
+    fn remove_strips_only_managed_rules() {
+        let mut doc: DocumentMut = r#"
+[[permission.rules]]
+decision = "deny"
+pattern = "Bash(rm -rf*)"
+"#
+        .parse()
+        .unwrap();
+
+        merge_hcom_permissions(&mut doc);
+        remove_hcom_permissions(&mut doc);
+
+        // The user's deny rule remains; managed allows are gone.
+        let arr = rules(&doc);
+        assert_eq!(arr.len(), 1);
+        let only = arr.get(0).unwrap();
+        assert_eq!(only.get("decision").and_then(|v| v.as_str()), Some("deny"));
+        assert!(!verify_permissions_at_doc(&doc));
+    }
+
+    #[test]
+    fn remove_drops_empty_permission_table() {
+        let mut doc = DocumentMut::new();
+        merge_hcom_permissions(&mut doc);
+        remove_hcom_permissions(&mut doc);
+        assert!(
+            doc.get("permission").is_none(),
+            "permission table should be removed when no rules remain"
+        );
+    }
+
+    // Mirror of verify_permissions_at but against an in-memory document so the
+    // tests never touch the real ~/.kimi-code/config.toml.
+    fn verify_permissions_at_doc(doc: &DocumentMut) -> bool {
+        let Some(Item::Table(permission)) = doc.get("permission") else {
+            return false;
+        };
+        let Some(Item::ArrayOfTables(arr)) = permission.get("rules") else {
+            return false;
+        };
+        let present: Vec<&str> = (0..arr.len())
+            .filter_map(|i| arr.get(i))
+            .filter(|t| t.get("decision").and_then(|v| v.as_str()) == Some("allow"))
+            .filter_map(|t| t.get("pattern").and_then(|v| v.as_str()))
+            .collect();
+        kimi_permission_patterns()
+            .iter()
+            .all(|expected| present.iter().any(|p| p == expected))
+    }
 }

--- a/src/hooks/kimi.rs
+++ b/src/hooks/kimi.rs
@@ -1,0 +1,658 @@
+//! Kimi Code CLI hook handlers and config.toml management.
+//!
+//! Kimi hooks are declared in `~/.kimi-code/config.toml` under `[[hooks]]` array
+//! tables. Each hook receives JSON on stdin and uses exit code / stdout for
+//! results (0 = allow, 2 = block).
+
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use serde_json::{Value, json};
+use toml_edit::{ArrayOfTables, DocumentMut, Item, Table};
+
+use crate::db::{HcomDb, InstanceRow};
+use crate::hooks::{HookPayload, HookResult, common};
+use crate::instance_binding;
+use crate::instance_lifecycle as lifecycle;
+use crate::instances;
+use crate::log;
+use crate::paths;
+use crate::shared::context::HcomContext;
+use crate::shared::{ST_ACTIVE, ST_LISTENING};
+
+const HOOK_TIMEOUT_SECS: i64 = 30;
+const KIMI_HOOK_COMMANDS: &[(&str, &str)] = &[
+    ("SessionStart", "kimi-sessionstart"),
+    ("UserPromptSubmit", "kimi-userpromptsubmit"),
+    ("PreToolUse", "kimi-pretooluse"),
+    ("PostToolUse", "kimi-posttooluse"),
+    ("Stop", "kimi-stop"),
+    ("SessionEnd", "kimi-sessionend"),
+    ("SubagentStart", "kimi-subagentstart"),
+    ("SubagentStop", "kimi-subagentstop"),
+    ("Notification", "kimi-notification"),
+];
+
+#[derive(Debug, thiserror::Error)]
+pub enum SetupError {
+    #[error("existing Kimi config at {} could not be read: {source}", path.display())]
+    ExistingReadFailed {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("existing Kimi config at {} is not valid TOML: {source}", path.display())]
+    ExistingParseFailed {
+        path: PathBuf,
+        #[source]
+        source: toml_edit::TomlError,
+    },
+    #[error("failed to create Kimi config directory {}: {source}", path.display())]
+    DirCreateFailed {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("atomic write to {} failed: {source}", path.display())]
+    AtomicWriteFailed {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("post-write Kimi hook verification failed for {}", .0.display())]
+    PostWriteVerifyFailed(PathBuf),
+}
+
+// ── Config path helpers ─────────────────────────────────────────────────
+
+fn kimi_config_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("KIMI_CONFIG_DIR")
+        && !dir.is_empty()
+    {
+        return PathBuf::from(dir);
+    }
+    dirs::home_dir().unwrap_or_default().join(".kimi-code")
+}
+
+pub fn get_kimi_settings_path() -> PathBuf {
+    kimi_config_dir().join("config.toml")
+}
+
+fn build_kimi_hook_command(command: &str) -> String {
+    let mut parts = crate::runtime_env::get_hcom_prefix();
+    parts.push(command.to_string());
+    parts.join(" ")
+}
+
+fn is_hcom_kimi_command(command: &str) -> bool {
+    let prefix = build_kimi_hook_command("");
+    command.starts_with(&prefix)
+        && KIMI_HOOK_COMMANDS
+            .iter()
+            .any(|(_, suffix)| command.trim() == format!("{}{}", prefix.trim_end(), suffix))
+}
+
+// ── TOML manipulation ───────────────────────────────────────────────────
+
+fn read_toml_document(path: &Path) -> Result<DocumentMut, SetupError> {
+    if !path.exists() {
+        return Ok(DocumentMut::new());
+    }
+    let content =
+        std::fs::read_to_string(path).map_err(|source| SetupError::ExistingReadFailed {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    content.parse::<DocumentMut>().map_err(|source| SetupError::ExistingParseFailed {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn write_toml(path: &Path, doc: &DocumentMut) -> Result<(), SetupError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| SetupError::DirCreateFailed {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let content = doc.to_string();
+    paths::atomic_write_io(path, &content).map_err(|source| SetupError::AtomicWriteFailed {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn merge_hcom_hooks(doc: &mut DocumentMut) {
+    let hooks_item = doc
+        .entry("hooks")
+        .or_insert_with(|| Item::ArrayOfTables(ArrayOfTables::new()));
+
+    if let Item::ArrayOfTables(arr) = hooks_item {
+        let mut filtered = ArrayOfTables::new();
+        for i in 0..arr.len() {
+            if let Some(table) = arr.get(i) {
+                let keep = table
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .map(|cmd| !is_hcom_kimi_command(cmd))
+                    .unwrap_or(true);
+                if keep {
+                    filtered.push(table.clone());
+                }
+            }
+        }
+        *arr = filtered;
+
+        for (event, command_suffix) in KIMI_HOOK_COMMANDS {
+            let mut table = Table::new();
+            table.insert("event", toml_edit::value(*event));
+            table.insert("command", toml_edit::value(build_kimi_hook_command(command_suffix)));
+            table.insert("timeout", toml_edit::value(HOOK_TIMEOUT_SECS));
+            arr.push(table);
+        }
+    }
+}
+
+fn remove_hcom_hooks(doc: &mut DocumentMut) {
+    let Some(hooks_item) = doc.get_mut("hooks") else {
+        return;
+    };
+    let Item::ArrayOfTables(arr) = hooks_item else {
+        return;
+    };
+    let mut filtered = ArrayOfTables::new();
+    for i in 0..arr.len() {
+        if let Some(table) = arr.get(i) {
+            let keep = table
+                .get("command")
+                .and_then(|v| v.as_str())
+                .map(|cmd| !is_hcom_kimi_command(cmd))
+                .unwrap_or(true);
+            if keep {
+                filtered.push(table.clone());
+            }
+        }
+    }
+    *arr = filtered;
+    if arr.is_empty() {
+        doc.remove("hooks");
+    }
+}
+
+fn verify_hooks_at(path: &Path) -> bool {
+    let Ok(doc) = read_toml_document(path) else {
+        return false;
+    };
+    let Some(Item::ArrayOfTables(arr)) = doc.get("hooks") else {
+        return false;
+    };
+    KIMI_HOOK_COMMANDS.iter().all(|(event, command_suffix)| {
+        let expected_cmd = build_kimi_hook_command(command_suffix);
+        (0..arr.len()).any(|i| {
+            arr.get(i).is_some_and(|table| {
+                table.get("event").and_then(|v| v.as_str()) == Some(*event)
+                    && table.get("command").and_then(|v| v.as_str()) == Some(&expected_cmd)
+                    && table.get("timeout").and_then(|v| v.as_integer()).is_some()
+            })
+        })
+    })
+}
+
+// ── Public setup / verify / remove ──────────────────────────────────────
+
+pub fn remove_kimi_hooks() -> bool {
+    let path = get_kimi_settings_path();
+    if !path.exists() {
+        return true;
+    }
+    match read_toml_document(&path) {
+        Ok(mut doc) => {
+            remove_hcom_hooks(&mut doc);
+            write_toml(&path, &doc).is_ok()
+        }
+        Err(_) => false,
+    }
+}
+
+pub fn try_setup_kimi_hooks(_include_permissions: bool) -> Result<(), SetupError> {
+    let path = get_kimi_settings_path();
+    let mut doc = read_toml_document(&path)?;
+    merge_hcom_hooks(&mut doc);
+    write_toml(&path, &doc)?;
+    if !verify_hooks_at(&path) {
+        return Err(SetupError::PostWriteVerifyFailed(path));
+    }
+    Ok(())
+}
+
+pub fn verify_kimi_hooks_installed(_check_permissions: bool) -> bool {
+    verify_hooks_at(&get_kimi_settings_path())
+}
+
+// ── Instance helpers ────────────────────────────────────────────────────
+
+fn resolve_instance(
+    db: &HcomDb,
+    ctx: &HcomContext,
+    payload: &HookPayload,
+) -> Option<InstanceRow> {
+    instance_binding::resolve_instance_from_binding(
+        db,
+        payload.session_id.as_deref(),
+        ctx.process_id.as_deref(),
+    )
+}
+
+pub fn derive_kimi_transcript_path(session_id: &str) -> Option<String> {
+    let base = dirs::home_dir()?.join(".kimi").join("sessions");
+    if !base.exists() {
+        return None;
+    }
+    let Ok(entries) = std::fs::read_dir(&base) else {
+        return None;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let candidate = path.join(session_id).join("context.jsonl");
+        if candidate.exists() {
+            return Some(candidate.to_string_lossy().to_string());
+        }
+    }
+    None
+}
+
+fn update_position(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload, instance_name: &str) {
+    let mut updates = serde_json::Map::new();
+    if let Some(session_id) = payload.session_id.as_ref().filter(|s| !s.is_empty()) {
+        updates.insert("session_id".into(), Value::String(session_id.clone()));
+        if let Some(tp) = derive_kimi_transcript_path(session_id) {
+            updates.insert("transcript_path".into(), Value::String(tp));
+        }
+    }
+    let cwd = payload
+        .raw
+        .get("cwd")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| ctx.cwd.to_str().unwrap_or(""));
+    if !cwd.is_empty() {
+        updates.insert("directory".into(), Value::String(cwd.to_string()));
+    }
+    if !updates.is_empty() {
+        instances::update_instance_position(db, instance_name, &updates);
+    }
+}
+
+// ── Hook handlers ───────────────────────────────────────────────────────
+
+fn handle_sessionstart(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> HookResult {
+    if ctx.process_id.is_none() {
+        return HookResult::Allow {
+            additional_context: Some(format!(
+                "[hcom available - run '{} start' to participate]",
+                crate::runtime_env::build_hcom_command()
+            )),
+            system_message: None,
+            delivery_ack: None,
+        };
+    }
+
+    let session_id = match payload.session_id.as_deref() {
+        Some(sid) => sid,
+        None => return hook_noop(),
+    };
+
+    let instance_name =
+        instance_binding::bind_session_to_process(db, session_id, ctx.process_id.as_deref());
+
+    log::log_info(
+        "hooks",
+        "kimi.sessionstart.bind",
+        &format!(
+            "instance={:?} session_id={} process_id={:?}",
+            instance_name, session_id, ctx.process_id,
+        ),
+    );
+
+    let instance_name = match instance_name {
+        Some(name) => name,
+        None => {
+            if let Some(ref pid) = ctx.process_id {
+                match instance_binding::create_orphaned_pty_identity(
+                    db,
+                    session_id,
+                    Some(pid.as_str()),
+                    "kimi",
+                ) {
+                    Some(name) => name,
+                    None => return hook_noop(),
+                }
+            } else {
+                return hook_noop();
+            }
+        }
+    };
+
+    let _ = db.rebind_instance_session(&instance_name, session_id);
+    instance_binding::capture_and_store_launch_context(db, &instance_name);
+    update_position(db, ctx, payload, &instance_name);
+
+    lifecycle::set_status(
+        db,
+        &instance_name,
+        ST_LISTENING,
+        "start",
+        Default::default(),
+    );
+
+    crate::runtime_env::set_terminal_title(&instance_name);
+    crate::relay::worker::ensure_worker(true);
+
+    if let Ok(Some(inst)) = db.get_instance_full(&instance_name)
+        && let Some(bootstrap) =
+            common::inject_bootstrap_once(db, ctx, &instance_name, &inst, &inst.tool)
+    {
+        return HookResult::Allow {
+            additional_context: Some(bootstrap),
+            system_message: None,
+            delivery_ack: None,
+        };
+    }
+
+    hook_noop()
+}
+
+fn handle_userpromptsubmit(
+    db: &HcomDb,
+    ctx: &HcomContext,
+    payload: &HookPayload,
+) -> HookResult {
+    let instance = match resolve_instance(db, ctx, payload) {
+        Some(inst) => inst,
+        None => return hook_noop(),
+    };
+    let instance_name = &instance.name;
+    update_position(db, ctx, payload, instance_name);
+
+    if let Some(prepared) = common::prepare_pending_messages(db, instance_name) {
+        return HookResult::Allow {
+            additional_context: Some(prepared.formatted),
+            system_message: None,
+            delivery_ack: Some(prepared.ack),
+        };
+    }
+
+    hook_noop()
+}
+
+fn handle_pretooluse(db: &HcomDb, _ctx: &HcomContext, payload: &HookPayload) -> HookResult {
+    let instance = match resolve_instance(db, _ctx, payload) {
+        Some(inst) => inst,
+        None => return hook_noop(),
+    };
+    let instance_name = &instance.name;
+
+    let detail = crate::hooks::family::extract_tool_detail(
+        "kimi",
+        &payload.tool_name,
+        &payload.tool_input,
+    );
+    if !detail.is_empty() {
+        lifecycle::set_status(
+            db,
+            instance_name,
+            ST_ACTIVE,
+            &detail,
+            Default::default(),
+        );
+    }
+
+    hook_noop()
+}
+
+fn handle_posttooluse(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> HookResult {
+    let instance = match resolve_instance(db, ctx, payload) {
+        Some(inst) => inst,
+        None => return hook_noop(),
+    };
+    let instance_name = &instance.name;
+
+    if let Some(prepared) = common::prepare_pending_messages(db, instance_name) {
+        return HookResult::Allow {
+            additional_context: Some(prepared.formatted),
+            system_message: None,
+            delivery_ack: Some(prepared.ack),
+        };
+    }
+
+    hook_noop()
+}
+
+fn handle_stop(db: &HcomDb, ctx: &HcomContext, payload: &HookPayload) -> HookResult {
+    let instance = match resolve_instance(db, ctx, payload) {
+        Some(inst) => inst,
+        None => return hook_noop(),
+    };
+    let instance_name = &instance.name;
+
+    if let Some(prepared) = common::prepare_pending_messages(db, instance_name) {
+        return HookResult::Block {
+            reason: prepared.formatted,
+        };
+    }
+
+    hook_noop()
+}
+
+fn handle_sessionend(db: &HcomDb, _ctx: &HcomContext, payload: &HookPayload) -> HookResult {
+    let instance = match resolve_instance(db, _ctx, payload) {
+        Some(inst) => inst,
+        None => return hook_noop(),
+    };
+    let instance_name = &instance.name;
+
+    common::finalize_session(
+        db,
+        instance_name,
+        "sessionend",
+        None,
+    );
+
+    hook_noop()
+}
+
+fn handle_subagentstart(
+    _db: &HcomDb,
+    _ctx: &HcomContext,
+    _payload: &HookPayload,
+) -> HookResult {
+    hook_noop()
+}
+
+fn handle_subagentstop(
+    _db: &HcomDb,
+    _ctx: &HcomContext,
+    _payload: &HookPayload,
+) -> HookResult {
+    hook_noop()
+}
+
+fn handle_notification(
+    db: &HcomDb,
+    ctx: &HcomContext,
+    payload: &HookPayload,
+) -> HookResult {
+    let instance = match resolve_instance(db, ctx, payload) {
+        Some(inst) => inst,
+        None => return hook_noop(),
+    };
+    let instance_name = &instance.name;
+
+    if let Some(prepared) = common::prepare_pending_messages(db, instance_name) {
+        return HookResult::Allow {
+            additional_context: Some(prepared.formatted),
+            system_message: None,
+            delivery_ack: Some(prepared.ack),
+        };
+    }
+
+    hook_noop()
+}
+
+fn hook_noop() -> HookResult {
+    HookResult::Allow {
+        additional_context: None,
+        system_message: None,
+        delivery_ack: None,
+    }
+}
+
+fn get_handler(
+    hook_name: &str,
+) -> Option<fn(&HcomDb, &HcomContext, &HookPayload) -> HookResult> {
+    match hook_name {
+        "kimi-sessionstart" => Some(handle_sessionstart),
+        "kimi-userpromptsubmit" => Some(handle_userpromptsubmit),
+        "kimi-pretooluse" => Some(handle_pretooluse),
+        "kimi-posttooluse" => Some(handle_posttooluse),
+        "kimi-stop" => Some(handle_stop),
+        "kimi-sessionend" => Some(handle_sessionend),
+        "kimi-subagentstart" => Some(handle_subagentstart),
+        "kimi-subagentstop" => Some(handle_subagentstop),
+        "kimi-notification" => Some(handle_notification),
+        _ => None,
+    }
+}
+
+// ── Dispatch ────────────────────────────────────────────────────────────
+
+pub fn dispatch_kimi_hook(hook_name: &str) -> i32 {
+    let start = Instant::now();
+
+    let ctx = HcomContext::from_os();
+
+    let mut input = Vec::new();
+    if let Err(e) = std::io::stdin().read_to_end(&mut input) {
+        log::log_error(
+            "hooks",
+            "kimi.stdin_error",
+            &format!("hook={} err={}", hook_name, e),
+        );
+        return 0;
+    }
+
+    let raw: Value = match serde_json::from_slice(&input) {
+        Ok(v) => v,
+        Err(e) => {
+            log::log_error(
+                "hooks",
+                "kimi.parse_error",
+                &format!("hook={} err={}", hook_name, e),
+            );
+            return 0;
+        }
+    };
+
+    let payload = HookPayload::from_kimi(hook_name, raw);
+
+    // Pre-gate: skip UserPromptSubmit for non-participants
+    if !ctx.is_launched && hook_name == "kimi-userpromptsubmit" {
+        let sid = match payload.session_id.as_deref() {
+            Some(sid) => sid,
+            None => return 0,
+        };
+        if let Ok(db) = HcomDb::open() {
+            if db.get_session_binding(sid).ok().flatten().is_none() {
+                return 0;
+            }
+        } else {
+            return 0;
+        }
+    }
+
+    if !crate::paths::ensure_hcom_directories() {
+        return 0;
+    }
+
+    let db = match HcomDb::open() {
+        Ok(db) => db,
+        Err(e) => {
+            log::log_error("hooks", "kimi.db.error", &format!("{}", e));
+            return 0;
+        }
+    };
+
+    if !common::hook_gate_check(&ctx, &db) {
+        return 0;
+    }
+
+    let handler = match get_handler(hook_name) {
+        Some(h) => h,
+        None => {
+            log::log_error(
+                "hooks",
+                "kimi.dispatch.unknown",
+                &format!("Unknown Kimi hook: {}", hook_name),
+            );
+            return 0;
+        }
+    };
+
+    let result = common::dispatch_with_panic_guard(
+        "kimi",
+        hook_name,
+        HookResult::Allow {
+            additional_context: None,
+            system_message: None,
+            delivery_ack: None,
+        },
+        || handler(&db, &ctx, &payload),
+    );
+
+    let exit_code = match &result {
+        HookResult::Allow { .. } => 0,
+        HookResult::Block { .. } => 2,
+        HookResult::UpdateInput { .. } => 0,
+    };
+
+    match result {
+        HookResult::Allow {
+            additional_context: Some(ctx),
+            ..
+        } => {
+            let output = json!({
+                "hookSpecificOutput": {
+                    "message": ctx,
+                }
+            });
+            println!("{}", output);
+        }
+        HookResult::Block { reason } => {
+            let output = json!({
+                "hookSpecificOutput": {
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            });
+            eprintln!("{}", reason);
+            println!("{}", output);
+        }
+        _ => {}
+    }
+
+    let total_ms = start.elapsed().as_secs_f64() * 1000.0;
+    log::log_info(
+        "hooks",
+        "kimi.dispatch.timing",
+        &format!(
+            "hook={} exit_code={} total_ms={:.2}",
+            hook_name, exit_code, total_ms
+        ),
+    );
+
+    exit_code
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -9,6 +9,7 @@ pub mod common;
 pub mod cursor;
 pub mod family;
 pub mod gemini;
+pub mod kimi;
 pub mod opencode;
 pub mod utils;
 
@@ -327,6 +328,33 @@ impl HookPayload {
                 None => String::new(),
             },
             notification_type: None,
+            raw,
+        }
+    }
+
+    /// Build from Kimi Code CLI hook JSON.
+    ///
+    /// Kimi hooks pass JSON on stdin with snake_case fields such as:
+    ///   { "session_id", "hook_event_name", "tool_name", "tool_input",
+    ///     "tool_output", "prompt", "source", "cwd" }
+    pub fn from_kimi(hook_type: &str, raw: Value) -> Self {
+        Self {
+            session_id: Self::opt_str_field(&raw, &["session_id"]),
+            transcript_path: None,
+            hook_name: if hook_type.is_empty() {
+                Self::str_field(&raw, &["hook_event_name"])
+            } else {
+                hook_type.to_string()
+            },
+            tool: "kimi".to_string(),
+            tool_name: Self::str_field(&raw, &["tool_name"]),
+            tool_input: Self::obj_field(&raw, &["tool_input"]),
+            tool_result: match raw.get("tool_output") {
+                Some(Value::String(s)) => s.clone(),
+                Some(v) => v.to_string(),
+                None => String::new(),
+            },
+            notification_type: Self::opt_str_field(&raw, &["notification_type", "sink"]),
             raw,
         }
     }

--- a/src/instance_binding.rs
+++ b/src/instance_binding.rs
@@ -809,7 +809,7 @@ pub fn resolve_instance_from_binding(
 fn auto_subscribe_defaults(db: &HcomDb, instance_name: &str, tool: &str) {
     if !matches!(
         tool,
-        "claude" | "gemini" | "codex" | "opencode" | "kilo" | "antigravity" | "cursor"
+        "claude" | "gemini" | "codex" | "opencode" | "kilo" | "antigravity" | "cursor" | "kimi"
     ) {
         return;
     }

--- a/src/instance_lifecycle.rs
+++ b/src/instance_lifecycle.rs
@@ -421,6 +421,8 @@ pub fn get_status_description(status: &str, context: &str) -> String {
                 format!("active: {tool}")
             } else if let Some(tool) = context.strip_prefix("approved:") {
                 format!("active: approved {tool}")
+            } else if let Some(tool) = context.strip_prefix("denied:") {
+                format!("active: denied {tool}")
             } else if context == "resuming" {
                 "resuming...".to_string()
             } else if context.is_empty() {

--- a/src/integration_spec.rs
+++ b/src/integration_spec.rs
@@ -235,6 +235,8 @@ const KIMI_HOOKS: &[&str] = &[
     "kimi-userpromptsubmit",
     "kimi-pretooluse",
     "kimi-posttooluse",
+    "kimi-permissionrequest",
+    "kimi-permissionresult",
     "kimi-stop",
     "kimi-sessionend",
     "kimi-subagentstart",
@@ -313,17 +315,12 @@ const CURSOR_HELP_EXAMPLES: &[HelpEntry] = &[
 
 const KIMI_HELP_EXAMPLES: &[HelpEntry] = &[
     ("hcom kimi --model kimi-k2.6", "Use a specific model"),
-    (
-        "hcom kimi --yolo",
-        "Bypass permission prompts",
-    ),
+    ("hcom kimi --yolo", "Bypass permission prompts"),
 ];
-const KIMI_HELP_EXTRA_ENV: &[HelpEntry] = &[
-    (
-        "HCOM_KIMI_SYSTEM_PROMPT",
-        "System prompt (env var or config)",
-    ),
-];
+const KIMI_HELP_EXTRA_ENV: &[HelpEntry] = &[(
+    "HCOM_KIMI_SYSTEM_PROMPT",
+    "System prompt (env var or config)",
+)];
 
 // ── Per-tool integration constants ──────────────────────────────────────
 
@@ -704,24 +701,37 @@ pub static KIMI: IntegrationSpec = IntegrationSpec {
     },
     launch: LaunchSpec {
         args_env: Some("HCOM_KIMI_ARGS"),
-        config_dir_env: Some("KIMI_CONFIG_DIR"),
+        // Kimi's data root (config + sessions + credentials) is overridden via
+        // KIMI_CODE_HOME; it does not honor a separate config-dir variable.
+        config_dir_env: Some("KIMI_CODE_HOME"),
+        // Kimi has no CLI flag for an interactive initial prompt (`-p/--prompt`
+        // is non-interactive print-and-exit, and a bare positional errors with
+        // "too many arguments"). Launches carrying an initial prompt fast-fail
+        // in the launcher rather than passing a broken arg.
         initial_prompt: InitialPromptShape::Positional,
         uses_pty_default: true,
         max_launch_count: 10,
         background: BackgroundMode::HeadlessPty,
     },
     resume: Some(ResumeSpec {
+        // `-r/--resume` is a documented alias of `--session <id>`.
         resume: ResumeArgs::Flag("--resume"),
-        fork: Some(ForkArgs::AppendFlag("--fork")),
+        // Kimi has no CLI fork primitive — `/fork` is an interactive slash
+        // command only (`kimi --fork` errors "unknown option"). Like
+        // gemini/cursor/agy, leave fork unsupported.
+        fork: None,
     }),
     help: HelpSpec {
         unique_examples: KIMI_HELP_EXAMPLES,
         extra_env: KIMI_HELP_EXTRA_ENV,
     },
+    // Tool names verified against kimi-code 0.9.0 built-in tools
+    // (docs/reference/tools.md): shell is `Bash`, file writes are `Write`/`Edit`,
+    // and the subagent tool is `Agent`.
     status_detail: StatusDetailSpec {
-        bash: &["Bash", "Shell", "ExecuteCommand"],
-        file: &["WriteFile", "EditFile", "Replace"],
-        delegate: &["Subagent", "Delegate"],
+        bash: &["Bash"],
+        file: &["Write", "Edit"],
+        delegate: &["Agent"],
     },
 };
 

--- a/src/integration_spec.rs
+++ b/src/integration_spec.rs
@@ -230,6 +230,18 @@ const CURSOR_HOOKS: &[&str] = &[
     "cursor-sessionend",
 ];
 
+const KIMI_HOOKS: &[&str] = &[
+    "kimi-sessionstart",
+    "kimi-userpromptsubmit",
+    "kimi-pretooluse",
+    "kimi-posttooluse",
+    "kimi-stop",
+    "kimi-sessionend",
+    "kimi-subagentstart",
+    "kimi-subagentstop",
+    "kimi-notification",
+];
+
 // ── Help examples / extra-env tables ────────────────────────────────────
 
 const CLAUDE_HELP_EXAMPLES: &[HelpEntry] = &[
@@ -296,6 +308,20 @@ const CURSOR_HELP_EXAMPLES: &[HelpEntry] = &[
     (
         "hcom cursor-agent --force",
         "Allow commands unless explicitly denied",
+    ),
+];
+
+const KIMI_HELP_EXAMPLES: &[HelpEntry] = &[
+    ("hcom kimi --model kimi-k2.6", "Use a specific model"),
+    (
+        "hcom kimi --yolo",
+        "Bypass permission prompts",
+    ),
+];
+const KIMI_HELP_EXTRA_ENV: &[HelpEntry] = &[
+    (
+        "HCOM_KIMI_SYSTEM_PROMPT",
+        "System prompt (env var or config)",
     ),
 ];
 
@@ -653,6 +679,52 @@ pub static CURSOR: IntegrationSpec = IntegrationSpec {
     },
 };
 
+pub static KIMI: IntegrationSpec = IntegrationSpec {
+    tool: Tool::Kimi,
+    name: "kimi",
+    label: "Kimi",
+    aliases: &[],
+    cli_binary: "kimi",
+    tui_prefix: "kim ",
+    adhoc_icon: None,
+    released: true,
+    ready_pattern: b"> ",
+    hooks: HooksSpec {
+        names: KIMI_HOOKS,
+        shared_hooks_with: None,
+        invocation: HookInvocation::JsonStdin,
+    },
+    gates: GatesSpec {
+        require_idle: true,
+        require_ready_prompt: false,
+        require_prompt_empty: true,
+        block_on_user_activity: true,
+        block_on_approval: true,
+        launch_requires_ready: false,
+    },
+    launch: LaunchSpec {
+        args_env: Some("HCOM_KIMI_ARGS"),
+        config_dir_env: Some("KIMI_CONFIG_DIR"),
+        initial_prompt: InitialPromptShape::Positional,
+        uses_pty_default: true,
+        max_launch_count: 10,
+        background: BackgroundMode::HeadlessPty,
+    },
+    resume: Some(ResumeSpec {
+        resume: ResumeArgs::Flag("--resume"),
+        fork: Some(ForkArgs::AppendFlag("--fork")),
+    }),
+    help: HelpSpec {
+        unique_examples: KIMI_HELP_EXAMPLES,
+        extra_env: KIMI_HELP_EXTRA_ENV,
+    },
+    status_detail: StatusDetailSpec {
+        bash: &["Bash", "Shell", "ExecuteCommand"],
+        file: &["WriteFile", "EditFile", "Replace"],
+        delegate: &["Subagent", "Delegate"],
+    },
+};
+
 pub static ADHOC: IntegrationSpec = IntegrationSpec {
     tool: Tool::Adhoc,
     name: "adhoc",
@@ -708,6 +780,7 @@ pub static ALL: &[&IntegrationSpec] = &[
     &KILO,
     &ANTIGRAVITY,
     &CURSOR,
+    &KIMI,
     &ADHOC,
 ];
 
@@ -722,6 +795,7 @@ impl Tool {
             Tool::Kilo => &KILO,
             Tool::Antigravity => &ANTIGRAVITY,
             Tool::Cursor => &CURSOR,
+            Tool::Kimi => &KIMI,
             Tool::Adhoc => &ADHOC,
         }
     }
@@ -759,6 +833,7 @@ mod tests {
             Tool::Kilo,
             Tool::Antigravity,
             Tool::Cursor,
+            Tool::Kimi,
             Tool::Adhoc,
         ] {
             let spec = tool.spec();
@@ -821,7 +896,8 @@ mod tests {
         assert!(names.contains(&"kilo"));
         assert!(names.contains(&"antigravity"));
         assert!(names.contains(&"cursor"));
-        assert_eq!(names.len(), 7);
+        assert!(names.contains(&"kimi"));
+        assert_eq!(names.len(), 8);
     }
 
     #[test]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1080,6 +1080,17 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
     // When a real hcom participant launched us, append a reply instruction so
     // the spawned agent knows to send its result back.
     if let Some(ref prompt) = params.initial_prompt {
+        // Kimi has no way to accept an initial prompt at launch: `-p/--prompt` is
+        // a non-interactive print-and-exit mode, and a bare positional errors
+        // ("too many arguments"). Fail clearly instead of launching a broken
+        // command — the task can be sent as a message once the agent is up.
+        if normalized.spec().tool == crate::tool::Tool::Kimi {
+            anyhow::bail!(
+                "kimi does not support an initial prompt at launch. \
+                 Launch `hcom kimi` without a prompt, then send the task with \
+                 `hcom send @<name> -- \"…\"`."
+            );
+        }
         let reply_suffix =
             if params.append_reply_handoff && launcher_name != "api" && launcher_name != "user" {
                 format!("\n\nWhen done, send your result back to @{launcher_name} via hcom.")

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -34,6 +34,7 @@ pub enum LaunchTool {
     Kilo,
     Antigravity,
     Cursor,
+    Kimi,
 }
 
 impl LaunchTool {
@@ -48,6 +49,7 @@ impl LaunchTool {
             "kilo" | "kilocode" => Ok(LaunchTool::Kilo),
             "antigravity" | "agy" => Ok(LaunchTool::Antigravity),
             "cursor" | "cursor-agent" => Ok(LaunchTool::Cursor),
+            "kimi" => Ok(LaunchTool::Kimi),
             _ => bail!("Unknown tool: {}", s),
         }
     }
@@ -62,6 +64,7 @@ impl LaunchTool {
             LaunchTool::Kilo => "kilo",
             LaunchTool::Antigravity => "antigravity",
             LaunchTool::Cursor => "cursor",
+            LaunchTool::Kimi => "kimi",
         }
     }
 
@@ -78,6 +81,7 @@ impl LaunchTool {
             LaunchTool::Kilo => crate::tool::Tool::Kilo,
             LaunchTool::Antigravity => crate::tool::Tool::Antigravity,
             LaunchTool::Cursor => crate::tool::Tool::Cursor,
+            LaunchTool::Kimi => crate::tool::Tool::Kimi,
         }
     }
 
@@ -142,7 +146,8 @@ impl LaunchBackend {
             | LaunchTool::OpenCode
             | LaunchTool::Kilo
             | LaunchTool::Antigravity
-            | LaunchTool::Cursor => LaunchBackend::HeadlessPty,
+            | LaunchTool::Cursor
+            | LaunchTool::Kimi => LaunchBackend::HeadlessPty,
         }
     }
 }
@@ -469,6 +474,23 @@ fn ensure_hooks_installed(tool: &LaunchTool, include_permissions: bool) -> Resul
                 bail!(
                     "Failed to setup Cursor hooks: {e}\n\
                      Run: hcom hooks add cursor\n\
+                     {diag}"
+                );
+            }
+            Ok(())
+        }
+        LaunchTool::Kimi => {
+            if crate::hooks::kimi::verify_kimi_hooks_installed(include_permissions) {
+                return Ok(());
+            }
+            if let Err(e) = crate::hooks::kimi::try_setup_kimi_hooks(include_permissions) {
+                let diag = install_diag_context(
+                    tool,
+                    &[("hooks_path", crate::hooks::kimi::get_kimi_settings_path())],
+                );
+                bail!(
+                    "Failed to setup Kimi hooks: {e}\n\
+                     Run: hcom hooks add kimi\n\
                      {diag}"
                 );
             }
@@ -1528,6 +1550,34 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
                         inside_ai_tool,
                     )
                 }
+
+                LaunchTool::Kimi => {
+                    instances::update_instance_position(
+                        db,
+                        &instance_name,
+                        &serde_json::Map::from_iter([(
+                            "launch_args".to_string(),
+                            json!(params.args),
+                        )]),
+                    );
+                    launch_pty_or_background(
+                        &mut BackgroundLaunchCtx {
+                            db,
+                            tool: "kimi",
+                            instance_name: &instance_name,
+                            process_id: &process_id,
+                            terminal_mode,
+                            tag: params.tag.as_deref().unwrap_or(""),
+                            working_dir,
+                            log_files: &mut log_files,
+                            handles: &mut handles,
+                        },
+                        &mut instance_env,
+                        &params.args,
+                        &params,
+                        inside_ai_tool,
+                    )
+                }
             }
         })();
 
@@ -1628,6 +1678,7 @@ fn validate_tool_args(tool: &LaunchTool, args: &[String]) -> Vec<String> {
             errs
         }
         LaunchTool::Cursor => crate::tools::cursor_preprocessing::validate_cursor_args(args),
+        LaunchTool::Kimi => Vec::new(),
         LaunchTool::OpenCode | LaunchTool::Kilo | LaunchTool::Antigravity => Vec::new(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ pub fn run_pty(args: &[String]) -> Result<()> {
         eprintln!();
         eprintln!("Usage: hcom pty <tool> [args...]");
         eprintln!();
-        eprintln!("Tools: claude, gemini, codex, opencode, kilo, antigravity (agy), cursor");
+        eprintln!("Tools: claude, gemini, codex, opencode, kilo, antigravity (agy), cursor, kimi");
         eprintln!();
         eprintln!("The PTY wrapper provides:");
         eprintln!("  - Text injection via TCP port (INJECT_PORT)");

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -732,7 +732,7 @@ impl Proxy {
         use std::str::FromStr;
 
         let delivery_start_timeout = match Tool::from_str(&self.config.tool) {
-            Ok(Tool::Claude) | Ok(Tool::Codex) | Ok(Tool::Antigravity) | Ok(Tool::Cursor) => {
+            Ok(Tool::Claude) | Ok(Tool::Codex) | Ok(Tool::Antigravity) | Ok(Tool::Cursor) | Ok(Tool::Kimi) => {
                 Duration::from_secs(5) // ? for shortcuts footer (Claude/Codex/agy)
             }
             Ok(Tool::OpenCode) | Ok(Tool::Kilo) => Duration::from_secs(5),

--- a/src/pty/mod.rs
+++ b/src/pty/mod.rs
@@ -732,7 +732,11 @@ impl Proxy {
         use std::str::FromStr;
 
         let delivery_start_timeout = match Tool::from_str(&self.config.tool) {
-            Ok(Tool::Claude) | Ok(Tool::Codex) | Ok(Tool::Antigravity) | Ok(Tool::Cursor) | Ok(Tool::Kimi) => {
+            Ok(Tool::Claude)
+            | Ok(Tool::Codex)
+            | Ok(Tool::Antigravity)
+            | Ok(Tool::Cursor)
+            | Ok(Tool::Kimi) => {
                 Duration::from_secs(5) // ? for shortcuts footer (Claude/Codex/agy)
             }
             Ok(Tool::OpenCode) | Ok(Tool::Kilo) => Duration::from_secs(5),

--- a/src/pty/screen.rs
+++ b/src/pty/screen.rs
@@ -394,7 +394,7 @@ impl ScreenTracker {
             Ok(Tool::Kilo) => None,     // Kilo shares OpenCode's plugin delivery model
             Ok(Tool::Antigravity) => self.get_antigravity_input_text(),
             Ok(Tool::Cursor) => self.get_cursor_input_text(),
-            Ok(Tool::Kimi) => None, // Kimi: standard PTY delivery, no custom input detection needed
+            Ok(Tool::Kimi) => self.get_kimi_input_text(),
             Ok(Tool::Adhoc) => None,
             Err(_) => None,
         }
@@ -576,6 +576,66 @@ impl ScreenTracker {
         }
 
         None // Prompt not found
+    }
+
+    /// Extract Kimi input box text.
+    ///
+    /// Kimi renders the prompt inside a rounded box:
+    /// ```text
+    ///   ╭───────────────╮
+    ///   │ > <user text> │
+    ///   ╰───────────────╯
+    /// ```
+    /// Multi-line input adds `│ … │` continuation rows before the bottom border.
+    ///
+    /// Unlike Gemini, Kimi's ready pattern (`> `) stays on screen even with user
+    /// text present, so emptiness is decided purely from the box contents — there
+    /// is no `is_ready()` shortcut. Searching bottom-to-top finds the input box
+    /// (lowest on screen) before the welcome banner box.
+    fn get_kimi_input_text(&self) -> Option<String> {
+        let lines = self.get_screen_lines();
+        let num_lines = lines.len();
+
+        for row_idx in (0..num_lines.saturating_sub(1)).rev() {
+            if !lines[row_idx].contains('╭') {
+                continue;
+            }
+            let prompt_line = &lines[row_idx + 1];
+            let Some(open) = prompt_line.find('│') else {
+                continue;
+            };
+            let after = &prompt_line[open + '│'.len_utf8()..];
+            let Some(close) = after.rfind('│') else {
+                continue;
+            };
+            let mut inner = after[..close].trim();
+            // Strip the leading prompt marker (`>` normal mode, `*` yolo mode).
+            if let Some(rest) = inner.strip_prefix('>').or_else(|| inner.strip_prefix('*')) {
+                inner = rest.trim();
+            }
+            if inner.is_empty() {
+                return Some(String::new());
+            }
+            // Collect wrapped continuation rows until the bottom border.
+            let mut text = inner.to_string();
+            for cont in &lines[(row_idx + 2)..num_lines] {
+                if cont.contains('╰') || cont.contains('╭') {
+                    break;
+                }
+                let t = cont
+                    .trim()
+                    .trim_start_matches('│')
+                    .trim_end_matches('│')
+                    .trim();
+                if !t.is_empty() {
+                    text.push(' ');
+                    text.push_str(t);
+                }
+            }
+            return Some(text);
+        }
+
+        None // Input box not found
     }
 
     /// Extract Codex input text.
@@ -1163,6 +1223,65 @@ mod tests {
         t.process(format!("{}\r\n", bottom).as_bytes());
         // Ready pattern visible in prompt text → empty
         assert_eq!(t.get_gemini_input_text(), Some(String::new()));
+    }
+
+    // ---- Kimi input extraction ----
+
+    #[test]
+    fn kimi_empty_box_is_empty() {
+        let mut t = make_tracker(24, 80, "> ");
+        t.process("╭──────────────────────────╮\r\n".as_bytes());
+        t.process("│ >                        │\r\n".as_bytes());
+        t.process("╰──────────────────────────╯\r\n".as_bytes());
+        assert_eq!(t.get_kimi_input_text(), Some(String::new()));
+        assert!(t.is_prompt_empty("kimi"));
+    }
+
+    #[test]
+    fn kimi_extracts_typed_text() {
+        let mut t = make_tracker(24, 80, "> ");
+        t.process("╭──────────────────────────╮\r\n".as_bytes());
+        t.process("│ > hello kimi             │\r\n".as_bytes());
+        t.process("╰──────────────────────────╯\r\n".as_bytes());
+        assert_eq!(t.get_kimi_input_text(), Some("hello kimi".to_string()));
+        // Crucial: ready pattern `> ` is still on screen, but the box has text,
+        // so the prompt must NOT be reported empty (would clobber user input).
+        assert!(!t.is_prompt_empty("kimi"));
+    }
+
+    #[test]
+    fn kimi_picks_input_box_over_welcome_banner() {
+        let mut t = make_tracker(30, 80, "> ");
+        // Welcome banner box (also uses ╭ … ╰) above the input box.
+        t.process("╭──────────────────────────╮\r\n".as_bytes());
+        t.process("│  Welcome to Kimi Code!   │\r\n".as_bytes());
+        t.process("╰──────────────────────────╯\r\n".as_bytes());
+        t.process("╭──────────────────────────╮\r\n".as_bytes());
+        t.process("│ >                        │\r\n".as_bytes());
+        t.process("╰──────────────────────────╯\r\n".as_bytes());
+        assert_eq!(t.get_kimi_input_text(), Some(String::new()));
+    }
+
+    #[test]
+    fn kimi_multi_line_input() {
+        let mut t = make_tracker(24, 80, "> ");
+        t.process("╭──────────────────────────╮\r\n".as_bytes());
+        t.process("│ > first line             │\r\n".as_bytes());
+        t.process("│   second line            │\r\n".as_bytes());
+        t.process("╰──────────────────────────╯\r\n".as_bytes());
+        assert_eq!(
+            t.get_kimi_input_text(),
+            Some("first line second line".to_string())
+        );
+    }
+
+    #[test]
+    fn kimi_yolo_marker_stripped() {
+        let mut t = make_tracker(24, 80, "> ");
+        t.process("╭──────────────────────────╮\r\n".as_bytes());
+        t.process("│ *                        │\r\n".as_bytes());
+        t.process("╰──────────────────────────╯\r\n".as_bytes());
+        assert_eq!(t.get_kimi_input_text(), Some(String::new()));
     }
 
     #[test]

--- a/src/pty/screen.rs
+++ b/src/pty/screen.rs
@@ -394,6 +394,7 @@ impl ScreenTracker {
             Ok(Tool::Kilo) => None,     // Kilo shares OpenCode's plugin delivery model
             Ok(Tool::Antigravity) => self.get_antigravity_input_text(),
             Ok(Tool::Cursor) => self.get_cursor_input_text(),
+            Ok(Tool::Kimi) => None, // Kimi: standard PTY delivery, no custom input detection needed
             Ok(Tool::Adhoc) => None,
             Err(_) => None,
         }

--- a/src/router.rs
+++ b/src/router.rs
@@ -54,6 +54,7 @@ const LAUNCH_TOOLS: &[&str] = &[
     "agy",
     "cursor",
     "cursor-agent",
+    "kimi",
     "f",
     "r",
 ];
@@ -112,6 +113,10 @@ fn dispatch_hook_for_tool(tool: Tool, hook: &str, args: &[String]) -> (i32, Stri
         ),
         Tool::Cursor => (
             crate::hooks::cursor::dispatch_cursor_hook_native(hook),
+            String::new(),
+        ),
+        Tool::Kimi => (
+            crate::hooks::kimi::dispatch_kimi_hook(hook),
             String::new(),
         ),
         Tool::Adhoc => unreachable!("adhoc has no hooks"),

--- a/src/router.rs
+++ b/src/router.rs
@@ -115,10 +115,7 @@ fn dispatch_hook_for_tool(tool: Tool, hook: &str, args: &[String]) -> (i32, Stri
             crate::hooks::cursor::dispatch_cursor_hook_native(hook),
             String::new(),
         ),
-        Tool::Kimi => (
-            crate::hooks::kimi::dispatch_kimi_hook(hook),
-            String::new(),
-        ),
+        Tool::Kimi => (crate::hooks::kimi::dispatch_kimi_hook(hook), String::new()),
         Tool::Adhoc => unreachable!("adhoc has no hooks"),
     }
 }

--- a/src/shared/constants.rs
+++ b/src/shared/constants.rs
@@ -65,6 +65,8 @@ pub const TOOL_MARKER_VARS: &[&str] = &[
     "KILO",
     "CURSOR_AGENT",
     "CURSOR_PROJECT_DIR",
+    "KIMI_CODE_CLI",
+    "KIMI_SESSION_ID",
 ];
 
 /// HCOM identity vars — set per-instance, cleared to prevent parent identity leakage.

--- a/src/shared/context.rs
+++ b/src/shared/context.rs
@@ -51,6 +51,7 @@ pub struct HcomContext {
     pub is_opencode: bool,
     pub is_kilo: bool,
     pub is_cursor: bool,
+    pub is_kimi: bool,
     /// HCOM_IS_FORK=1 (--fork-session launch).
     pub is_fork: bool,
     /// Codex thread ID (session equivalent).
@@ -103,6 +104,7 @@ impl HcomContext {
         let is_opencode = is_eq("OPENCODE", "1");
         let is_kilo = is_eq("KILO", "1");
         let is_cursor = is_set("CURSOR_AGENT") || is_set("CURSOR_PROJECT_DIR");
+        let is_kimi = is_eq("KIMI_CODE_CLI", "1") || is_set("KIMI_SESSION_ID");
 
         // Determine tool type
         let tool = if is_claude {
@@ -119,6 +121,8 @@ impl HcomContext {
             Tool::Kilo
         } else if is_cursor {
             Tool::Cursor
+        } else if is_kimi {
+            Tool::Kimi
         } else {
             Tool::Adhoc
         };
@@ -144,6 +148,7 @@ impl HcomContext {
             is_opencode,
             is_kilo,
             is_cursor,
+            is_kimi,
             is_fork: is_eq("HCOM_IS_FORK", "1"),
             codex_thread_id: get_nonempty("CODEX_THREAD_ID"),
             launched_by: get_nonempty("HCOM_LAUNCHED_BY"),
@@ -204,6 +209,7 @@ impl HcomContext {
             || self.is_opencode
             || self.is_kilo
             || self.is_cursor
+            || self.is_kimi
     }
 
     /// Detect current tool name, or "adhoc".

--- a/src/shared/platform.rs
+++ b/src/shared/platform.rs
@@ -131,6 +131,9 @@ pub fn is_inside_ai_tool() -> bool {
         // Cursor Agent
         || is_set("CURSOR_AGENT")
         || is_set("CURSOR_PROJECT_DIR")
+        // Kimi Code
+        || is_eq("KIMI_CODE_CLI", "1")
+        || is_set("KIMI_SESSION_ID")
         // hcom-launched
         || is_eq("HCOM_LAUNCHED", "1")
 }
@@ -162,6 +165,8 @@ pub fn detect_current_tool_from_env() -> &'static str {
         "kilo"
     } else if is_set("CURSOR_AGENT") || is_set("CURSOR_PROJECT_DIR") {
         "cursor"
+    } else if is_eq("KIMI_CODE_CLI", "1") || is_set("KIMI_SESSION_ID") {
+        "kimi"
     } else {
         "adhoc"
     }

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -18,6 +18,7 @@ pub enum Tool {
     Kilo,
     Antigravity,
     Cursor,
+    Kimi,
     Adhoc,
 }
 
@@ -95,6 +96,9 @@ impl Tool {
             Tool::Cursor => {
                 crate::hooks::cursor::verify_cursor_hooks_installed(include_permissions)
             }
+            Tool::Kimi => {
+                crate::hooks::kimi::verify_kimi_hooks_installed(include_permissions)
+            }
             Tool::Adhoc => false,
         }
     }
@@ -125,6 +129,8 @@ impl Tool {
             }
             Tool::Cursor => crate::hooks::cursor::try_setup_cursor_hooks(include_permissions)
                 .map_err(|e| e.to_string()),
+            Tool::Kimi => crate::hooks::kimi::try_setup_kimi_hooks(include_permissions)
+                .map_err(|e| e.to_string()),
             Tool::Adhoc => Err("Adhoc has no hooks to install".to_string()),
         }
     }
@@ -145,6 +151,7 @@ impl Tool {
                 .map_err(|e| e.to_string()),
             Tool::Antigravity => Ok(crate::hooks::antigravity::remove_antigravity_hooks()),
             Tool::Cursor => Ok(crate::hooks::cursor::remove_cursor_hooks()),
+            Tool::Kimi => Ok(crate::hooks::kimi::remove_kimi_hooks()),
             Tool::Adhoc => Ok(false),
         }
     }
@@ -160,6 +167,7 @@ impl Tool {
             Tool::Kilo => crate::hooks::opencode::get_kilo_plugin_path(),
             Tool::Antigravity => crate::hooks::antigravity::get_antigravity_hooks_path(),
             Tool::Cursor => crate::hooks::cursor::get_cursor_hooks_path(),
+            Tool::Kimi => crate::hooks::kimi::get_kimi_settings_path(),
             Tool::Adhoc => return String::new(),
         };
         path_buf.to_string_lossy().to_string()

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -96,9 +96,7 @@ impl Tool {
             Tool::Cursor => {
                 crate::hooks::cursor::verify_cursor_hooks_installed(include_permissions)
             }
-            Tool::Kimi => {
-                crate::hooks::kimi::verify_kimi_hooks_installed(include_permissions)
-            }
+            Tool::Kimi => crate::hooks::kimi::verify_kimi_hooks_installed(include_permissions),
             Tool::Adhoc => false,
         }
     }

--- a/src/transcript/kimi.rs
+++ b/src/transcript/kimi.rs
@@ -1,25 +1,52 @@
 //! Kimi Code CLI transcript parser.
 //!
-//! Reads `context.jsonl` from Kimi session directories and normalizes into
-//! the tool-agnostic `Exchange` format used by hcom.
+//! Reads a session's `wire.jsonl` (the kimi-code wire log) and normalizes it
+//! into the tool-agnostic `Exchange` format used by hcom.
 //!
-//! Kimi context.jsonl structure (per-line JSON):
-//!   - `role`: "user" | "assistant" | "tool" | "_system_prompt" | "_checkpoint" | "_usage"
-//!   - `content`: string or object (assistant has `think`/`text` sub-fields)
-//!   - `tool_calls`: array on assistant messages
-//!   - `tool_call_id`: on tool messages
+//! `wire.jsonl` is a streaming event log — one JSON object per line, tagged by
+//! `type`. A conversational turn is structured as:
+//!   - `turn.prompt` — `{input:[{type:"text",text}], origin}` — the submitted prompt
+//!   - `context.append_message` — persisted messages. Only `role:"user"` is
+//!     persisted live (assistant content is streamed, see below). The `origin`
+//!     distinguishes real input (`user`) from hcom hook deliveries
+//!     (`hook_result`, `system_trigger`).
+//!   - `context.append_loop_event` — carries the assistant turn:
+//!       - `event.type:"content.part"` → `part:{type:"text"|"think", …}`
+//!       - `event.type:"tool.call"`    → `{toolCallId, name, args:{…}}`
+//!       - `event.type:"tool.result"`  → `{toolCallId, result:{output, isError}}`
+//!
+//! Other event types (metadata, config.update, usage.record, step.*, …) are
+//! skipped. Assistant text/think/tools are NOT in `context.append_message`.
 
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-use serde_json::Value;
+use serde_json::{Value, json};
 
-use super::shared::{Exchange, ToolUse, extract_edit_info, is_error_result, normalize_tool_name};
+use super::shared::{
+    Exchange, ToolUse, extract_content_text, extract_edit_info, finalize_action_text,
+    is_error_result, normalize_tool_name,
+};
 
-/// Parse Kimi `context.jsonl` into exchanges.
-pub fn parse_kimi_context_jsonl(
+/// In-progress turn accumulator.
+#[derive(Default)]
+struct Turn {
+    user: String,
+    think: String,
+    text: String,
+    tools: Vec<ToolUse>,
+    edits: Vec<Value>,
+    errors: Vec<Value>,
+    ended_on_error: bool,
+    files: Vec<String>,
+    /// toolCallId → index into `tools`, for matching results back to calls.
+    call_index: HashMap<String, usize>,
+}
+
+/// Parse a Kimi `wire.jsonl` into exchanges.
+pub fn parse_kimi_wire_jsonl(
     path: &Path,
     last: usize,
     detailed: bool,
@@ -27,171 +54,133 @@ pub fn parse_kimi_context_jsonl(
     let file = File::open(path).map_err(|e| format!("Failed to open {}: {e}", path.display()))?;
     let reader = BufReader::new(file);
 
-    let mut lines: Vec<Value> = Vec::new();
+    let mut exchanges: Vec<Exchange> = Vec::new();
+    let mut position = 0;
+    let mut cur: Option<Turn> = None;
+
     for line in reader.lines() {
         let line = line.map_err(|e| format!("Read error: {e}"))?;
         if line.trim().is_empty() {
             continue;
         }
-        let value: Value = serde_json::from_str(&line).map_err(|e| format!("JSON parse: {e}"))?;
-        // Skip internal meta roles
-        if let Some(role) = value.get("role").and_then(|v| v.as_str())
-            && role.starts_with('_')
-        {
-            continue;
-        }
-        lines.push(value);
-    }
+        let v: Value = serde_json::from_str(&line).map_err(|e| format!("JSON parse: {e}"))?;
 
-    // Group messages into exchanges: user -> assistant [-> tool]*
-    let mut exchanges: Vec<Exchange> = Vec::new();
-    let mut i = 0;
-    let mut position = 0;
-
-    while i < lines.len() {
-        let role = lines[i].get("role").and_then(|v| v.as_str()).unwrap_or("");
-        if role != "user" {
-            i += 1;
-            continue;
-        }
-
-        position += 1;
-        let user_text = extract_text(&lines[i]);
-        let assistant_idx = i + 1;
-
-        // Gather tools and tool results that follow the assistant message
-        let mut tools: Vec<ToolUse> = Vec::new();
-        let mut edits: Vec<Value> = Vec::new();
-        let mut errors: Vec<Value> = Vec::new();
-        let mut ended_on_error = false;
-        let mut action_parts: Vec<String> = Vec::new();
-
-        if assistant_idx < lines.len() {
-            let next_role = lines[assistant_idx]
-                .get("role")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            if next_role == "assistant" {
-                // Extract tool_calls from assistant message
-                if let Some(calls) = lines[assistant_idx].get("tool_calls").and_then(|v| v.as_array())
-                {
-                    // Build a map of tool_call_id -> tool result for matching
-                    let mut results: HashMap<String, Value> = HashMap::new();
-                    let mut j = assistant_idx + 1;
-                    while j < lines.len() {
-                        let r = lines[j].get("role").and_then(|v| v.as_str()).unwrap_or("");
-                        if r == "tool" {
-                            if let Some(id) = lines[j]
-                                .get("tool_call_id")
-                                .and_then(|v| v.as_str())
-                            {
-                                results.insert(id.to_string(), lines[j].clone());
+        match v.get("type").and_then(Value::as_str).unwrap_or("") {
+            "turn.prompt" => {
+                if let Some(t) = cur.take() {
+                    position += 1;
+                    exchanges.push(build_exchange(t, position, detailed));
+                }
+                cur = Some(Turn {
+                    user: extract_content_text(v.get("input")),
+                    ..Default::default()
+                });
+            }
+            "context.append_message" => {
+                let Some(t) = cur.as_mut() else { continue };
+                let Some(m) = v.get("message") else { continue };
+                if m.get("role").and_then(Value::as_str) != Some("user") {
+                    continue;
+                }
+                // hcom messages arrive as hook-injected user messages; prefer
+                // their (unwrapped) content over the bare `<hcom>` trigger that
+                // turn.prompt recorded.
+                let origin = m
+                    .get("origin")
+                    .and_then(|o| o.get("kind"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if origin == "hook_result" || origin == "system_trigger" {
+                    let cleaned = unwrap_hook_result(&extract_content_text(m.get("content")));
+                    if !cleaned.is_empty() {
+                        t.user = cleaned;
+                    }
+                }
+            }
+            "context.append_loop_event" => {
+                let Some(t) = cur.as_mut() else { continue };
+                let Some(ev) = v.get("event") else { continue };
+                match ev.get("type").and_then(Value::as_str).unwrap_or("") {
+                    "content.part" => {
+                        let part = ev.get("part").unwrap_or(&Value::Null);
+                        match part.get("type").and_then(Value::as_str).unwrap_or("") {
+                            "text" => {
+                                if let Some(s) = part.get("text").and_then(Value::as_str) {
+                                    t.text.push_str(s);
+                                }
                             }
-                            j += 1;
-                        } else {
-                            break;
+                            "think" if detailed => {
+                                if let Some(s) = part.get("think").and_then(Value::as_str) {
+                                    t.think.push_str(s);
+                                }
+                            }
+                            _ => {}
                         }
                     }
-
-                    for call in calls {
-                        let name = call
-                            .get("function")
-                            .and_then(|f| f.get("name"))
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("unknown")
-                            .to_string();
-                        let call_id = call.get("id").and_then(|v| v.as_str()).unwrap_or("");
-                        let arguments = call
-                            .get("function")
-                            .and_then(|f| f.get("arguments"))
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("{}");
-                        let args_parsed: Value =
-                            serde_json::from_str(arguments).unwrap_or(Value::Object(Default::default()));
-
-                        let result = results.get(call_id).cloned();
-                        let is_err = result.as_ref().map(is_error_result).unwrap_or(false);
-                        let result_text = result
-                            .as_ref()
-                            .and_then(|r| r.get("content").and_then(|v| v.as_str()))
-                            .unwrap_or("");
-
-                        let file = args_parsed
+                    "tool.call" => {
+                        let name = ev.get("name").and_then(Value::as_str).unwrap_or("unknown");
+                        let args = ev.get("args").cloned().unwrap_or_else(|| json!({}));
+                        // Kimi file tools key the path off `path`; alias it to
+                        // `file_path` for the shared file/edit extractors.
+                        let mut aliased = args.clone();
+                        if let Some(obj) = aliased.as_object_mut()
+                            && !obj.contains_key("file_path")
+                            && let Some(p) = obj.get("path").cloned()
+                        {
+                            obj.insert("file_path".into(), p);
+                        }
+                        let file = aliased
                             .get("file_path")
-                            .or_else(|| args_parsed.get("path"))
-                            .or_else(|| args_parsed.get("file"))
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
-
-                        let command = args_parsed
+                            .and_then(Value::as_str)
+                            .map(str::to_string);
+                        let command = aliased
                             .get("command")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
-
-                        let canonical_name = normalize_tool_name(&name).to_string();
-
-                        if is_err {
-                            ended_on_error = true;
-                            errors.push(serde_json::json!({
-                                "tool": canonical_name,
-                                "error": result_text,
-                            }));
+                            .and_then(Value::as_str)
+                            .map(str::to_string);
+                        if let Some(f) = &file
+                            && !t.files.contains(f)
+                        {
+                            t.files.push(f.clone());
                         }
-
-                        if let Some(edit) = extract_edit_info(&result, &args_parsed) {
-                            edits.push(edit);
+                        if let Some(edit) = extract_edit_info(&None, &aliased) {
+                            t.edits.push(edit);
                         }
-                        if !action_parts.contains(&canonical_name) {
-                            action_parts.push(canonical_name.clone());
+                        if let Some(id) = ev.get("toolCallId").and_then(Value::as_str) {
+                            t.call_index.insert(id.to_string(), t.tools.len());
                         }
-
-                        tools.push(ToolUse {
-                            name: canonical_name,
-                            is_error: is_err,
-                            file: file.clone(),
-                            command: command.clone(),
+                        t.tools.push(ToolUse {
+                            name: normalize_tool_name(name).to_string(),
+                            is_error: false,
+                            file,
+                            command,
                         });
                     }
+                    "tool.result" => {
+                        let id = ev.get("toolCallId").and_then(Value::as_str).unwrap_or("");
+                        let result = ev.get("result").unwrap_or(&Value::Null);
+                        let output = result.get("output").and_then(Value::as_str).unwrap_or("");
+                        let is_err = result
+                            .get("isError")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false)
+                            || is_error_result(&json!({"is_error": false, "content": output}));
+                        t.ended_on_error = is_err;
+                        if is_err && let Some(&idx) = t.call_index.get(id) {
+                            t.tools[idx].is_error = true;
+                            let tool = t.tools[idx].name.clone();
+                            t.errors.push(json!({"tool": tool, "error": output}));
+                        }
+                    }
+                    _ => {}
                 }
-
-                // Advance past assistant + any tool results we consumed
-                i = assistant_idx + 1;
-                while i < lines.len()
-                    && lines[i].get("role").and_then(|v| v.as_str()) == Some("tool")
-                {
-                    i += 1;
-                }
-            } else {
-                i = assistant_idx;
             }
-        } else {
-            i = assistant_idx;
+            _ => {}
         }
+    }
 
-        let action = if action_parts.is_empty() {
-            String::new()
-        } else {
-            action_parts.join(", ")
-        };
-
-        let files: Vec<String> = tools
-            .iter()
-            .filter_map(|t| t.file.clone())
-            .collect::<std::collections::HashSet<_>>()
-            .into_iter()
-            .collect();
-
-        exchanges.push(Exchange {
-            position,
-            user: user_text,
-            action,
-            files,
-            timestamp: String::new(),
-            tools,
-            edits,
-            errors,
-            ended_on_error,
-        });
+    if let Some(t) = cur.take() {
+        position += 1;
+        exchanges.push(build_exchange(t, position, detailed));
     }
 
     if !detailed && exchanges.len() > last {
@@ -201,24 +190,47 @@ pub fn parse_kimi_context_jsonl(
     Ok(exchanges)
 }
 
-/// Extract human-readable text from a Kimi message.
-fn extract_text(msg: &Value) -> String {
-    match msg.get("content") {
-        Some(Value::String(s)) => s.clone(),
-        Some(Value::Object(obj)) => {
-            // Assistant message with think/text parts
-            let think = obj.get("think").and_then(|v| v.as_str()).unwrap_or("");
-            let text = obj.get("text").and_then(|v| v.as_str()).unwrap_or("");
-            if think.is_empty() {
-                text.to_string()
-            } else if text.is_empty() {
-                format!("[think]\n{think}")
-            } else {
-                format!("[think]\n{think}\n\n{text}")
-            }
+fn build_exchange(t: Turn, position: usize, detailed: bool) -> Exchange {
+    let text = t.text.trim();
+    let think = t.think.trim();
+    let action_text = if detailed && !think.is_empty() {
+        if text.is_empty() {
+            format!("[think]\n{think}")
+        } else {
+            format!("[think]\n{think}\n\n{text}")
         }
-        _ => String::new(),
+    } else {
+        text.to_string()
+    };
+    let action = finalize_action_text(&action_text, &t.tools, &t.errors, t.ended_on_error);
+
+    Exchange {
+        position,
+        user: t.user,
+        action,
+        files: t.files,
+        timestamp: String::new(),
+        tools: t.tools,
+        edits: t.edits,
+        errors: t.errors,
+        ended_on_error: t.ended_on_error,
     }
+}
+
+/// Strip the `<hook_result hook_event="…">…</hook_result>` wrapper that kimi
+/// puts around UserPromptSubmit hook deliveries, leaving the inner message.
+fn unwrap_hook_result(text: &str) -> String {
+    let t = text.trim();
+    if let Some(rest) = t.strip_prefix("<hook_result")
+        && let Some(gt) = rest.find('>')
+    {
+        let inner = rest[gt + 1..]
+            .trim_end()
+            .strip_suffix("</hook_result>")
+            .unwrap_or(&rest[gt + 1..]);
+        return inner.trim().to_string();
+    }
+    t.to_string()
 }
 
 #[cfg(test)]
@@ -226,7 +238,24 @@ mod tests {
     use super::*;
     use std::io::Write;
 
-    fn make_temp_jsonl(lines: &[&str]) -> tempfile::NamedTempFile {
+    fn turn_prompt(text: &str) -> String {
+        json!({"type": "turn.prompt", "input": [{"type": "text", "text": text}], "origin": {"kind": "user"}}).to_string()
+    }
+    fn content_part(part: Value) -> String {
+        json!({"type": "context.append_loop_event", "event": {"type": "content.part", "part": part}})
+            .to_string()
+    }
+    fn tool_call(id: &str, name: &str, args: Value) -> String {
+        json!({"type": "context.append_loop_event", "event": {"type": "tool.call", "toolCallId": id, "name": name, "args": args}}).to_string()
+    }
+    fn tool_result(id: &str, result: Value) -> String {
+        json!({"type": "context.append_loop_event", "event": {"type": "tool.result", "toolCallId": id, "result": result}}).to_string()
+    }
+    fn append_user(origin: Value, text: &str) -> String {
+        json!({"type": "context.append_message", "message": {"role": "user", "content": [{"type": "text", "text": text}], "origin": origin}}).to_string()
+    }
+
+    fn make_temp_jsonl(lines: &[String]) -> tempfile::NamedTempFile {
         let mut file = tempfile::NamedTempFile::new().unwrap();
         for line in lines {
             writeln!(file, "{}", line).unwrap();
@@ -235,43 +264,114 @@ mod tests {
     }
 
     #[test]
-    fn parse_simple_user_assistant() {
-        let jsonl = make_temp_jsonl(&[
-            r#"{"role":"user","content":"hello"}"#,
-            r#"{"role":"assistant","content":{"think":"","text":"hi there"}}"#,
-        ]);
-        let exchanges = parse_kimi_context_jsonl(jsonl.path(), 10, true).unwrap();
-        assert_eq!(exchanges.len(), 1);
-        assert_eq!(exchanges[0].user, "hello");
-        assert!(exchanges[0].action.is_empty());
-        assert!(exchanges[0].tools.is_empty());
+    fn extracts_assistant_text_from_loop_events() {
+        let lines = vec![
+            json!({"type": "metadata", "protocol_version": "1.3"}).to_string(),
+            turn_prompt("what is hcom?"),
+            content_part(json!({"type": "think", "think": "pondering"})),
+            content_part(json!({"type": "text", "text": "hcom is a comms tool."})),
+            json!({"type": "usage.record", "usage": {}}).to_string(),
+        ];
+        let jsonl = make_temp_jsonl(&lines);
+
+        let ex = parse_kimi_wire_jsonl(jsonl.path(), 10, false).unwrap();
+        assert_eq!(ex.len(), 1);
+        assert_eq!(ex[0].user, "what is hcom?");
+        // The core regression: assistant text must be extracted (not "(no response)").
+        assert_eq!(ex[0].action, "hcom is a comms tool.");
     }
 
     #[test]
-    fn parse_with_bash_tool() {
-        let jsonl = make_temp_jsonl(&[
-            r#"{"role":"user","content":"run ls"}"#,
-            r#"{"role":"assistant","content":{"think":"","text":""},"tool_calls":[{"id":"call_1","function":{"name":"Bash","arguments":"{\"command\":\"ls\"}"}}]}"#,
-            r#"{"role":"tool","content":"file.txt","tool_call_id":"call_1"}"#,
-        ]);
-        let exchanges = parse_kimi_context_jsonl(jsonl.path(), 10, true).unwrap();
-        assert_eq!(exchanges.len(), 1);
-        assert_eq!(exchanges[0].tools.len(), 1);
-        assert_eq!(exchanges[0].tools[0].name, "Bash");
-        assert_eq!(exchanges[0].tools[0].command, Some("ls".to_string()));
-        assert_eq!(exchanges[0].action, "Bash");
+    fn detailed_includes_think() {
+        let lines = vec![
+            turn_prompt("q"),
+            content_part(json!({"type": "think", "think": "reasoning"})),
+            content_part(json!({"type": "text", "text": "answer"})),
+        ];
+        let jsonl = make_temp_jsonl(&lines);
+
+        let ex = parse_kimi_wire_jsonl(jsonl.path(), 10, true).unwrap();
+        assert!(ex[0].action.contains("[think]"));
+        assert!(ex[0].action.contains("reasoning"));
+        assert!(ex[0].action.contains("answer"));
     }
 
     #[test]
-    fn skips_internal_roles() {
-        let jsonl = make_temp_jsonl(&[
-            r#"{"role":"_system_prompt","content":"you are helpful"}"#,
-            r#"{"role":"user","content":"hi"}"#,
-            r#"{"role":"assistant","content":{"think":"","text":"hello"}}"#,
-            r#"{"role":"_usage","content":""}"#,
-        ]);
-        let exchanges = parse_kimi_context_jsonl(jsonl.path(), 10, true).unwrap();
-        assert_eq!(exchanges.len(), 1);
-        assert_eq!(exchanges[0].user, "hi");
+    fn parses_tool_call_and_result() {
+        let lines = vec![
+            turn_prompt("run who"),
+            tool_call("c1", "Bash", json!({"command": "who"})),
+            tool_result("c1", json!({"output": "anno  console"})),
+            content_part(json!({"type": "text", "text": "done"})),
+        ];
+        let jsonl = make_temp_jsonl(&lines);
+
+        let ex = parse_kimi_wire_jsonl(jsonl.path(), 10, true).unwrap();
+        assert_eq!(ex.len(), 1);
+        assert_eq!(ex[0].tools.len(), 1);
+        assert_eq!(ex[0].tools[0].name, "Bash");
+        assert_eq!(ex[0].tools[0].command.as_deref(), Some("who"));
+        assert!(!ex[0].tools[0].is_error);
+        assert_eq!(ex[0].action, "done");
+    }
+
+    #[test]
+    fn flags_tool_error_via_iserror() {
+        let lines = vec![
+            turn_prompt("edit"),
+            tool_call(
+                "c2",
+                "Edit",
+                json!({"path": "/a.txt", "old_string": "x", "new_string": "y"}),
+            ),
+            tool_result("c2", json!({"output": "rejected by user", "isError": true})),
+        ];
+        let jsonl = make_temp_jsonl(&lines);
+
+        let ex = parse_kimi_wire_jsonl(jsonl.path(), 10, true).unwrap();
+        assert!(ex[0].tools[0].is_error);
+        assert!(ex[0].ended_on_error);
+        assert_eq!(ex[0].tools[0].name, "Edit");
+        assert_eq!(ex[0].files, vec!["/a.txt".to_string()]);
+        assert_eq!(ex[0].errors.len(), 1);
+    }
+
+    #[test]
+    fn hcom_delivery_uses_hook_message_not_trigger() {
+        // hcom delivery: the trigger is `<hcom>` but the real message arrives as
+        // a hook_result user message — the transcript should show the message.
+        let lines = vec![
+            turn_prompt("<hcom>"),
+            append_user(json!({"kind": "user"}), "<hcom>"),
+            append_user(
+                json!({"kind": "hook_result", "event": "UserPromptSubmit"}),
+                "<hook_result hook_event=\"UserPromptSubmit\">\n<hcom>[request #1] bigboss → me: ping</hcom>\n</hook_result>",
+            ),
+            content_part(json!({"type": "text", "text": "pong"})),
+        ];
+        let jsonl = make_temp_jsonl(&lines);
+
+        let ex = parse_kimi_wire_jsonl(jsonl.path(), 10, false).unwrap();
+        assert_eq!(ex.len(), 1);
+        assert_eq!(ex[0].user, "<hcom>[request #1] bigboss → me: ping</hcom>");
+        assert_eq!(ex[0].action, "pong");
+    }
+
+    #[test]
+    fn multiple_turns_split_correctly() {
+        let lines = vec![
+            turn_prompt("first"),
+            content_part(json!({"type": "text", "text": "one"})),
+            turn_prompt("second"),
+            content_part(json!({"type": "text", "text": "two"})),
+        ];
+        let jsonl = make_temp_jsonl(&lines);
+
+        let ex = parse_kimi_wire_jsonl(jsonl.path(), 10, false).unwrap();
+        assert_eq!(ex.len(), 2);
+        assert_eq!(ex[0].user, "first");
+        assert_eq!(ex[0].action, "one");
+        assert_eq!(ex[1].user, "second");
+        assert_eq!(ex[1].action, "two");
     }
 }

--- a/src/transcript/kimi.rs
+++ b/src/transcript/kimi.rs
@@ -1,0 +1,277 @@
+//! Kimi Code CLI transcript parser.
+//!
+//! Reads `context.jsonl` from Kimi session directories and normalizes into
+//! the tool-agnostic `Exchange` format used by hcom.
+//!
+//! Kimi context.jsonl structure (per-line JSON):
+//!   - `role`: "user" | "assistant" | "tool" | "_system_prompt" | "_checkpoint" | "_usage"
+//!   - `content`: string or object (assistant has `think`/`text` sub-fields)
+//!   - `tool_calls`: array on assistant messages
+//!   - `tool_call_id`: on tool messages
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::shared::{Exchange, ToolUse, extract_edit_info, is_error_result, normalize_tool_name};
+
+/// Parse Kimi `context.jsonl` into exchanges.
+pub fn parse_kimi_context_jsonl(
+    path: &Path,
+    last: usize,
+    detailed: bool,
+) -> Result<Vec<Exchange>, String> {
+    let file = File::open(path).map_err(|e| format!("Failed to open {}: {e}", path.display()))?;
+    let reader = BufReader::new(file);
+
+    let mut lines: Vec<Value> = Vec::new();
+    for line in reader.lines() {
+        let line = line.map_err(|e| format!("Read error: {e}"))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(&line).map_err(|e| format!("JSON parse: {e}"))?;
+        // Skip internal meta roles
+        if let Some(role) = value.get("role").and_then(|v| v.as_str())
+            && role.starts_with('_')
+        {
+            continue;
+        }
+        lines.push(value);
+    }
+
+    // Group messages into exchanges: user -> assistant [-> tool]*
+    let mut exchanges: Vec<Exchange> = Vec::new();
+    let mut i = 0;
+    let mut position = 0;
+
+    while i < lines.len() {
+        let role = lines[i].get("role").and_then(|v| v.as_str()).unwrap_or("");
+        if role != "user" {
+            i += 1;
+            continue;
+        }
+
+        position += 1;
+        let user_text = extract_text(&lines[i]);
+        let assistant_idx = i + 1;
+
+        // Gather tools and tool results that follow the assistant message
+        let mut tools: Vec<ToolUse> = Vec::new();
+        let mut edits: Vec<Value> = Vec::new();
+        let mut errors: Vec<Value> = Vec::new();
+        let mut ended_on_error = false;
+        let mut action_parts: Vec<String> = Vec::new();
+
+        if assistant_idx < lines.len() {
+            let next_role = lines[assistant_idx]
+                .get("role")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if next_role == "assistant" {
+                // Extract tool_calls from assistant message
+                if let Some(calls) = lines[assistant_idx].get("tool_calls").and_then(|v| v.as_array())
+                {
+                    // Build a map of tool_call_id -> tool result for matching
+                    let mut results: HashMap<String, Value> = HashMap::new();
+                    let mut j = assistant_idx + 1;
+                    while j < lines.len() {
+                        let r = lines[j].get("role").and_then(|v| v.as_str()).unwrap_or("");
+                        if r == "tool" {
+                            if let Some(id) = lines[j]
+                                .get("tool_call_id")
+                                .and_then(|v| v.as_str())
+                            {
+                                results.insert(id.to_string(), lines[j].clone());
+                            }
+                            j += 1;
+                        } else {
+                            break;
+                        }
+                    }
+
+                    for call in calls {
+                        let name = call
+                            .get("function")
+                            .and_then(|f| f.get("name"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown")
+                            .to_string();
+                        let call_id = call.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                        let arguments = call
+                            .get("function")
+                            .and_then(|f| f.get("arguments"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("{}");
+                        let args_parsed: Value =
+                            serde_json::from_str(arguments).unwrap_or(Value::Object(Default::default()));
+
+                        let result = results.get(call_id).cloned();
+                        let is_err = result.as_ref().map(is_error_result).unwrap_or(false);
+                        let result_text = result
+                            .as_ref()
+                            .and_then(|r| r.get("content").and_then(|v| v.as_str()))
+                            .unwrap_or("");
+
+                        let file = args_parsed
+                            .get("file_path")
+                            .or_else(|| args_parsed.get("path"))
+                            .or_else(|| args_parsed.get("file"))
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+
+                        let command = args_parsed
+                            .get("command")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+
+                        let canonical_name = normalize_tool_name(&name).to_string();
+
+                        if is_err {
+                            ended_on_error = true;
+                            errors.push(serde_json::json!({
+                                "tool": canonical_name,
+                                "error": result_text,
+                            }));
+                        }
+
+                        if let Some(edit) = extract_edit_info(&result, &args_parsed) {
+                            edits.push(edit);
+                        }
+                        if !action_parts.contains(&canonical_name) {
+                            action_parts.push(canonical_name.clone());
+                        }
+
+                        tools.push(ToolUse {
+                            name: canonical_name,
+                            is_error: is_err,
+                            file: file.clone(),
+                            command: command.clone(),
+                        });
+                    }
+                }
+
+                // Advance past assistant + any tool results we consumed
+                i = assistant_idx + 1;
+                while i < lines.len()
+                    && lines[i].get("role").and_then(|v| v.as_str()) == Some("tool")
+                {
+                    i += 1;
+                }
+            } else {
+                i = assistant_idx;
+            }
+        } else {
+            i = assistant_idx;
+        }
+
+        let action = if action_parts.is_empty() {
+            String::new()
+        } else {
+            action_parts.join(", ")
+        };
+
+        let files: Vec<String> = tools
+            .iter()
+            .filter_map(|t| t.file.clone())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        exchanges.push(Exchange {
+            position,
+            user: user_text,
+            action,
+            files,
+            timestamp: String::new(),
+            tools,
+            edits,
+            errors,
+            ended_on_error,
+        });
+    }
+
+    if !detailed && exchanges.len() > last {
+        exchanges = exchanges.split_off(exchanges.len() - last);
+    }
+
+    Ok(exchanges)
+}
+
+/// Extract human-readable text from a Kimi message.
+fn extract_text(msg: &Value) -> String {
+    match msg.get("content") {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Object(obj)) => {
+            // Assistant message with think/text parts
+            let think = obj.get("think").and_then(|v| v.as_str()).unwrap_or("");
+            let text = obj.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            if think.is_empty() {
+                text.to_string()
+            } else if text.is_empty() {
+                format!("[think]\n{think}")
+            } else {
+                format!("[think]\n{think}\n\n{text}")
+            }
+        }
+        _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn make_temp_jsonl(lines: &[&str]) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        for line in lines {
+            writeln!(file, "{}", line).unwrap();
+        }
+        file
+    }
+
+    #[test]
+    fn parse_simple_user_assistant() {
+        let jsonl = make_temp_jsonl(&[
+            r#"{"role":"user","content":"hello"}"#,
+            r#"{"role":"assistant","content":{"think":"","text":"hi there"}}"#,
+        ]);
+        let exchanges = parse_kimi_context_jsonl(jsonl.path(), 10, true).unwrap();
+        assert_eq!(exchanges.len(), 1);
+        assert_eq!(exchanges[0].user, "hello");
+        assert!(exchanges[0].action.is_empty());
+        assert!(exchanges[0].tools.is_empty());
+    }
+
+    #[test]
+    fn parse_with_bash_tool() {
+        let jsonl = make_temp_jsonl(&[
+            r#"{"role":"user","content":"run ls"}"#,
+            r#"{"role":"assistant","content":{"think":"","text":""},"tool_calls":[{"id":"call_1","function":{"name":"Bash","arguments":"{\"command\":\"ls\"}"}}]}"#,
+            r#"{"role":"tool","content":"file.txt","tool_call_id":"call_1"}"#,
+        ]);
+        let exchanges = parse_kimi_context_jsonl(jsonl.path(), 10, true).unwrap();
+        assert_eq!(exchanges.len(), 1);
+        assert_eq!(exchanges[0].tools.len(), 1);
+        assert_eq!(exchanges[0].tools[0].name, "Bash");
+        assert_eq!(exchanges[0].tools[0].command, Some("ls".to_string()));
+        assert_eq!(exchanges[0].action, "Bash");
+    }
+
+    #[test]
+    fn skips_internal_roles() {
+        let jsonl = make_temp_jsonl(&[
+            r#"{"role":"_system_prompt","content":"you are helpful"}"#,
+            r#"{"role":"user","content":"hi"}"#,
+            r#"{"role":"assistant","content":{"think":"","text":"hello"}}"#,
+            r#"{"role":"_usage","content":""}"#,
+        ]);
+        let exchanges = parse_kimi_context_jsonl(jsonl.path(), 10, true).unwrap();
+        assert_eq!(exchanges.len(), 1);
+        assert_eq!(exchanges[0].user, "hi");
+    }
+}

--- a/src/transcript/mod.rs
+++ b/src/transcript/mod.rs
@@ -68,7 +68,7 @@ pub fn read(path: &Path, kind: ToolKind, opts: &ReadOptions) -> Result<Vec<Excha
         ToolKind::Gemini => gemini::parse_gemini_json(path, opts.last),
         ToolKind::Codex => codex::parse_codex_jsonl(path, opts.last, opts.detailed),
         ToolKind::Cursor => cursor::parse_cursor_jsonl(path, opts.last, opts.detailed),
-        ToolKind::Kimi => kimi::parse_kimi_context_jsonl(path, opts.last, opts.detailed),
+        ToolKind::Kimi => kimi::parse_kimi_wire_jsonl(path, opts.last, opts.detailed),
         ToolKind::OpenCode => {
             let sid = opts.session_id.as_deref().unwrap_or("");
             if sid.is_empty() {

--- a/src/transcript/mod.rs
+++ b/src/transcript/mod.rs
@@ -8,6 +8,7 @@ pub mod claude;
 pub mod codex;
 pub mod cursor;
 pub mod gemini;
+pub mod kimi;
 pub mod opencode;
 pub mod shared;
 
@@ -30,6 +31,7 @@ pub enum ToolKind {
     Codex,
     OpenCode,
     Cursor,
+    Kimi,
 }
 
 /// Options for reading a transcript.
@@ -66,6 +68,7 @@ pub fn read(path: &Path, kind: ToolKind, opts: &ReadOptions) -> Result<Vec<Excha
         ToolKind::Gemini => gemini::parse_gemini_json(path, opts.last),
         ToolKind::Codex => codex::parse_codex_jsonl(path, opts.last, opts.detailed),
         ToolKind::Cursor => cursor::parse_cursor_jsonl(path, opts.last, opts.detailed),
+        ToolKind::Kimi => kimi::parse_kimi_context_jsonl(path, opts.last, opts.detailed),
         ToolKind::OpenCode => {
             let sid = opts.session_id.as_deref().unwrap_or("");
             if sid.is_empty() {
@@ -117,6 +120,7 @@ pub fn kind_from_agent_or_path(agent: &str, path: &str) -> ToolKind {
         "codex" => ToolKind::Codex,
         "opencode" | "kilo" => ToolKind::OpenCode,
         "cursor" | "cursor-agent" => ToolKind::Cursor,
+        "kimi" => ToolKind::Kimi,
         _ => detect_kind_from_path(path).unwrap_or(ToolKind::Claude),
     }
 }

--- a/src/tui/db.rs
+++ b/src/tui/db.rs
@@ -242,6 +242,7 @@ fn parse_tool(s: &str) -> Tool {
         "kilo" => Tool::Kilo,
         "antigravity" => Tool::Antigravity,
         "cursor" => Tool::Cursor,
+        "kimi" => Tool::Kimi,
         _ => Tool::Adhoc,
     }
 }

--- a/src/tui/model.rs
+++ b/src/tui/model.rs
@@ -229,7 +229,14 @@ fn strip_context_prefix(ctx: &str) -> &str {
             other => other,
         };
     }
-    const PREFIXES: &[&str] = &["tool:", "deliver:", "approved:", "stale:", "tui:"];
+    const PREFIXES: &[&str] = &[
+        "tool:",
+        "deliver:",
+        "approved:",
+        "denied:",
+        "stale:",
+        "tui:",
+    ];
     for p in PREFIXES {
         if let Some(rest) = ctx.strip_prefix(p) {
             return rest;

--- a/src/tui/model.rs
+++ b/src/tui/model.rs
@@ -84,6 +84,7 @@ pub enum Tool {
     Kilo,
     Antigravity,
     Cursor,
+    Kimi,
     Adhoc,
 }
 
@@ -98,6 +99,7 @@ impl Tool {
             Self::Kilo => crate::tool::Tool::Kilo,
             Self::Antigravity => crate::tool::Tool::Antigravity,
             Self::Cursor => crate::tool::Tool::Cursor,
+            Self::Kimi => crate::tool::Tool::Kimi,
             Self::Adhoc => crate::tool::Tool::Adhoc,
         }
     }
@@ -120,7 +122,8 @@ impl Tool {
             Self::OpenCode => Self::Kilo,
             Self::Kilo => Self::Antigravity,
             Self::Antigravity => Self::Cursor,
-            Self::Cursor => Self::Claude,
+            Self::Cursor => Self::Kimi,
+            Self::Kimi => Self::Claude,
             Self::Adhoc => Self::Adhoc,
         }
     }
@@ -128,13 +131,14 @@ impl Tool {
     /// Cycle backward (for launch panel). Adhoc is not launchable.
     pub fn prev(&self) -> Self {
         match self {
-            Self::Claude => Self::Cursor,
+            Self::Claude => Self::Kimi,
             Self::Gemini => Self::Claude,
             Self::Codex => Self::Gemini,
             Self::OpenCode => Self::Codex,
             Self::Antigravity => Self::Kilo,
             Self::Kilo => Self::OpenCode,
             Self::Cursor => Self::Antigravity,
+            Self::Kimi => Self::Cursor,
             Self::Adhoc => Self::Adhoc,
         }
     }
@@ -1174,12 +1178,14 @@ mod tests {
         assert_eq!(Tool::OpenCode.next(), Tool::Kilo);
         assert_eq!(Tool::Kilo.next(), Tool::Antigravity);
         assert_eq!(Tool::Antigravity.next(), Tool::Cursor);
-        assert_eq!(Tool::Cursor.next(), Tool::Claude);
+        assert_eq!(Tool::Cursor.next(), Tool::Kimi);
+        assert_eq!(Tool::Kimi.next(), Tool::Claude);
     }
 
     #[test]
     fn tool_prev_cycles_backward() {
-        assert_eq!(Tool::Claude.prev(), Tool::Cursor);
+        assert_eq!(Tool::Claude.prev(), Tool::Kimi);
+        assert_eq!(Tool::Kimi.prev(), Tool::Cursor);
         assert_eq!(Tool::Cursor.prev(), Tool::Antigravity);
         assert_eq!(Tool::Antigravity.prev(), Tool::Kilo);
         assert_eq!(Tool::Kilo.prev(), Tool::OpenCode);

--- a/src/tui/rpc.rs
+++ b/src/tui/rpc.rs
@@ -81,7 +81,7 @@ pub fn build_launch_argv(
     // Tool-specific prompt flags
     if !prompt.is_empty() {
         match tool {
-            Tool::Claude | Tool::Codex | Tool::Cursor => {
+            Tool::Claude | Tool::Codex | Tool::Cursor | Tool::Kimi => {
                 if headless && tool == Tool::Claude {
                     argv.push("-p".into());
                 }


### PR DESCRIPTION
This adds full support for Kimi Code CLI as a new agent in hcom.

**What works:**
- `hcom kimi` — launch Kimi with hcom hooks
- `hcom r <name>` — resume a Kimi session
- `hcom f <name>` — fork a Kimi session
- `hcom hooks add kimi` / `hcom hooks remove kimi` — manage hooks
- Message delivery between Kimi and other agents
- Transcript reading via `hcom transcript`
- TUI cycling through all agents including Kimi

**New files:**
- `src/hooks/kimi.rs` — hook setup, dispatch, TOML config management
- `src/transcript/kimi.rs` — parser for Kimi context.jsonl

**Tests:** 1759 pass, 0 failures. Clippy clean.

**Usage:**
```bash
hcom hooks add kimi
hcom kimi
```