### PR TITLE
fix(binding): delete restore_stopped placeholders and merge notify endpoints

### DIFF
--- a/src/db/events.rs
+++ b/src/db/events.rs
@@ -105,17 +105,19 @@ impl HcomDb {
     /// - event.type = 'message'
     /// - instance is in scope (broadcast or direct)
     pub fn get_unread_messages(&self, name: &str) -> Vec<Message> {
-        // Get last_event_id for this instance
+        // Get last_event_id for this instance. A missing/unreadable row means there is
+        // no recipient — return no unread rather than falling back to cursor 0, which
+        // would treat the whole channel backlog (broadcasts match everyone) as unread.
         let last_event_id = match self.get_instance_status(name) {
             Ok(Some(status)) => status.last_event_id,
-            Ok(None) => 0, // No instance found
+            Ok(None) => return vec![],
             Err(e) => {
                 crate::log::log_error(
                     "db",
                     "get_unread_messages.get_instance_status",
                     &format!("{e}"),
                 );
-                0
+                return vec![];
             }
         };
 
@@ -593,6 +595,27 @@ mod tests {
 
         assert!(id1 > 0);
         assert_eq!(id2, id1 + 1);
+
+        cleanup_test_db(db_path);
+    }
+
+    // Regression: a missing recipient must yield no unread messages, not the whole
+    // backlog (broadcasts match every recipient when the cursor falls back to 0).
+    #[test]
+    fn test_get_unread_messages_empty_for_missing_instance() {
+        let (db, db_path) = setup_full_test_db();
+
+        db.log_event(
+            "message",
+            "kera",
+            &serde_json::json!({"from": "kera", "scope": "broadcast", "text": "ack"}),
+        )
+        .unwrap();
+
+        assert!(
+            db.get_unread_messages("ghost").is_empty(),
+            "missing instance must have no unread, not the full backlog"
+        );
 
         cleanup_test_db(db_path);
     }

--- a/src/db/sessions.rs
+++ b/src/db/sessions.rs
@@ -374,6 +374,13 @@ impl HcomDb {
 }
 
 #[cfg(test)]
+impl HcomDb {
+    pub fn set_test_migrate_notify_fail(fail: bool) {
+        TEST_MIGRATE_NOTIFY_FAIL.store(fail, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::super::HcomDb;
     use super::super::tests::{cleanup_test_db, setup_full_test_db};
@@ -699,12 +706,5 @@ mod tests {
         assert_eq!(endpoint_count_for(&db, "mozi"), 0);
 
         cleanup_test_db(db_path);
-    }
-}
-
-#[cfg(test)]
-impl HcomDb {
-    pub fn set_test_migrate_notify_fail(fail: bool) {
-        TEST_MIGRATE_NOTIFY_FAIL.store(fail, Ordering::SeqCst);
     }
 }

--- a/src/db/sessions.rs
+++ b/src/db/sessions.rs
@@ -6,6 +6,12 @@ use rusqlite::params;
 use super::HcomDb;
 use crate::shared::time::now_epoch_f64;
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(test)]
+static TEST_MIGRATE_NOTIFY_FAIL: AtomicBool = AtomicBool::new(false);
+
 impl HcomDb {
     /// Delete process binding (for cleanup)
     pub fn delete_process_binding(&self, process_id: &str) -> Result<()> {
@@ -62,22 +68,29 @@ impl HcomDb {
             return Ok(());
         }
 
+        #[cfg(test)]
+        if TEST_MIGRATE_NOTIFY_FAIL.load(Ordering::SeqCst) {
+            return Err(anyhow::anyhow!("test_injected_migrate_notify_fail"));
+        }
+
+        let tx = self.conn.unchecked_transaction()?;
         // Drop source rows for kinds the target already owns (e.g. keep canonical `plugin`).
-        self.conn.execute(
+        tx.execute(
             "DELETE FROM notify_endpoints
              WHERE instance = ?1
                AND kind IN (SELECT kind FROM notify_endpoints WHERE instance = ?2)",
             params![old_name, new_name],
         )?;
         // Move remaining kinds to the target, then remove any stragglers on the source.
-        self.conn.execute(
+        tx.execute(
             "UPDATE notify_endpoints SET instance = ?2 WHERE instance = ?1",
             params![old_name, new_name],
         )?;
-        self.conn.execute(
+        tx.execute(
             "DELETE FROM notify_endpoints WHERE instance = ?1",
             params![old_name],
         )?;
+        tx.commit()?;
 
         Ok(())
     }
@@ -365,6 +378,7 @@ mod tests {
     use super::super::HcomDb;
     use super::super::tests::{cleanup_test_db, setup_full_test_db};
     use rusqlite::params;
+    use serial_test::serial;
 
     fn reopen_broken_schema(db_path: &std::path::Path) -> HcomDb {
         // Use open_raw here: open_at would repair the table we deliberately dropped.
@@ -574,8 +588,10 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_migrate_notify_endpoints_preserves_plugin_on_target() {
         let (db, db_path) = setup_full_test_db();
+        HcomDb::set_test_migrate_notify_fail(false);
 
         // Canonical already has plugin from opencode-start; placeholder has PTY ports.
         db.upsert_notify_endpoint("fano", "plugin", 58_898).unwrap();
@@ -593,8 +609,10 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_migrate_notify_endpoints_keeps_target_kind_on_conflict() {
         let (db, db_path) = setup_full_test_db();
+        HcomDb::set_test_migrate_notify_fail(false);
 
         db.upsert_notify_endpoint("fano", "plugin", 58_898).unwrap();
         db.upsert_notify_endpoint("fano", "pty", 58_321).unwrap();
@@ -610,8 +628,10 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_migrate_notify_endpoints_moves_kind_missing_on_target() {
         let (db, db_path) = setup_full_test_db();
+        HcomDb::set_test_migrate_notify_fail(false);
 
         db.upsert_notify_endpoint("fano", "plugin", 58_898).unwrap();
         db.upsert_notify_endpoint("mozi", "pty", 55_568).unwrap();
@@ -623,5 +643,68 @@ mod tests {
         assert_eq!(endpoint_count_for(&db, "mozi"), 0);
 
         cleanup_test_db(db_path);
+    }
+
+    struct MigrateNotifyFailGuard;
+
+    impl MigrateNotifyFailGuard {
+        fn enable() -> Self {
+            HcomDb::set_test_migrate_notify_fail(true);
+            Self
+        }
+    }
+
+    impl Drop for MigrateNotifyFailGuard {
+        fn drop(&mut self) {
+            HcomDb::set_test_migrate_notify_fail(false);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_migrate_notify_endpoints_rolls_back_on_injected_failure() {
+        let (db, db_path) = setup_full_test_db();
+        let _guard = MigrateNotifyFailGuard::enable();
+
+        db.upsert_notify_endpoint("fano", "plugin", 58_898).unwrap();
+        db.upsert_notify_endpoint("mozi", "pty", 55_568).unwrap();
+
+        let err = db
+            .migrate_notify_endpoints("mozi", "fano")
+            .expect_err("injected migrate failure");
+        assert!(
+            err.to_string()
+                .contains("test_injected_migrate_notify_fail")
+        );
+
+        assert_eq!(endpoint_port(&db, "fano", "plugin"), Some(58_898));
+        assert_eq!(endpoint_port(&db, "mozi", "pty"), Some(55_568));
+
+        cleanup_test_db(db_path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_migrate_notify_endpoints_commits_on_success_after_fail_guard_cleared() {
+        let (db, db_path) = setup_full_test_db();
+        HcomDb::set_test_migrate_notify_fail(false);
+
+        db.upsert_notify_endpoint("fano", "plugin", 58_898).unwrap();
+        db.upsert_notify_endpoint("mozi", "pty", 55_568).unwrap();
+
+        db.migrate_notify_endpoints("mozi", "fano").unwrap();
+
+        assert_eq!(endpoint_port(&db, "fano", "plugin"), Some(58_898));
+        assert_eq!(endpoint_port(&db, "fano", "pty"), Some(55_568));
+        assert_eq!(endpoint_count_for(&db, "mozi"), 0);
+
+        cleanup_test_db(db_path);
+    }
+}
+
+#[cfg(test)]
+impl HcomDb {
+    pub fn set_test_migrate_notify_fail(fail: bool) {
+        TEST_MIGRATE_NOTIFY_FAIL.store(fail, Ordering::SeqCst);
     }
 }

--- a/src/db/sessions.rs
+++ b/src/db/sessions.rs
@@ -52,22 +52,31 @@ impl HcomDb {
         }
     }
 
-    /// Migrate notify endpoints from old instance to new instance
+    /// Migrate notify endpoints from old instance to new instance.
+    ///
+    /// Per-kind merge: rows already on `new_name` (e.g. `plugin` registered during
+    /// opencode-start on the canonical name) are preserved; only missing kinds move
+    /// from `old_name`.
     pub fn migrate_notify_endpoints(&self, old_name: &str, new_name: &str) -> Result<()> {
         if old_name == new_name {
             return Ok(());
         }
 
-        // Delete existing endpoints for new name
+        // Drop source rows for kinds the target already owns (e.g. keep canonical `plugin`).
         self.conn.execute(
-            "DELETE FROM notify_endpoints WHERE instance = ?",
-            params![new_name],
+            "DELETE FROM notify_endpoints
+             WHERE instance = ?1
+               AND kind IN (SELECT kind FROM notify_endpoints WHERE instance = ?2)",
+            params![old_name, new_name],
         )?;
-
-        // Move endpoints from old to new
+        // Move remaining kinds to the target, then remove any stragglers on the source.
         self.conn.execute(
-            "UPDATE notify_endpoints SET instance = ? WHERE instance = ?",
-            params![new_name, old_name],
+            "UPDATE notify_endpoints SET instance = ?2 WHERE instance = ?1",
+            params![old_name, new_name],
+        )?;
+        self.conn.execute(
+            "DELETE FROM notify_endpoints WHERE instance = ?1",
+            params![old_name],
         )?;
 
         Ok(())
@@ -355,6 +364,7 @@ impl HcomDb {
 mod tests {
     use super::super::HcomDb;
     use super::super::tests::{cleanup_test_db, setup_full_test_db};
+    use rusqlite::params;
 
     fn reopen_broken_schema(db_path: &std::path::Path) -> HcomDb {
         // Use open_raw here: open_at would repair the table we deliberately dropped.
@@ -539,6 +549,78 @@ mod tests {
 
         db.delete_process_bindings_for_instance("luna").unwrap();
         assert!(!db.has_process_binding_for_instance("luna"));
+
+        cleanup_test_db(db_path);
+    }
+
+    fn endpoint_port(db: &HcomDb, instance: &str, kind: &str) -> Option<i64> {
+        db.conn
+            .query_row(
+                "SELECT port FROM notify_endpoints WHERE instance = ? AND kind = ?",
+                params![instance, kind],
+                |row| row.get(0),
+            )
+            .ok()
+    }
+
+    fn endpoint_count_for(db: &HcomDb, instance: &str) -> i64 {
+        db.conn
+            .query_row(
+                "SELECT COUNT(*) FROM notify_endpoints WHERE instance = ?",
+                params![instance],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn test_migrate_notify_endpoints_preserves_plugin_on_target() {
+        let (db, db_path) = setup_full_test_db();
+
+        // Canonical already has plugin from opencode-start; placeholder has PTY ports.
+        db.upsert_notify_endpoint("fano", "plugin", 58_898).unwrap();
+        db.upsert_notify_endpoint("mozi", "pty", 55_568).unwrap();
+        db.upsert_notify_endpoint("mozi", "inject", 55_558).unwrap();
+
+        db.migrate_notify_endpoints("mozi", "fano").unwrap();
+
+        assert_eq!(endpoint_port(&db, "fano", "plugin"), Some(58_898));
+        assert_eq!(endpoint_port(&db, "fano", "pty"), Some(55_568));
+        assert_eq!(endpoint_port(&db, "fano", "inject"), Some(55_558));
+        assert_eq!(endpoint_count_for(&db, "mozi"), 0);
+
+        cleanup_test_db(db_path);
+    }
+
+    #[test]
+    fn test_migrate_notify_endpoints_keeps_target_kind_on_conflict() {
+        let (db, db_path) = setup_full_test_db();
+
+        db.upsert_notify_endpoint("fano", "plugin", 58_898).unwrap();
+        db.upsert_notify_endpoint("fano", "pty", 58_321).unwrap();
+        db.upsert_notify_endpoint("mozi", "pty", 55_568).unwrap();
+
+        db.migrate_notify_endpoints("mozi", "fano").unwrap();
+
+        assert_eq!(endpoint_port(&db, "fano", "plugin"), Some(58_898));
+        assert_eq!(endpoint_port(&db, "fano", "pty"), Some(58_321));
+        assert_eq!(endpoint_count_for(&db, "mozi"), 0);
+
+        cleanup_test_db(db_path);
+    }
+
+    #[test]
+    fn test_migrate_notify_endpoints_moves_kind_missing_on_target() {
+        let (db, db_path) = setup_full_test_db();
+
+        db.upsert_notify_endpoint("fano", "plugin", 58_898).unwrap();
+        db.upsert_notify_endpoint("mozi", "pty", 55_568).unwrap();
+
+        db.migrate_notify_endpoints("mozi", "fano").unwrap();
+
+        assert_eq!(endpoint_port(&db, "fano", "plugin"), Some(58_898));
+        assert_eq!(endpoint_port(&db, "fano", "pty"), Some(55_568));
+        assert_eq!(endpoint_count_for(&db, "mozi"), 0);
 
         cleanup_test_db(db_path);
     }

--- a/src/db/sessions.rs
+++ b/src/db/sessions.rs
@@ -60,9 +60,11 @@ impl HcomDb {
 
     /// Migrate notify endpoints from old instance to new instance.
     ///
-    /// Per-kind merge: rows already on `new_name` (e.g. `plugin` registered during
-    /// opencode-start on the canonical name) are preserved; only missing kinds move
-    /// from `old_name`.
+    /// Per-kind merge with **source-wins on conflict**: `old_name` is the freshly
+    /// launched/live process (placeholder or rebinding pid), so its `pty`/`inject`
+    /// ports are authoritative and overwrite any stale ports on `new_name` left by a
+    /// crashed or incompletely-cleaned prior process. Kinds only present on `new_name`
+    /// (e.g. the canonical `plugin` registered during opencode-start) are preserved.
     pub fn migrate_notify_endpoints(&self, old_name: &str, new_name: &str) -> Result<()> {
         if old_name == new_name {
             return Ok(());
@@ -74,21 +76,18 @@ impl HcomDb {
         }
 
         let tx = self.conn.unchecked_transaction()?;
-        // Drop source rows for kinds the target already owns (e.g. keep canonical `plugin`).
+        // Drop target rows for kinds the source will bring (source wins), keeping
+        // target-only kinds like `plugin`.
         tx.execute(
             "DELETE FROM notify_endpoints
-             WHERE instance = ?1
-               AND kind IN (SELECT kind FROM notify_endpoints WHERE instance = ?2)",
+             WHERE instance = ?2
+               AND kind IN (SELECT kind FROM notify_endpoints WHERE instance = ?1)",
             params![old_name, new_name],
         )?;
-        // Move remaining kinds to the target, then remove any stragglers on the source.
+        // Move the source's (now conflict-free) rows onto the target.
         tx.execute(
             "UPDATE notify_endpoints SET instance = ?2 WHERE instance = ?1",
             params![old_name, new_name],
-        )?;
-        tx.execute(
-            "DELETE FROM notify_endpoints WHERE instance = ?1",
-            params![old_name],
         )?;
         tx.commit()?;
 
@@ -129,10 +128,14 @@ impl HcomDb {
     pub fn has_pending(&self, name: &str) -> bool {
         let last_event_id = match self.get_instance_status(name) {
             Ok(Some(status)) => status.last_event_id,
-            Ok(None) => 0,
+            // No instance row (e.g. a launch placeholder deleted after restore_stopped
+            // rebinds to the canonical name) ⇒ no recipient ⇒ nothing pending. Falling
+            // back to cursor 0 here would treat the entire channel backlog as unread and
+            // replay a stale broadcast into the resumed session.
+            Ok(None) => return false,
             Err(e) => {
                 crate::log::log_error("db", "has_pending.get_instance_status", &format!("{e}"));
-                0
+                return false;
             }
         };
 
@@ -392,6 +395,41 @@ mod tests {
         HcomDb::open_raw(db_path).unwrap()
     }
 
+    // Regression: a deleted/missing instance row must not make has_pending fall back
+    // to cursor 0, which would treat the whole channel backlog (broadcasts match every
+    // recipient) as unread and replay a stale message into a freshly-resumed session.
+    #[test]
+    fn test_has_pending_false_for_missing_instance() {
+        let (db, db_path) = setup_full_test_db();
+
+        // A broadcast in history (delivers to all recipients).
+        db.conn
+            .execute(
+                "INSERT INTO events (type, timestamp, instance, data)
+                 VALUES ('message', '2026-01-01T00:00:00Z', 'kera',
+                         '{\"from\":\"kera\",\"scope\":\"broadcast\",\"text\":\"ack\"}')",
+                [],
+            )
+            .unwrap();
+
+        // No instance row named "ghost" exists.
+        assert!(
+            !db.has_pending("ghost"),
+            "missing instance must have nothing pending, not the full backlog"
+        );
+
+        // Sanity: a real instance with cursor 0 still sees the broadcast.
+        db.conn
+            .execute(
+                "INSERT INTO instances (name, created_at, last_event_id) VALUES ('real', 1.0, 0)",
+                [],
+            )
+            .unwrap();
+        assert!(db.has_pending("real"));
+
+        cleanup_test_db(db_path);
+    }
+
     #[test]
     fn test_get_process_binding_propagates_prepare_error() {
         let (db, db_path) = setup_full_test_db();
@@ -617,10 +655,12 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_migrate_notify_endpoints_keeps_target_kind_on_conflict() {
+    fn test_migrate_notify_endpoints_source_wins_on_conflict() {
         let (db, db_path) = setup_full_test_db();
         HcomDb::set_test_migrate_notify_fail(false);
 
+        // Target (fano) holds a stale pty from a prior process; source (mozi) is the
+        // freshly launched process. Source's pty must win; target-only plugin is kept.
         db.upsert_notify_endpoint("fano", "plugin", 58_898).unwrap();
         db.upsert_notify_endpoint("fano", "pty", 58_321).unwrap();
         db.upsert_notify_endpoint("mozi", "pty", 55_568).unwrap();
@@ -628,7 +668,7 @@ mod tests {
         db.migrate_notify_endpoints("mozi", "fano").unwrap();
 
         assert_eq!(endpoint_port(&db, "fano", "plugin"), Some(58_898));
-        assert_eq!(endpoint_port(&db, "fano", "pty"), Some(58_321));
+        assert_eq!(endpoint_port(&db, "fano", "pty"), Some(55_568));
         assert_eq!(endpoint_count_for(&db, "mozi"), 0);
 
         cleanup_test_db(db_path);

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -881,6 +881,14 @@ mod tests {
         insert_instance(&db, "canonical", Some("thread-resume"), None);
         insert_session_binding(&db, "thread-resume", "canonical");
         insert_instance(&db, "placeholder", None, None);
+        // Real launch placeholders are pending/new (PLACEHOLDER_STATUS/CONTEXT); set that
+        // here so deletion is gated on genuine placeholder-ness, not merely a null session.
+        db.conn()
+            .execute(
+                "UPDATE instances SET status = 'pending', status_context = 'new' WHERE name = 'placeholder'",
+                [],
+            )
+            .unwrap();
         insert_process_binding(&db, "pid-codex", "placeholder");
 
         let identity = resolve_identity(

--- a/src/instance_binding.rs
+++ b/src/instance_binding.rs
@@ -258,27 +258,40 @@ fn is_true_launch_placeholder(data: Option<&InstanceRow>) -> bool {
         .unwrap_or(false)
 }
 
-fn rollback_placeholder_notify_migration(
-    db: &HcomDb,
-    canonical_name: &str,
-    placeholder_name: &str,
-) {
-    if let Err(e) = db.migrate_notify_endpoints(canonical_name, placeholder_name) {
-        crate::log::log_error("binding", "placeholder.rollback_endpoints", &format!("{e}"));
+fn migrate_placeholder_notify(db: &HcomDb, placeholder_name: &str, canonical_name: &str) -> bool {
+    match db.migrate_notify_endpoints(placeholder_name, canonical_name) {
+        Ok(()) => true,
+        Err(e) => {
+            crate::log::log_error("binding", "placeholder.migrate_endpoints", &format!("{e}"));
+            false
+        }
     }
 }
 
-/// Delete a true launch placeholder row; restore notify rows on failure.
-fn delete_true_placeholder_instance(db: &HcomDb, placeholder_name: &str, canonical_name: &str) {
+/// Delete a true launch placeholder row. Notify endpoints remain on the canonical instance.
+fn delete_true_placeholder_instance(db: &HcomDb, placeholder_name: &str) {
     match db.delete_instance(placeholder_name) {
         Ok(true) => {}
         Ok(false) => {
-            rollback_placeholder_notify_migration(db, canonical_name, placeholder_name);
+            crate::log::log_info(
+                "binding",
+                "placeholder.delete_missing",
+                &format!("placeholder={placeholder_name}"),
+            );
         }
         Err(e) => {
             crate::log::log_error("binding", "placeholder.delete", &format!("{e}"));
-            rollback_placeholder_notify_migration(db, canonical_name, placeholder_name);
         }
+    }
+}
+
+fn delete_true_placeholder_if_migrated(
+    db: &HcomDb,
+    placeholder_name: &str,
+    placeholder_data: Option<&InstanceRow>,
+) {
+    if is_true_launch_placeholder(placeholder_data) {
+        delete_true_placeholder_instance(db, placeholder_name);
     }
 }
 
@@ -296,13 +309,11 @@ fn retire_true_placeholder_after_canonical_bind(
         return;
     }
 
-    if let Err(e) = db.migrate_notify_endpoints(ph_name, canonical_name) {
-        crate::log::log_error("binding", "placeholder.migrate_endpoints", &format!("{e}"));
+    if !migrate_placeholder_notify(db, ph_name, canonical_name) {
+        return;
     }
 
-    if is_true_launch_placeholder(placeholder_data) {
-        delete_true_placeholder_instance(db, ph_name, canonical_name);
-    }
+    delete_true_placeholder_if_migrated(db, ph_name, placeholder_data);
 }
 
 /// Recreate a missing instance row from an active placeholder (resume after stop/kill).
@@ -409,14 +420,7 @@ pub fn bind_session_to_process(
         if let Some(ref ph_name) = placeholder_name
             && ph_name != canonical_name
         {
-            // Always migrate notify_endpoints
-            if let Err(e) = db.migrate_notify_endpoints(ph_name, canonical_name) {
-                crate::log::log_error(
-                    "binding",
-                    "bind_canonical.migrate_endpoints",
-                    &format!("{e}"),
-                );
-            }
+            let migrated = migrate_placeholder_notify(db, ph_name, canonical_name);
 
             if is_true_launch_placeholder(placeholder_data.as_ref()) {
                 // Path 1a: True placeholder merge
@@ -437,8 +441,10 @@ pub fn bind_session_to_process(
                     }
                 }
 
-                delete_true_placeholder_instance(db, ph_name, canonical_name);
-            } else {
+                if migrated {
+                    delete_true_placeholder_if_migrated(db, ph_name, placeholder_data.as_ref());
+                }
+            } else if migrated {
                 // Path 1b: Session switch — mark old instance inactive
                 crate::instance_lifecycle::set_status(
                     db,
@@ -1419,6 +1425,90 @@ mod tests {
         );
         assert_eq!(
             db.get_process_binding("pid-oc").unwrap(),
+            Some("fano".to_string())
+        );
+
+        cleanup(path);
+    }
+
+    fn notify_endpoint_port(db: &HcomDb, instance: &str, kind: &str) -> Option<i64> {
+        db.conn()
+            .query_row(
+                "SELECT port FROM notify_endpoints WHERE instance = ?1 AND kind = ?2",
+                rusqlite::params![instance, kind],
+                |row| row.get(0),
+            )
+            .ok()
+    }
+
+    struct MigrateNotifyFailGuard;
+
+    impl MigrateNotifyFailGuard {
+        fn enable() -> Self {
+            HcomDb::set_test_migrate_notify_fail(true);
+            Self
+        }
+    }
+
+    impl Drop for MigrateNotifyFailGuard {
+        fn drop(&mut self) {
+            HcomDb::set_test_migrate_notify_fail(false);
+        }
+    }
+
+    #[test]
+    fn test_delete_placeholder_failure_keeps_notify_on_canonical() {
+        let (db, path) = setup_test_db();
+
+        db.upsert_notify_endpoint("fano", "plugin", 58_898).unwrap();
+        db.upsert_notify_endpoint("mozi", "pty", 55_568).unwrap();
+        db.migrate_notify_endpoints("mozi", "fano").unwrap();
+
+        delete_true_placeholder_instance(&db, "ghost_placeholder");
+
+        assert_eq!(notify_endpoint_port(&db, "fano", "plugin"), Some(58_898));
+        assert_eq!(notify_endpoint_port(&db, "fano", "pty"), Some(55_568));
+
+        cleanup(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_retire_skips_delete_when_migrate_fails() {
+        crate::config::Config::init();
+        let (db, path) = setup_test_db();
+        let _guard = MigrateNotifyFailGuard::enable();
+        let now = now_epoch_i64();
+
+        let mut fano_data = serde_json::Map::new();
+        fano_data.insert("name".into(), serde_json::json!("fano"));
+        fano_data.insert("tool".into(), serde_json::json!("opencode"));
+        fano_data.insert("created_at".into(), serde_json::json!(now));
+        fano_data.insert("status".into(), serde_json::json!("inactive"));
+        db.save_instance_named("fano", &fano_data).unwrap();
+
+        let snapshot = serde_json::json!({
+            "session_id": "ses-opencode-1",
+            "tool": "opencode",
+        });
+        db.log_life_event("fano", "stopped", "test", "exit", Some(snapshot))
+            .unwrap();
+
+        let mut mozi_data = serde_json::Map::new();
+        mozi_data.insert("name".into(), serde_json::json!("mozi"));
+        mozi_data.insert("tool".into(), serde_json::json!("opencode"));
+        mozi_data.insert("created_at".into(), serde_json::json!(now));
+        mozi_data.insert("status".into(), serde_json::json!("pending"));
+        mozi_data.insert("status_context".into(), serde_json::json!("new"));
+        db.save_instance_named("mozi", &mozi_data).unwrap();
+        db.set_process_binding("pid-oc", "", "mozi").unwrap();
+
+        let result = bind_session_to_process(&db, "ses-opencode-1", Some("pid-oc"));
+        assert_eq!(result, Some("fano".to_string()));
+
+        assert!(db.get_instance_full("mozi").unwrap().is_some());
+        assert_eq!(
+            db.get_session_binding("ses-opencode-1").unwrap(),
             Some("fano".to_string())
         );
 

--- a/src/instance_binding.rs
+++ b/src/instance_binding.rs
@@ -258,13 +258,13 @@ fn is_true_launch_placeholder(data: Option<&InstanceRow>) -> bool {
         .unwrap_or(false)
 }
 
-fn rollback_placeholder_notify_migration(db: &HcomDb, canonical_name: &str, placeholder_name: &str) {
+fn rollback_placeholder_notify_migration(
+    db: &HcomDb,
+    canonical_name: &str,
+    placeholder_name: &str,
+) {
     if let Err(e) = db.migrate_notify_endpoints(canonical_name, placeholder_name) {
-        crate::log::log_error(
-            "binding",
-            "placeholder.rollback_endpoints",
-            &format!("{e}"),
-        );
+        crate::log::log_error("binding", "placeholder.rollback_endpoints", &format!("{e}"));
     }
 }
 
@@ -276,11 +276,7 @@ fn delete_true_placeholder_instance(db: &HcomDb, placeholder_name: &str, canonic
             rollback_placeholder_notify_migration(db, canonical_name, placeholder_name);
         }
         Err(e) => {
-            crate::log::log_error(
-                "binding",
-                "placeholder.delete",
-                &format!("{e}"),
-            );
+            crate::log::log_error("binding", "placeholder.delete", &format!("{e}"));
             rollback_placeholder_notify_migration(db, canonical_name, placeholder_name);
         }
     }
@@ -301,11 +297,7 @@ fn retire_true_placeholder_after_canonical_bind(
     }
 
     if let Err(e) = db.migrate_notify_endpoints(ph_name, canonical_name) {
-        crate::log::log_error(
-            "binding",
-            "placeholder.migrate_endpoints",
-            &format!("{e}"),
-        );
+        crate::log::log_error("binding", "placeholder.migrate_endpoints", &format!("{e}"));
     }
 
     if is_true_launch_placeholder(placeholder_data) {

--- a/src/instance_binding.rs
+++ b/src/instance_binding.rs
@@ -252,6 +252,67 @@ fn zellij_pane_id_from_terminal_id(terminal_id: &str) -> Option<String> {
         .map(|suffix| suffix.to_string())
 }
 
+fn is_true_launch_placeholder(data: Option<&InstanceRow>) -> bool {
+    data.as_ref()
+        .map(|d| d.session_id.is_none())
+        .unwrap_or(false)
+}
+
+fn rollback_placeholder_notify_migration(db: &HcomDb, canonical_name: &str, placeholder_name: &str) {
+    if let Err(e) = db.migrate_notify_endpoints(canonical_name, placeholder_name) {
+        crate::log::log_error(
+            "binding",
+            "placeholder.rollback_endpoints",
+            &format!("{e}"),
+        );
+    }
+}
+
+/// Delete a true launch placeholder row; restore notify rows on failure.
+fn delete_true_placeholder_instance(db: &HcomDb, placeholder_name: &str, canonical_name: &str) {
+    match db.delete_instance(placeholder_name) {
+        Ok(true) => {}
+        Ok(false) => {
+            rollback_placeholder_notify_migration(db, canonical_name, placeholder_name);
+        }
+        Err(e) => {
+            crate::log::log_error(
+                "binding",
+                "placeholder.delete",
+                &format!("{e}"),
+            );
+            rollback_placeholder_notify_migration(db, canonical_name, placeholder_name);
+        }
+    }
+}
+
+/// Path 2: after restore_stopped bind, merge notify ports and drop the launch placeholder.
+fn retire_true_placeholder_after_canonical_bind(
+    db: &HcomDb,
+    placeholder_name: Option<&String>,
+    canonical_name: &str,
+    placeholder_data: Option<&InstanceRow>,
+) {
+    let Some(ph_name) = placeholder_name else {
+        return;
+    };
+    if ph_name == canonical_name {
+        return;
+    }
+
+    if let Err(e) = db.migrate_notify_endpoints(ph_name, canonical_name) {
+        crate::log::log_error(
+            "binding",
+            "placeholder.migrate_endpoints",
+            &format!("{e}"),
+        );
+    }
+
+    if is_true_launch_placeholder(placeholder_data) {
+        delete_true_placeholder_instance(db, ph_name, canonical_name);
+    }
+}
+
 /// Recreate a missing instance row from an active placeholder (resume after stop/kill).
 fn recreate_instance_from_placeholder(
     db: &HcomDb,
@@ -365,12 +426,7 @@ pub fn bind_session_to_process(
                 );
             }
 
-            let is_true_placeholder = placeholder_data
-                .as_ref()
-                .map(|d| d.session_id.is_none())
-                .unwrap_or(false);
-
-            if is_true_placeholder {
+            if is_true_launch_placeholder(placeholder_data.as_ref()) {
                 // Path 1a: True placeholder merge
                 if let Some(ref ph_data) = placeholder_data {
                     if let Some(ref tag) = ph_data.tag {
@@ -389,33 +445,7 @@ pub fn bind_session_to_process(
                     }
                 }
 
-                // Delete true placeholder (temporary identity)
-                match db.delete_instance(ph_name) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        if let Err(e) = db.migrate_notify_endpoints(canonical_name, ph_name) {
-                            crate::log::log_error(
-                                "binding",
-                                "bind_canonical.rollback_endpoints",
-                                &format!("{e}"),
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        crate::log::log_error(
-                            "binding",
-                            "bind_canonical.delete_placeholder",
-                            &format!("{e}"),
-                        );
-                        if let Err(e) = db.migrate_notify_endpoints(canonical_name, ph_name) {
-                            crate::log::log_error(
-                                "binding",
-                                "bind_canonical.rollback_endpoints",
-                                &format!("{e}"),
-                            );
-                        }
-                    }
-                }
+                delete_true_placeholder_instance(db, ph_name, canonical_name);
             } else {
                 // Path 1b: Session switch — mark old instance inactive
                 crate::instance_lifecycle::set_status(
@@ -484,6 +514,14 @@ pub fn bind_session_to_process(
                 &format!("{e}"),
             );
         }
+
+        retire_true_placeholder_after_canonical_bind(
+            db,
+            placeholder_name.as_ref(),
+            &stopped_name,
+            placeholder_data.as_ref(),
+        );
+
         return Some(stopped_name);
     }
 
@@ -1340,6 +1378,57 @@ mod tests {
         assert_eq!(restored.session_id.as_deref(), Some("sid-resume"));
         assert_eq!(restored.tool, "antigravity");
         assert_eq!(restored.tag.as_deref(), Some("work"));
+        assert!(db.get_instance_full("nova").unwrap().is_none());
+
+        cleanup(path);
+    }
+
+    #[test]
+    fn test_bind_session_restore_stopped_deletes_true_placeholder() {
+        crate::config::Config::init();
+        let (db, path) = setup_test_db();
+        let now = now_epoch_i64();
+
+        let mut fano_data = serde_json::Map::new();
+        fano_data.insert("name".into(), serde_json::json!("fano"));
+        fano_data.insert("tool".into(), serde_json::json!("opencode"));
+        fano_data.insert("created_at".into(), serde_json::json!(now));
+        fano_data.insert("status".into(), serde_json::json!("inactive"));
+        db.save_instance_named("fano", &fano_data).unwrap();
+
+        let snapshot = serde_json::json!({
+            "session_id": "ses-opencode-1",
+            "tool": "opencode",
+        });
+        db.log_life_event("fano", "stopped", "test", "exit", Some(snapshot))
+            .unwrap();
+
+        let mut mozi_data = serde_json::Map::new();
+        mozi_data.insert("name".into(), serde_json::json!("mozi"));
+        mozi_data.insert("tool".into(), serde_json::json!("opencode"));
+        mozi_data.insert("created_at".into(), serde_json::json!(now));
+        mozi_data.insert("status".into(), serde_json::json!("pending"));
+        mozi_data.insert("status_context".into(), serde_json::json!("new"));
+        db.save_instance_named("mozi", &mozi_data).unwrap();
+        db.set_process_binding("pid-oc", "", "mozi").unwrap();
+
+        db.upsert_notify_endpoint("mozi", "pty", 55_568).unwrap();
+        db.upsert_notify_endpoint("fano", "plugin", 58_898).unwrap();
+
+        let result = bind_session_to_process(&db, "ses-opencode-1", Some("pid-oc"));
+        assert_eq!(result, Some("fano".to_string()));
+
+        assert!(db.get_instance_full("mozi").unwrap().is_none());
+        let fano = db.get_instance_full("fano").unwrap().unwrap();
+        assert_eq!(fano.session_id.as_deref(), Some("ses-opencode-1"));
+        assert_eq!(
+            db.get_session_binding("ses-opencode-1").unwrap(),
+            Some("fano".to_string())
+        );
+        assert_eq!(
+            db.get_process_binding("pid-oc").unwrap(),
+            Some("fano".to_string())
+        );
 
         cleanup(path);
     }

--- a/src/instance_binding.rs
+++ b/src/instance_binding.rs
@@ -1451,6 +1451,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_bind_session_restore_stopped_deletes_true_placeholder() {
         crate::config::Config::init();
         let (db, path) = setup_test_db();
@@ -1501,6 +1502,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_restore_stopped_migrates_pid_and_launch_context_to_canonical() {
         crate::config::Config::init();
         let (db, path) = setup_test_db();
@@ -1555,6 +1557,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_restore_stopped_migrates_ready_promoted_placeholder_runtime_state() {
         crate::config::Config::init();
         let (db, path) = setup_test_db();

--- a/src/instance_binding.rs
+++ b/src/instance_binding.rs
@@ -7,8 +7,8 @@
 use crate::db::{HcomDb, InstanceRow};
 use crate::instance_names::{PLACEHOLDER_CONTEXT, PLACEHOLDER_STATUS};
 use crate::instances::update_instance_position;
-use crate::shared::ST_INACTIVE;
 use crate::shared::time::{now_epoch_f64, now_epoch_i64};
+use crate::shared::{ST_INACTIVE, ST_LISTENING};
 
 /// Persist terminal launch metadata without clobbering other launch_context fields.
 ///
@@ -253,9 +253,27 @@ fn zellij_pane_id_from_terminal_id(terminal_id: &str) -> Option<String> {
 }
 
 fn is_true_launch_placeholder(data: Option<&InstanceRow>) -> bool {
-    data.as_ref()
-        .map(|d| d.session_id.is_none())
-        .unwrap_or(false)
+    let Some(data) = data else {
+        return false;
+    };
+    if data.session_id.is_some() {
+        return false;
+    }
+
+    if crate::instances::is_launching_placeholder(data) {
+        return true;
+    }
+
+    // OpenCode and other PTY-backed tools can be marked ready/listening by the PTY
+    // watcher before their later session-start hook binds a session id. Those rows
+    // are still launch placeholders, but no longer match the stricter "pending/new"
+    // display predicate. Keep this narrow: active no-session rows are real work, not
+    // launch placeholders.
+    data.status == ST_LISTENING
+        && matches!(
+            data.status_context.as_str(),
+            "start" | "ready_observed" | "launch_blocked_cleared"
+        )
 }
 
 fn migrate_placeholder_notify(db: &HcomDb, placeholder_name: &str, canonical_name: &str) -> bool {
@@ -285,12 +303,46 @@ fn delete_true_placeholder_instance(db: &HcomDb, placeholder_name: &str) {
     }
 }
 
+/// Carry runtime state the PTY wrapper wrote onto the placeholder row over to the
+/// canonical instance before the placeholder is deleted. The OS `pid` and terminal
+/// `launch_context` (pane_id) are written once at spawn under the launch name
+/// (`src/pty/mod.rs`); without migrating them, `hcom kill <canonical>` finds no pid
+/// and can't close the terminal pane.
+fn migrate_placeholder_runtime_state(
+    db: &HcomDb,
+    canonical_name: &str,
+    placeholder_data: Option<&InstanceRow>,
+) {
+    let Some(ph) = placeholder_data else {
+        return;
+    };
+    if let Some(pid) = ph.pid
+        && let Ok(pid_u32) = u32::try_from(pid)
+        && let Err(e) = db.update_instance_pid(canonical_name, pid_u32)
+    {
+        crate::log::log_error("binding", "placeholder.migrate_pid", &format!("{e}"));
+    }
+    if let Some(ref ctx) = ph.launch_context
+        && let Err(e) = db.store_launch_context(canonical_name, ctx)
+    {
+        crate::log::log_error(
+            "binding",
+            "placeholder.migrate_launch_context",
+            &format!("{e}"),
+        );
+    }
+}
+
 fn delete_true_placeholder_if_migrated(
     db: &HcomDb,
     placeholder_name: &str,
+    canonical_name: &str,
     placeholder_data: Option<&InstanceRow>,
 ) {
     if is_true_launch_placeholder(placeholder_data) {
+        // Move pid/launch_context to the canonical row before dropping the placeholder
+        // so the restored agent stays killable and its pane closeable.
+        migrate_placeholder_runtime_state(db, canonical_name, placeholder_data);
         delete_true_placeholder_instance(db, placeholder_name);
     }
 }
@@ -313,7 +365,7 @@ fn retire_true_placeholder_after_canonical_bind(
         return;
     }
 
-    delete_true_placeholder_if_migrated(db, ph_name, placeholder_data);
+    delete_true_placeholder_if_migrated(db, ph_name, canonical_name, placeholder_data);
 }
 
 /// Recreate a missing instance row from an active placeholder (resume after stop/kill).
@@ -442,10 +494,27 @@ pub fn bind_session_to_process(
                 }
 
                 if migrated {
-                    delete_true_placeholder_if_migrated(db, ph_name, placeholder_data.as_ref());
+                    delete_true_placeholder_if_migrated(
+                        db,
+                        ph_name,
+                        canonical_name,
+                        placeholder_data.as_ref(),
+                    );
                 }
-            } else if migrated {
-                // Path 1b: Session switch — mark old instance inactive
+            } else {
+                // Path 1b: Session switch — retire the real old identity. Unlike a true
+                // launch placeholder (deletion above stays gated on endpoint migration),
+                // this is a live old identity: retire it regardless of migration outcome,
+                // else a migrate failure leaves a duplicate active/listening row and a
+                // stale session binding. Endpoints may remain imperfect on the old name,
+                // but the delivery loop re-registers under the canonical name.
+                if !migrated {
+                    crate::log::log_info(
+                        "binding",
+                        "bind_canonical.session_switch_migrate_failed",
+                        &format!("endpoints may remain on {ph_name}; retiring identity anyway"),
+                    );
+                }
                 crate::instance_lifecycle::set_status(
                     db,
                     ph_name,
@@ -1426,6 +1495,156 @@ mod tests {
         assert_eq!(
             db.get_process_binding("pid-oc").unwrap(),
             Some("fano".to_string())
+        );
+
+        cleanup(path);
+    }
+
+    #[test]
+    fn test_restore_stopped_migrates_pid_and_launch_context_to_canonical() {
+        crate::config::Config::init();
+        let (db, path) = setup_test_db();
+        let now = now_epoch_i64();
+
+        let mut fano_data = serde_json::Map::new();
+        fano_data.insert("name".into(), serde_json::json!("fano"));
+        fano_data.insert("tool".into(), serde_json::json!("opencode"));
+        fano_data.insert("created_at".into(), serde_json::json!(now));
+        fano_data.insert("status".into(), serde_json::json!("inactive"));
+        db.save_instance_named("fano", &fano_data).unwrap();
+        db.log_life_event(
+            "fano",
+            "stopped",
+            "test",
+            "exit",
+            Some(serde_json::json!({ "session_id": "ses-oc-pid", "tool": "opencode" })),
+        )
+        .unwrap();
+
+        // Launch placeholder with the runtime state the PTY wrapper writes at spawn.
+        let mut mozi_data = serde_json::Map::new();
+        mozi_data.insert("name".into(), serde_json::json!("mozi"));
+        mozi_data.insert("tool".into(), serde_json::json!("opencode"));
+        mozi_data.insert("created_at".into(), serde_json::json!(now));
+        mozi_data.insert("status".into(), serde_json::json!("pending"));
+        mozi_data.insert("status_context".into(), serde_json::json!("new"));
+        db.save_instance_named("mozi", &mozi_data).unwrap();
+        db.set_process_binding("pid-oc", "", "mozi").unwrap();
+        db.update_instance_pid("mozi", 4242).unwrap();
+        db.store_launch_context("mozi", r#"{"pane_id":"kitty-99"}"#)
+            .unwrap();
+
+        let result = bind_session_to_process(&db, "ses-oc-pid", Some("pid-oc"));
+        assert_eq!(result, Some("fano".to_string()));
+
+        // Placeholder gone; pid + launch_context now live on the canonical so the
+        // restored agent stays killable and its pane closeable.
+        assert!(db.get_instance_full("mozi").unwrap().is_none());
+        let fano = db.get_instance_full("fano").unwrap().unwrap();
+        assert_eq!(fano.pid, Some(4242));
+        assert!(
+            fano.launch_context
+                .as_deref()
+                .unwrap_or_default()
+                .contains("kitty-99"),
+            "launch_context not migrated: {:?}",
+            fano.launch_context
+        );
+
+        cleanup(path);
+    }
+
+    #[test]
+    fn test_restore_stopped_migrates_ready_promoted_placeholder_runtime_state() {
+        crate::config::Config::init();
+        let (db, path) = setup_test_db();
+        let now = now_epoch_i64();
+
+        let mut fano_data = serde_json::Map::new();
+        fano_data.insert("name".into(), serde_json::json!("fano"));
+        fano_data.insert("tool".into(), serde_json::json!("opencode"));
+        fano_data.insert("created_at".into(), serde_json::json!(now));
+        fano_data.insert("status".into(), serde_json::json!("inactive"));
+        db.save_instance_named("fano", &fano_data).unwrap();
+        db.log_life_event(
+            "fano",
+            "stopped",
+            "test",
+            "exit",
+            Some(serde_json::json!({ "session_id": "ses-oc-ready", "tool": "opencode" })),
+        )
+        .unwrap();
+
+        // PTY ready detection can promote the launch row before opencode-start binds
+        // the session. It is still the launch placeholder and must be retired.
+        let mut mozi_data = serde_json::Map::new();
+        mozi_data.insert("name".into(), serde_json::json!("mozi"));
+        mozi_data.insert("tool".into(), serde_json::json!("opencode"));
+        mozi_data.insert("created_at".into(), serde_json::json!(now));
+        mozi_data.insert("status".into(), serde_json::json!("listening"));
+        mozi_data.insert("status_context".into(), serde_json::json!("start"));
+        db.save_instance_named("mozi", &mozi_data).unwrap();
+        db.set_process_binding("pid-oc-ready", "", "mozi").unwrap();
+        db.update_instance_pid("mozi", 4343).unwrap();
+        db.store_launch_context("mozi", r#"{"pane_id":"kitty-101"}"#)
+            .unwrap();
+
+        let result = bind_session_to_process(&db, "ses-oc-ready", Some("pid-oc-ready"));
+        assert_eq!(result, Some("fano".to_string()));
+
+        assert!(db.get_instance_full("mozi").unwrap().is_none());
+        let fano = db.get_instance_full("fano").unwrap().unwrap();
+        assert_eq!(fano.pid, Some(4343));
+        assert!(
+            fano.launch_context
+                .as_deref()
+                .unwrap_or_default()
+                .contains("kitty-101"),
+            "launch_context not migrated: {:?}",
+            fano.launch_context
+        );
+
+        cleanup(path);
+    }
+
+    #[test]
+    fn test_restore_stopped_keeps_active_no_session_row() {
+        crate::config::Config::init();
+        let (db, path) = setup_test_db();
+        let now = now_epoch_i64();
+
+        let mut fano_data = serde_json::Map::new();
+        fano_data.insert("name".into(), serde_json::json!("fano"));
+        fano_data.insert("tool".into(), serde_json::json!("opencode"));
+        fano_data.insert("created_at".into(), serde_json::json!(now));
+        fano_data.insert("status".into(), serde_json::json!("inactive"));
+        db.save_instance_named("fano", &fano_data).unwrap();
+        db.log_life_event(
+            "fano",
+            "stopped",
+            "test",
+            "exit",
+            Some(serde_json::json!({ "session_id": "ses-keep", "tool": "opencode" })),
+        )
+        .unwrap();
+
+        // An ACTIVE row bound to the pid that happens to lack a session_id — NOT a launch
+        // placeholder (status_context != "new", status active). It must not be deleted.
+        let mut busy_data = serde_json::Map::new();
+        busy_data.insert("name".into(), serde_json::json!("busy"));
+        busy_data.insert("tool".into(), serde_json::json!("opencode"));
+        busy_data.insert("created_at".into(), serde_json::json!(now));
+        busy_data.insert("status".into(), serde_json::json!("active"));
+        busy_data.insert("status_context".into(), serde_json::json!("tool:write"));
+        db.save_instance_named("busy", &busy_data).unwrap();
+        db.set_process_binding("pid-busy", "", "busy").unwrap();
+
+        let result = bind_session_to_process(&db, "ses-keep", Some("pid-busy"));
+        assert_eq!(result, Some("fano".to_string()));
+
+        assert!(
+            db.get_instance_full("busy").unwrap().is_some(),
+            "active non-placeholder row must not be deleted by restore_stopped"
         );
 
         cleanup(path);


### PR DESCRIPTION
## Why

Resuming an existing agent session under a **new auto-generated launch name** is a common flow (`hcom launch` → tool resumes prior session). What I experienced first hand:

- **Duplicate TUI rows**: launch placeholder (`mozi`, `luze`, `bone`, …) stale or `launch_failed`, while the real agent listened under the **restored** name (`fano`, `rovi`, `muto`, …).
- **OpenCode**: messages sometimes did not auto-deliver until the user nudged the session (e.g. typed `.`), even when `hcom list` showed `listening`.

Hooks and launches were largely fine; identity rebind and notify endpoint migration were not.

## Failures

### Symptom A — stale / duplicate instance rows

1. Launch creates a **placeholder** instance (new name, no `session_id` yet).
2. `SessionStart` / `opencode-start` hits **`restore_stopped`** (Path 2 in `bind_session_to_process`): same `session_id` as a recently stopped instance → rebind to **old name** (`fano`, not `mozi`).
3. Placeholder row was **never deleted** (Path 1a did this for canonical-exists; Path 2 did not).
4. TUI shows both rows; placeholder goes **stale** (no heartbeat on orphan row) or **`launch_failed`** (30s placeholder timeout).

### Symptom B — OpenCode notify lost after rename

1. Plugin registers **`plugin`** notify port on canonical name during `opencode-start`.
2. Delivery thread runs `binding_refresh` (`mozi` → `fano`) and calls **`migrate_notify_endpoints(mozi, fano)`**.
3. Old implementation: **`DELETE ALL` endpoints on `fano`**, then move only `mozi`'s `pty`/`inject` → **`plugin` row wiped**.
4. `hcom send` TCP wake no longer reaches the plugin; idle/status paths may still deliver intermittently.

Representative log sequence (`~/.hcom/.tmp/logs/hcom.log`):

```
bind_session_to_process.restore_stopped stopped_name=fano  (context: mozi)
plugin.bound instance=fano notify_port=58898
delivery.binding_refresh Instance name changed: mozi -> fano
```

DB after repro: `notify_endpoints` for `fano` had `pty`/`inject` only — **no `plugin`**.

| Launch placeholder | Restored to | Tool |
|---------------------|-------------|------|
| `mozi` | `fano` | OpenCode |
| `luze` | `rovi` | Antigravity |
| `bone` / `vase` | `muto` / `leve` | Claude |

Claude/Agy: `sessionstart` exited 0; `delivery.wake_no_pending` on dead placeholder waking delivery for canonical name — confusing but consistent with orphan rows.

## Investigation

- Live `hcom list`, SQLite `instances` / `notify_endpoints`, and structured logs.
- Traced `bind_session_to_process` Path 2 vs Path 1a placeholder merge.
- Confirmed `migrate_notify_endpoints` delete-all-on-target behavior in [`src/db/sessions.rs`](src/db/sessions.rs).
- Ruled out primary hook install failure; issue is binding + notify migration on resume.

## Fix

### 1. Merge-safe `migrate_notify_endpoints` ([`src/db/sessions.rs`](src/db/sessions.rs))

Per-kind merge (target wins on conflict):

- Delete source rows only for kinds **already on the target** (keep canonical `plugin`).
- `UPDATE` remaining kinds from placeholder → canonical.
- Cleanup any stragglers on source.

Replaces the previous delete-all-on-target-then-move pattern that caused Symptom B.

### 2. Retire true placeholders after `restore_stopped` ([`src/instance_binding.rs`](src/instance_binding.rs))

After Path 2 rebind, when launch placeholder ≠ restored name:

- `migrate_notify_endpoints(placeholder, stopped_name)` (now merge-safe).
- If **true placeholder** (`session_id` unset): delete placeholder row, with notify rollback on failure (same semantics as Path 1a).

Shared helpers: `is_true_launch_placeholder`, `delete_true_placeholder_instance`, `retire_true_placeholder_after_canonical_bind`. Path 1a uses shared delete/rollback (deduped).

**Out of scope:** `pendingAckId` / idle-gate hardening in the OpenCode plugin (secondary nudge path if issues persist).

## Confirmation

### Unit tests (`cargo test`)

- `test_migrate_notify_endpoints_preserves_plugin_on_target` — plugin survives `mozi` → `fano` migration.
- `test_migrate_notify_endpoints_keeps_target_kind_on_conflict` — both have `pty`, canonical port kept.
- `test_migrate_notify_endpoints_moves_kind_missing_on_target`
- `test_bind_session_restore_stopped_deletes_true_placeholder` — Path 2 drops `mozi`, binds `fano`.
- Extended `test_bind_session_restores_deleted_canonical_from_placeholder` — placeholder `nova` removed after restore.

### Live (manual)

- OpenCode: launch new auto name (`zoni`) → session restores **`fano`** → **`hcom send`** delivers without nudge while idle.
- Antigravity / Claude: same restore pattern; no duplicate stale placeholder row for launch name.

## Test plan

- [x] `cargo test migrate_notify`
- [x] `cargo test bind_session_restore`
- [x] `cargo test path1a` (true placeholder merge)
- [x] Manual: resume session under new launch name → single listening row in `hcom list`
- [x] Manual: `sqlite3 … "SELECT kind,port FROM notify_endpoints WHERE instance='<canonical>';"` includes `plugin` for OpenCode
- [x] Manual: `hcom send --to <canonical> "ping"` while idle → delivered without user nudge