### PR TITLE
Fix delayed hcom message delivery

### DIFF
--- a/src/db/subscriptions.rs
+++ b/src/db/subscriptions.rs
@@ -1008,7 +1008,17 @@ fn send_sub_notification(db: &HcomDb, caller: &str, message: &str) -> bool {
     };
 
     let text = format!("@{} {}", full_name, message);
-    send_system_message(db, "[hcom-events]", &text).is_ok()
+    let Ok(delivered_to) = send_system_message(db, "[hcom-events]", &text) else {
+        return false;
+    };
+    // send_system_message only logs the [hcom-events] row; unlike `hcom send`
+    // it does not ping notify endpoints, so the notification can sit unread
+    // until an unrelated wake. Wake only the matching caller here: this path
+    // runs inline from log_event, so avoid a broader wake_all fan-out.
+    if delivered_to.iter().any(|recipient| recipient == caller) {
+        crate::notify::wake(db, caller, &[]);
+    }
+    true
 }
 
 /// SHA-256 hex hash.
@@ -1024,7 +1034,10 @@ fn sha256_hash(input: &str) -> String {
 mod tests {
     use super::*;
     use rusqlite::params;
+    use std::io::ErrorKind;
+    use std::net::TcpListener;
     use std::path::PathBuf;
+    use std::time::{Duration, Instant};
 
     fn setup_full_test_db() -> (HcomDb, PathBuf) {
         use std::sync::atomic::{AtomicU64, Ordering};
@@ -1045,6 +1058,28 @@ mod tests {
 
     fn cleanup_test_db(path: PathBuf) {
         let _ = std::fs::remove_file(path);
+    }
+
+    fn bind_probe() -> TcpListener {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        listener
+    }
+
+    fn await_connect(listener: &TcpListener, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match listener.accept() {
+                Ok(_) => return true,
+                Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        return false;
+                    }
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                Err(_) => return false,
+            }
+        }
     }
 
     fn count_reqwatch_without_reply_notifications(db: &HcomDb, requester: &str) -> i64 {
@@ -1703,6 +1738,41 @@ mod tests {
             .unwrap();
         assert_eq!(delivered.len(), 1);
         assert!(delivered.contains(&"luna".to_string()));
+
+        cleanup_test_db(db_path);
+    }
+
+    #[test]
+    fn test_send_sub_notification_wakes_target_instance() {
+        let (db, db_path) = setup_full_test_db();
+
+        db.conn
+            .execute(
+                "INSERT INTO instances (name, tag, created_at) VALUES ('tofu', '', 1000.0), ('rune', '', 1000.0)",
+                [],
+            )
+            .unwrap();
+        let tofu_probe = bind_probe();
+        let rune_probe = bind_probe();
+        db.upsert_notify_endpoint("tofu", "plugin", tofu_probe.local_addr().unwrap().port())
+            .unwrap();
+        db.upsert_notify_endpoint("rune", "plugin", rune_probe.local_addr().unwrap().port())
+            .unwrap();
+
+        assert!(send_sub_notification(
+            &db,
+            "tofu",
+            "[sub:test] #42 dani status | blocked | approval"
+        ));
+
+        assert!(
+            await_connect(&tofu_probe, Duration::from_millis(500)),
+            "subscription notification should wake the subscribed instance"
+        );
+        assert!(
+            !await_connect(&rune_probe, Duration::from_millis(100)),
+            "subscription notification should not broadcast-wake unrelated instances"
+        );
 
         cleanup_test_db(db_path);
     }

--- a/src/opencode_plugin/hcom.ts
+++ b/src/opencode_plugin/hcom.ts
@@ -95,7 +95,9 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
   let notifyServer: ReturnType<typeof Bun.listen> | null = null  // TCP notify server for instant message wake
   let lastReportedStatus: string | null = null  // Skip redundant status updates
   let pendingAckId: number | null = null        // Deferred ack: set by deliverPendingToIdle, acked by transform
-  let deliveryInFlight = false                  // Delivery guard flag: rejects concurrent callers (not a queuing mutex)
+  let deliveryInFlight = false                  // Delivery guard flag set before the first await
+  let deliveryPending = false                   // Wake arrived while delivery was already in flight
+  let deliveryRetryScheduled = false            // Avoid duplicate queued retry passes
   let permissionPending = false                  // Exact permission gate from OpenCode events
   let launchedAgent: string | null = parseCliArgValue("--agent")
   let launchedModel: PromptModel | null = parseCliModelArg()
@@ -142,18 +144,42 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
     return `<hcom>[${messages.length} new messages] | ${parts.join(" | ")}</hcom>`
   }
 
+  function schedulePendingDelivery(sid: string, reason: string): void {
+    if (deliveryRetryScheduled) return
+    deliveryRetryScheduled = true
+    log("DEBUG", "plugin.delivery_retry_scheduled", instanceName, { reason })
+    queueMicrotask(() => {
+      deliveryRetryScheduled = false
+      if (!instanceName) return
+      void deliverPendingToIdle(sid)
+    })
+  }
+
+  // Re-arm a queued wake once nothing is mid-flight. The pendingAckId guard
+  // leaves the still-injecting case to the post-ack drain so we do not
+  // double-deliver the same unread message batch.
+  function drainPendingDelivery(sid: string, reason: string): void {
+    if (deliveryPending && pendingAckId === null) {
+      deliveryPending = false
+      schedulePendingDelivery(sid, reason)
+    }
+  }
+
   // Deliver pending messages via promptAsync. Ack is deferred to transform
   // (fires on the loop iteration that actually processes the user message).
   //
-  // Two-layer serialization:
+  // Three-layer serialization:
   //   deliveryInFlight — guard flag set synchronously before the first await.
   //     Closes the TOCTOU window where TCP notify and idle-status wake paths
   //     could both pass a null check before either one set the value.
-  //     Concurrent callers are rejected (not queued); they will retry on the
-  //     next wake event.
+  //     Concurrent callers set deliveryPending so their wake is replayed after
+  //     the current pass, or after the current injected message is acked.
   //   pendingAckId — set after messages are read, cleared by transform.
   //     Prevents re-delivery while a prior injection is still being processed.
   //     If promptAsync fails to queue, pendingAckId is cleared immediately.
+  //   deliveryPending — a wake that arrived while delivery was in-flight or an
+  //     injection was pending ack. drainPendingDelivery replays it at each exit
+  //     point: normal finally, deferred ack, and promptAsync rejection.
   async function deliverPendingToIdle(sid: string): Promise<boolean> {
     if (permissionPending) {
       log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "permission_pending" })
@@ -164,11 +190,13 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
       return false
     }
     if (deliveryInFlight) {
-      log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "delivery_in_flight" })
+      deliveryPending = true
+      log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "delivery_in_flight", queued: true })
       return false
     }
     if (pendingAckId !== null) {
-      log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "pending_ack_in_flight", pending_ack: pendingAckId })
+      deliveryPending = true
+      log("DEBUG", "plugin.delivery_skipped", instanceName, { reason: "pending_ack_in_flight", pending_ack: pendingAckId, queued: true })
       return false
     }
     deliveryInFlight = true
@@ -221,6 +249,7 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
               error: String(e),
               pending_ack: maxId,
             })
+            drainPendingDelivery(sid, "prompt_async_failed_pending_wake")
           })
         }
       } catch (e) {
@@ -240,6 +269,7 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
       return true
     } finally {
       deliveryInFlight = false
+      drainPendingDelivery(sid, "delivery_in_flight_wake")
     }
   }
 
@@ -450,6 +480,8 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
             lastReportedStatus = null
             pendingAckId = null
             deliveryInFlight = false
+            deliveryPending = false
+            deliveryRetryScheduled = false
             permissionPending = false
             currentAgent = launchedAgent
             currentModel = launchedModel
@@ -563,6 +595,9 @@ export const HcomPlugin: Plugin = async ({ client, $ }) => {
           pendingAckId = null
           await $.nothrow()`hcom opencode-read --name ${instanceName} --ack --up-to ${String(ackId)}`.quiet()
           log("INFO", "plugin.deferred_ack", instanceName, { acked_to: ackId })
+          if (deliveryPending && sessionId) {
+            drainPendingDelivery(sessionId, "post_ack_pending_wake")
+          }
         }
       } catch (e) {
         log("ERROR", "plugin.transform_error", instanceName, { error: String(e) })


### PR DESCRIPTION
Subscription notifications could be logged as `[hcom-events]` messages without waking the subscribed agent. That left agents waiting until some unrelated status change or message wake made them read the queued notification. OpenCode had a second race where a wake that arrived during an active delivery read or while a prompt injection was waiting for transform ack was ignored.

This fixes both paths. Subscription notifications now wake only the matched subscriber after the message is logged, and OpenCode queues one pending delivery wake and drains it after the current read, after deferred ack, or after `promptAsync` rejects.

The Rust path adds a TCP-probe test proving only the subscribed target is woken; the OpenCode replay path has no unit test because it depends on plugin runtime sequencing and was validated against a state-machine repro of the in-flight, pending-ack, and rejection sequence. Checked with `cargo fmt --check`, `cargo test db::subscriptions::tests::test_send_sub_notification_wakes_target_instance`, and `bun build src/opencode_plugin/hcom.ts --external @opencode-ai/plugin --external @opencode-ai/sdk --outfile /tmp/opencode/hcom-plugin.js`.
