### PR TITLE
fix(pi): replay delivery wakes dropped during the in-flight window

### DIFF
--- a/src/pi_plugin/hcom.ts
+++ b/src/pi_plugin/hcom.ts
@@ -82,6 +82,8 @@ export default function hcomExtension(pi: ExtensionAPI) {
 	let currentCtx: ExtensionContext | null = null;
 	let pendingAckId: number | null = null;
 	let deliveryInFlight = false;
+	let deliveryPending = false; // a wake arrived while delivery was gated; replay it once clear
+	let deliveryRetryScheduled = false; // dedup the queued replay pass
 	let reconcileTimer: ReturnType<typeof setInterval> | null = null;
 	let reconcileInFlight = false;
 	let bootstrapInjectedForSession: string | null = null;
@@ -201,7 +203,18 @@ export default function hcomExtension(pi: ExtensionAPI) {
 		await bindIdentity(ctx);
 		if (!instanceName || !sessionId) return false;
 		if (!isBoundSession(ctx.sessionManager.getSessionId())) return false;
-		if (deliveryInFlight || pendingAckId !== null) return false;
+		if (deliveryInFlight || pendingAckId !== null) {
+			// A delivery is mid-flight or awaiting ack. Drop nothing: record the wake
+			// so it is replayed once clear, otherwise a message that arrives in this
+			// window stays unread until an unrelated later wake (reconcile is idle-gated).
+			deliveryPending = true;
+			log("DEBUG", "plugin.delivery_skipped", instanceName, {
+				reason: deliveryInFlight ? "delivery_in_flight" : "pending_ack_in_flight",
+				pending_ack: pendingAckId,
+				queued: true,
+			});
+			return false;
+		}
 		deliveryInFlight = true;
 		try {
 			const pending = await fetchPending();
@@ -230,6 +243,28 @@ export default function hcomExtension(pi: ExtensionAPI) {
 			}
 		} finally {
 			deliveryInFlight = false;
+			drainPendingDelivery("delivery_in_flight_wake");
+		}
+	}
+
+	// Replay a wake that was queued while delivery was gated. Re-armed once nothing
+	// is mid-flight and no ack is pending, so the same unread batch is not delivered
+	// twice. The microtask + dedup flag collapse a burst of queued wakes into one pass.
+	function schedulePendingDelivery(reason: string): void {
+		if (deliveryRetryScheduled) return;
+		deliveryRetryScheduled = true;
+		log("DEBUG", "plugin.delivery_retry_scheduled", instanceName, { reason });
+		queueMicrotask(() => {
+			deliveryRetryScheduled = false;
+			if (!instanceName || !currentCtx) return;
+			void deliverPending(currentCtx);
+		});
+	}
+
+	function drainPendingDelivery(reason: string): void {
+		if (deliveryPending && !deliveryInFlight && pendingAckId === null) {
+			deliveryPending = false;
+			schedulePendingDelivery(reason);
 		}
 	}
 
@@ -239,6 +274,9 @@ export default function hcomExtension(pi: ExtensionAPI) {
 		pendingAckId = null;
 		await hcom(["pi-read", "--name", instanceName, "--ack", "--up-to", String(ackId)]);
 		log("INFO", "plugin.deferred_ack", instanceName, { acked_to: ackId, source });
+		// The extension-input ack path clears pendingAckId outside deliverPending;
+		// replay any wake that was gated while it was set.
+		drainPendingDelivery("post_ack_wake");
 	}
 
 	async function reportStatus(ctx: ExtensionContext, status: "active" | "listening", context = "", detail = ""): Promise<void> {
@@ -298,6 +336,8 @@ export default function hcomExtension(pi: ExtensionAPI) {
 		bindingPromise = null;
 		pendingAckId = null;
 		deliveryInFlight = false;
+		deliveryPending = false;
+		deliveryRetryScheduled = false;
 		bootstrapInjectedForSession = null;
 		lastReportedStatusKey = null;
 		lastPendingPollAt = 0;


### PR DESCRIPTION
## Summary
Follow-up to #66. PR #66 made Pi ack right after `sendUserMessage`, shrinking the `pendingAckId` half of `deliverPending`'s early-return gate. The **`deliveryInFlight` half is still open and drops wakes silently** — a message arriving while a delivery is mid-flight hits `return false` and is lost until an unrelated later wake, because `reconcile`/`pollPendingIfDue` are idle-gated and can't rescue it while the agent is busy.

## Background
The sibling OpenCode plugin had this exact bug and fixed it in `965d37d` (*"queue delivery wakes instead of dropping them"*) by recording the gated wake and replaying it. Pi was forked from the OpenCode model on 2026-06-04, **6 days before** that fix landed, so it never inherited the replay machinery — it still drops wakes the way pre-`965d37d` OpenCode did.

## Fix
Port the wake-queue/replay, adapted to Pi:
- The gated early-return now sets `deliveryPending` (logged `plugin.delivery_skipped … queued:true`) instead of dropping the wake.
- `schedulePendingDelivery` / `drainPendingDelivery` replay it via a deduped microtask once nothing is in flight and no ack is pending — drained from both the `deliverPending` `finally` and the post-ack path, covering PR #66's eager ack and the extension-input ack route.
- The dedup flag collapses a burst of gated wakes into a single replay pass, so the same unread batch is never delivered twice.
- New state reset in `resetBinding`.

This is complementary to #66: #66 covers the (claimed) never/late-ack case; this covers the in-flight wake drop, which is the failure mode reproducible on Pi 0.73.1 / 0.80.2.

## Verification
- `cargo fmt --check` clean; hermetic `pi_e2e_hook_dispatch` + `copilot_e2e_hook_dispatch` pass. Change is TS-only (embedded plugin), no Rust diff.
- Live, against a real Pi agent mid `sleep 120`:
  - rapid 5-message burst → 4× `delivery_skipped(delivery_in_flight, queued:true)` + `delivery_retry_scheduled` (pre-fix these wakes were silently dropped)
  - spaced 6-message burst → 6 clean `count:1` deliveries
  - agent consumed all tokens end-to-end (`BURST_1-5`, `SP_A-E`); `pi-read` leftover stayed empty throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)