### PR TITLE
fix: contain and patch the vt100 row-erase panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,8 +2518,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vt100"
 version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+source = "git+https://github.com/Junyi-99/vt100-rust?rev=131a75e72d9da43d503772578dc1f1c332befbba#131a75e72d9da43d503772578dc1f1c332befbba"
 dependencies = [
  "itoa",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,14 @@ lru = "0.16"
 [dev-dependencies]
 serial_test = "3"
 
+# vt100 0.16.2 panics when a downward resize orphans a double-width character's
+# "wide" flag and it's later erased (index out of bounds in Row::clear_wide).
+# Pinned to the fix from the still-open upstream PR until a release ships it:
+# https://github.com/doy/vt100-rust/issues/28
+# https://github.com/doy/vt100-rust/pull/30
+[patch.crates-io]
+vt100 = { git = "https://github.com/Junyi-99/vt100-rust", rev = "131a75e72d9da43d503772578dc1f1c332befbba" }
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/src/pty/screen.rs
+++ b/src/pty/screen.rs
@@ -103,6 +103,11 @@ fn is_block_border(line: &str) -> bool {
 /// Screen tracker with vt100 emulation
 pub struct ScreenTracker {
     parser: vt100::Parser,
+    // Current terminal dimensions, tracked independently of the parser so a
+    // panicked parser can be rebuilt from scratch at the right size (see
+    // `process`/`resize`).
+    rows: u16,
+    cols: u16,
     ready_pattern: String,
     waiting_approval: bool,
     last_output: Instant,
@@ -138,6 +143,8 @@ impl ScreenTracker {
 
         let mut tracker = Self {
             parser: vt100::Parser::new(rows, cols, 0),
+            rows,
+            cols,
             ready_pattern: String::from_utf8_lossy(ready_pattern).into_owned(),
             waiting_approval: false,
             last_output: Instant::now(),
@@ -207,8 +214,30 @@ impl ScreenTracker {
             self.waiting_approval = title.contains(CODEX_ACTION_REQUIRED);
         }
 
-        // Feed to vt100 parser
-        self.parser.process(data);
+        // Feed to vt100 parser. vt100 has known panics on malformed/edge-case
+        // terminal frames (e.g. https://github.com/doy/vt100-rust/issues/28 —
+        // a wide character orphaned by a resize, then erased). Catch rather
+        // than let it unwind and kill the PTY wrapper (hcom issue #73); the
+        // panic hook still logs the underlying panic, so this just contains
+        // the blast radius. A parser that panicked mid-mutation may be left
+        // in an inconsistent state, so rebuild it from scratch rather than
+        // keep using it — this drops the current screen contents, but the
+        // next output chunk repopulates it.
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.parser.process(data);
+        }))
+        .is_err()
+        {
+            crate::log::log_warn(
+                "pty",
+                "screen.parser_panic",
+                &format!(
+                    "vt100 parser panicked processing output for {}; resetting screen state",
+                    self.instance_name.as_deref().unwrap_or("unknown")
+                ),
+            );
+            self.parser = vt100::Parser::new(self.rows, self.cols, 0);
+        }
 
         // Track output timing
         self.last_output = Instant::now();
@@ -223,7 +252,23 @@ impl ScreenTracker {
 
     /// Resize the screen
     pub fn resize(&mut self, rows: u16, cols: u16) {
-        self.parser.screen_mut().set_size(rows, cols);
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.parser.screen_mut().set_size(rows, cols);
+        }))
+        .is_err()
+        {
+            crate::log::log_warn(
+                "pty",
+                "screen.parser_panic",
+                &format!(
+                    "vt100 parser panicked resizing screen for {}; resetting screen state",
+                    self.instance_name.as_deref().unwrap_or("unknown")
+                ),
+            );
+            self.parser = vt100::Parser::new(rows, cols, 0);
+        }
+        self.rows = rows;
+        self.cols = cols;
     }
 
     /// Clear approval state immediately when the user responds.
@@ -990,6 +1035,8 @@ mod tests {
     fn make_tracker(rows: u16, cols: u16, ready_pattern: &str) -> ScreenTracker {
         ScreenTracker {
             parser: vt100::Parser::new(rows, cols, 0),
+            rows,
+            cols,
             ready_pattern: ready_pattern.to_string(),
             waiting_approval: false,
             last_output: Instant::now(),
@@ -1003,6 +1050,36 @@ mod tests {
             debug_flag_path: std::path::PathBuf::new(),
             instance_name: None,
         }
+    }
+
+    // ---- vt100 panic containment (issue #73) ----
+
+    #[test]
+    fn process_survives_vt100_wide_char_resize_panic() {
+        // A double-width (wide) character whose continuation cell gets
+        // truncated by a downward resize used to panic inside vt100
+        // (upstream doy/vt100-rust#28: `Row::clear_wide` indexes one past
+        // the row's new length) the next time that cell was erased. That
+        // panic used to unwind straight through `process`/`resize` and kill
+        // the PTY wrapper (hcom issue #73, observed as repeated
+        // `stopped by pty: closed` on real Codex sessions). It must now be
+        // contained: the tracker rebuilds its parser and stays usable.
+        let mut t = make_tracker(3, 10, "");
+
+        // Wide CJK char printed so it spans the last two columns (8, 9).
+        t.process(b"\x1b[1;9H");
+        t.process("\u{4e2d}".as_bytes());
+
+        // Shrink to 9 columns: the continuation cell (old col 9) is
+        // truncated away, orphaning the wide flag on the new last column.
+        t.resize(3, 9);
+
+        // Erase-in-line on that orphaned wide cell is what panicked upstream.
+        t.process(b"\x1b[1;9H\x1b[K");
+
+        // Tracker must have survived and still be fully usable.
+        assert_eq!(t.cols(), 9);
+        t.process(b"still alive\r\n");
     }
 
     // ---- is_ready ----


### PR DESCRIPTION
## Summary
Fixes #73. vt100 0.16.2 has a real upstream bug ([doy/vt100-rust#28](https://github.com/doy/vt100-rust/issues/28), open fix in [PR #30](https://github.com/doy/vt100-rust/pull/30)): `Grid::set_size` shrinks rows via `Row::resize`, which doesn't clean up a double-width character's "wide" flag when its continuation cell is truncated away by a downward resize. The orphaned wide cell then panics the next time it's erased (`Row::clear_wide` indexes one past the row's new length) — this matches the exact panic signature and line (`row.rs:89`) from the reported incidents.

hcom's global panic hook logs the panic but doesn't stop it from unwinding, so it killed the whole PTY wrapper thread and dropped the wrapped agent session (observed as repeated `stopped by pty: closed` on real Codex sessions, sometimes two in the same second).

Two changes, in order:

1. **Containment**: wraps the two vt100 call sites (`Parser::process`, `Screen::set_size`) in `catch_unwind` and rebuilds the parser from scratch on a caught panic — a parser that panicked mid-mutation may be left in an inconsistent internal state, so it's discarded rather than reused. This is defense-in-depth for any other vt100 edge case, not just this one.
2. **Root-cause fix**: pins vt100 to a patched git commit (`Junyi-99/vt100-rust@131a75e`, the commit backing the still-open PR #30 above) so the underlying bug doesn't happen in the first place. Verified independently against a plain clone of the patched fork, outside hcom's own containment code, that the panic no longer occurs. This is a stopgap until vt100 ships a release with the fix — at that point the `[patch.crates-io]` entry in `Cargo.toml` should come out and the version requirement bumped normally.

## Test plan
- [x] New regression test reproduces the exact upstream repro (wide CJK character, downward resize, erase-in-line) and confirms the panic no longer escapes `process()`/`resize()`
- [x] Independently verified the patched vt100 fork fixes the bug on its own (standalone repro, no hcom code involved)
- [x] Full test suite (1854 tests) passes
- [x] `cargo clippy --all-targets` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vqvir6b7ZYB4FXWHmEy1qE)_