### PR TITLE
Fix relay state synchronization across clock skew

### DIFF
--- a/src/relay/client.rs
+++ b/src/relay/client.rs
@@ -153,8 +153,9 @@ impl MqttRelay {
             mqttoptions.set_credentials("hcom", &config.relay_token);
         }
 
-        // LWT: publish empty retained payload on ungraceful disconnect so remote
-        // devices detect our absence and clean up our instances.
+        // An LWT cannot be freshly sealed when the broker emits it. Use an
+        // empty retained payload to clear the broker snapshot; peers ignore
+        // the unauthenticated payload and fall back to stale-device detection.
         let lwt_topic = state_topic(&relay_id, &device_uuid);
         let lwt = rumqttc::v5::mqttbytes::v5::LastWill {
             topic: lwt_topic.clone().into(),
@@ -485,7 +486,7 @@ impl MqttRelay {
                 Packet::Publish(publish) => {
                     let topic = String::from_utf8_lossy(&publish.topic).to_string();
                     let payload = publish.payload.to_vec();
-                    self.handle_incoming_message(&topic, &payload, publish.retain)
+                    self.handle_incoming_message(&topic, &payload)
                 }
                 Packet::Disconnect(_) => {
                     *connected = false;
@@ -500,11 +501,10 @@ impl MqttRelay {
 
     /// Handle an incoming MQTT publish message.
     ///
-    /// Topic layout: `{relay_id}/{device_uuid}` for state snapshots,
-    /// `{relay_id}/control` for control events. Empty payload on a state topic
-    /// means "device gone" (LWT or graceful cleanup) — special-cased before
-    /// any decrypt attempt because it carries no plaintext.
-    fn handle_incoming_message(&self, topic: &str, payload: &[u8], is_retained: bool) -> bool {
+    /// Topic layout: `{relay_id}/{device_uuid}` for state snapshots and
+    /// `{relay_id}/control` for control events. Empty state payloads may be an
+    /// ungraceful LWT, but are ignored because they are unauthenticated.
+    fn handle_incoming_message(&self, topic: &str, payload: &[u8]) -> bool {
         let prefix = format!("{}/", self.relay_id);
         if !topic.starts_with(&prefix) {
             return false; // Not our relay group
@@ -560,14 +560,9 @@ impl MqttRelay {
             if device_id == self.device_uuid {
                 return false; // Ignore own messages
             }
-            super::pull::handle_state_message(
-                &db,
-                device_id,
-                payload,
-                &self.device_uuid,
-                is_retained,
-                &mut ctx,
-            )
+            // MQTT RETAIN is delivery metadata, not authenticated state
+            // freshness. State ordering comes from the sealed timestamp.
+            super::pull::handle_state_message(&db, device_id, payload, &self.device_uuid, &mut ctx)
         }
     }
 
@@ -649,8 +644,8 @@ impl MqttRelay {
         }
     }
 
-    /// Graceful shutdown: publish empty retained message to clear device state,
-    /// wait for PUBACK, then disconnect.
+    /// Graceful shutdown: publish an authenticated retained tombstone, wait for
+    /// PUBACK, then disconnect.
     fn shutdown_graceful(
         &self,
         event_rx: &mpsc::Receiver<Result<Event, rumqttc::v5::ConnectionError>>,
@@ -659,17 +654,22 @@ impl MqttRelay {
         log::log_info(
             "relay",
             "relay.shutdown_graceful",
-            "clearing retained state",
+            "publishing authenticated state tombstone",
         );
 
-        // Publish empty retained to clear our state from broker
-        if let Err(e) = self.client.publish(
-            &topic,
-            QoS::AtLeastOnce,
-            true, // retain
-            vec![],
-        ) {
-            log::log_warn("relay", "relay.shutdown_publish_err", &format!("{}", e));
+        let tombstone = self
+            .psk
+            .lock()
+            .map_err(|e| format!("PSK lock poisoned: {e}"))
+            .and_then(|psk| seal_state_tombstone(&psk, &self.relay_id, &topic));
+
+        let publish_result = tombstone.and_then(|payload| {
+            self.client
+                .publish(&topic, QoS::AtLeastOnce, true, payload)
+                .map_err(|e| e.to_string())
+        });
+        if let Err(e) = publish_result {
+            log::log_warn("relay", "relay.shutdown_publish_err", &e);
         } else {
             // Wait for PUBACK (up to 5s) by draining the event channel
             let deadline = Instant::now() + Duration::from_secs(5);
@@ -713,6 +713,17 @@ fn ignore_unauthenticated_empty_state(_db: &HcomDb, device_id: &str) {
             super::device_id_prefix(device_id)
         ),
     );
+}
+
+fn seal_state_tombstone(psk: &[u8; 32], relay_id: &str, topic: &str) -> Result<Vec<u8>, String> {
+    let payload = serde_json::to_vec(&json!({
+        "state": serde_json::Value::Null,
+        "events": [],
+    }))
+    .map_err(|e| format!("failed to serialize state tombstone: {e}"))?;
+    let ts_secs = crate::shared::time::now_epoch_f64() as u64;
+    super::crypto::seal(psk, relay_id, topic, &payload, ts_secs)
+        .map_err(|e| format!("failed to seal state tombstone: {e}"))
 }
 
 /// Tracks PUBACK or connection error for an ephemeral publish.
@@ -871,15 +882,7 @@ pub fn clear_retained_state(config: &HcomConfig) -> bool {
         Ok(psk) => psk,
         Err(_) => return false,
     };
-    let payload = match serde_json::to_vec(&json!({
-        "state": serde_json::Value::Null,
-        "events": [],
-    })) {
-        Ok(payload) => payload,
-        Err(_) => return false,
-    };
-    let ts_secs = crate::shared::time::now_epoch_f64() as u64;
-    let sealed = match super::crypto::seal(&psk, relay_id, &topic, &payload, ts_secs) {
+    let sealed = match seal_state_tombstone(&psk, relay_id, &topic) {
         Ok(sealed) => sealed,
         Err(_) => return false,
     };
@@ -922,5 +925,18 @@ mod tests {
         ignore_unauthenticated_empty_state(&db, "device-1234");
 
         assert!(db.get_instance_full("luna:ABCD").unwrap().is_some());
+    }
+
+    #[test]
+    fn test_state_tombstone_is_authenticated_null_state() {
+        let psk = [0x42; 32];
+        let relay_id = "relay-test";
+        let topic = "relay-test/device-1234";
+        let sealed = seal_state_tombstone(&psk, relay_id, topic).unwrap();
+        let plaintext = crate::relay::crypto::open(&psk, relay_id, topic, &sealed).unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&plaintext).unwrap();
+
+        assert!(payload["state"].is_null());
+        assert_eq!(payload["events"], json!([]));
     }
 }

--- a/src/relay/crypto.rs
+++ b/src/relay/crypto.rs
@@ -95,16 +95,16 @@ pub fn seal(
     Ok(out)
 }
 
-/// Parsed envelope header. The `nonce` and `ts_secs` are exposed so the caller
-/// can run the replay guard before paying for `open`.
+/// Parsed envelope header. The `nonce` and `ts_secs` are exposed for replay
+/// checks after the full envelope authenticates.
 pub struct Envelope<'a> {
     pub nonce: [u8; NONCE_LEN],
     pub ts_secs: u64,
     pub ciphertext: &'a [u8],
 }
 
-/// Parse the wire header without decrypting. Lets the caller validate freshness
-/// and dedupe the nonce before spending CPU on the AEAD.
+/// Parse the wire header without decrypting. Callers must authenticate the full
+/// envelope before trusting these fields or applying replay policy.
 pub fn parse_envelope(buf: &[u8]) -> Result<Envelope<'_>, CryptoError> {
     if buf.len() < HEADER_LEN + TAG_LEN {
         return Err(CryptoError::BadEnvelope);

--- a/src/relay/pull.rs
+++ b/src/relay/pull.rs
@@ -3,7 +3,7 @@
 //! Handles MQTT messages received from remote devices:
 //! - State messages: upsert remote instances, import events
 //! - Control messages: process stop/kill commands
-//! - Empty payloads: device gone (LWT or graceful cleanup)
+//! - Authenticated null state: device gone (graceful cleanup)
 
 use rusqlite::params;
 use serde_json::Value;
@@ -28,6 +28,11 @@ struct OpenedEnvelope {
     ts_secs: u64,
 }
 
+enum ReplayPolicy {
+    ControlFreshness,
+    State { min_accepted_ts: Option<u64> },
+}
+
 fn state_ts_key(device_id: &str) -> String {
     format!("relay_state_ts_{}", device_id)
 }
@@ -50,8 +55,7 @@ fn open_envelope_for_handler(
     ctx: &mut InboundContext<'_>,
     sender_short: &str,
     payload: &[u8],
-    allow_stale: bool,
-    retained_watermark: Option<u64>,
+    replay_policy: ReplayPolicy,
 ) -> Option<OpenedEnvelope> {
     let parsed = match crypto::parse_envelope(payload) {
         Ok(p) => p,
@@ -60,46 +64,47 @@ fn open_envelope_for_handler(
             return None;
         }
     };
+    let plaintext = match crypto::open(ctx.psk, ctx.relay_id, ctx.topic, payload) {
+        Ok(pt) => pt,
+        Err(e) => {
+            log::log_warn("relay", "relay.decrypt_fail", &format!("{}", e));
+            return None;
+        }
+    };
+
     let now_secs = crate::shared::time::now_epoch_f64() as u64;
-    let replay_result = if allow_stale {
-        ctx.replay_guard.check_retained(
+    let replay_result = match replay_policy {
+        ReplayPolicy::ControlFreshness => {
+            ctx.replay_guard
+                .check(sender_short, parsed.nonce, parsed.ts_secs, now_secs)
+        }
+        ReplayPolicy::State { min_accepted_ts } => ctx.replay_guard.check_state(
             sender_short,
             parsed.nonce,
             parsed.ts_secs,
             now_secs,
-            retained_watermark,
-        )
-    } else {
-        ctx.replay_guard
-            .check(sender_short, parsed.nonce, parsed.ts_secs, now_secs)
+            min_accepted_ts,
+        ),
     };
     if let Err(e) = replay_result {
         log::log_warn("relay", "relay.replay", &format!("{}", e));
         return None;
     }
-
-    match crypto::open(ctx.psk, ctx.relay_id, ctx.topic, payload) {
-        Ok(pt) => {
-            if let Err(e) = ctx
-                .replay_guard
-                .record_nonce(sender_short, parsed.nonce, now_secs)
-            {
-                log::log_warn("relay", "relay.replay", &format!("{}", e));
-                return None;
-            }
-            Some(OpenedEnvelope {
-                plaintext: pt,
-                ts_secs: parsed.ts_secs,
-            })
-        }
-        Err(e) => {
-            log::log_warn("relay", "relay.decrypt_fail", &format!("{}", e));
-            None
-        }
+    if let Err(e) = ctx
+        .replay_guard
+        .record_nonce(sender_short, parsed.nonce, now_secs)
+    {
+        log::log_warn("relay", "relay.replay", &format!("{}", e));
+        return None;
     }
+
+    Some(OpenedEnvelope {
+        plaintext,
+        ts_secs: parsed.ts_secs,
+    })
 }
 
-/// Handle device gone (empty retained payload = LWT or graceful disconnect).
+/// Handle an authenticated null state from a departing device.
 /// Removes all instances belonging to the disconnected device.
 pub fn handle_device_gone(db: &HcomDb, device_id: &str) {
     if let Err(e) = db.conn().execute(
@@ -138,10 +143,11 @@ pub fn handle_control_message(
     own_device: &str,
     ctx: &mut InboundContext<'_>,
 ) -> bool {
-    let opened = match open_envelope_for_handler(ctx, "control", payload, false, None) {
-        Some(p) => p,
-        None => return false,
-    };
+    let opened =
+        match open_envelope_for_handler(ctx, "control", payload, ReplayPolicy::ControlFreshness) {
+            Some(p) => p,
+            None => return false,
+        };
 
     let data: Value = match serde_json::from_slice(&opened.plaintext) {
         Ok(v) => v,
@@ -179,21 +185,21 @@ pub fn handle_state_message(
     device_id: &str,
     payload: &[u8],
     own_device: &str,
-    allow_stale: bool,
     ctx: &mut InboundContext<'_>,
 ) -> bool {
     let t0 = std::time::Instant::now();
 
-    let retained_watermark = if allow_stale {
-        state_ts_watermark(db, device_id)
-    } else {
-        None
+    let opened = match open_envelope_for_handler(
+        ctx,
+        device_id,
+        payload,
+        ReplayPolicy::State {
+            min_accepted_ts: state_ts_watermark(db, device_id),
+        },
+    ) {
+        Some(p) => p,
+        None => return false,
     };
-    let opened =
-        match open_envelope_for_handler(ctx, device_id, payload, allow_stale, retained_watermark) {
-            Some(p) => p,
-            None => return false,
-        };
 
     let data: Value = match serde_json::from_slice(&opened.plaintext) {
         Ok(v) => v,
@@ -826,7 +832,6 @@ mod tests {
             "device-1234",
             &envelope,
             "own-device-5678",
-            false,
             &mut InboundContext {
                 psk: &psk,
                 relay_id: "relay-test",
@@ -871,7 +876,6 @@ mod tests {
             "device-1234",
             &envelope,
             "own-device-5678",
-            false,
             &mut InboundContext {
                 psk: &psk,
                 relay_id: "relay-test",
@@ -915,7 +919,6 @@ mod tests {
             "device-1234",
             &envelope,
             "own-device-5678",
-            false,
             &mut InboundContext {
                 psk: &psk,
                 relay_id: "relay-test",
@@ -933,64 +936,75 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_handle_retained_state_message_allows_stale_snapshot() {
+    fn test_handle_state_message_accepts_sender_clock_skew_in_both_directions() {
         let (_dir, _hcom_dir, _home, _guard) = isolated_test_env();
         let db = HcomDb::open().unwrap();
-
-        let payload = json!({
-            "state": {
-                "short_id": "ABCD",
-                "reset_ts": 0.0,
-                "instances": {
-                    "luna": {
-                        "status": "active",
-                        "context": "",
-                        "detail": "",
-                        "status_time": crate::shared::time::now_epoch_f64(),
-                        "parent": serde_json::Value::Null,
-                        "directory": "/tmp/demo",
-                        "transcript": "/tmp/demo/transcript.jsonl",
-                        "wait_timeout": 42,
-                        "last_stop": 0.0,
-                        "tcp_mode": false,
-                        "tag": serde_json::Value::Null,
-                        "tool": "codex",
-                        "background": false
-                    }
-                }
-            },
-            "events": []
-        });
-
-        let topic = "relay-test/device-1234";
-        let stale_secs = (crate::shared::time::now_epoch_f64() as u64).saturating_sub(600);
-        let bytes = serde_json::to_vec(&payload).unwrap();
-        let envelope =
-            crate::relay::crypto::seal(&fixture_psk(), "relay-test", topic, &bytes, stale_secs)
-                .unwrap();
         let mut guard = ReplayGuard::default();
         let psk = fixture_psk();
+        let now = crate::shared::time::now_epoch_f64() as i64;
 
-        assert!(!handle_state_message(
-            &db,
-            "device-1234",
-            &envelope,
-            "own-device-5678",
-            true,
-            &mut InboundContext {
-                psk: &psk,
-                relay_id: "relay-test",
-                topic,
-                replay_guard: &mut guard,
-            },
-        ));
+        for (device_id, short_id, offset) in [
+            ("device-past", "PAST", -61_i64),
+            ("device-future", "FUTR", 61_i64),
+        ] {
+            let payload = json!({
+                "state": {
+                    "short_id": short_id,
+                    "reset_ts": 0.0,
+                    "instances": {
+                        "luna": {
+                            "status": "active",
+                            "context": "",
+                            "detail": "",
+                            "status_time": crate::shared::time::now_epoch_f64(),
+                            "parent": serde_json::Value::Null,
+                            "directory": "/tmp/demo",
+                            "transcript": "/tmp/demo/transcript.jsonl",
+                            "wait_timeout": 42,
+                            "last_stop": 0.0,
+                            "tcp_mode": false,
+                            "tag": serde_json::Value::Null,
+                            "tool": "codex",
+                            "background": false
+                        }
+                    }
+                },
+                "events": []
+            });
+            let topic = format!("relay-test/{device_id}");
+            let bytes = serde_json::to_vec(&payload).unwrap();
+            let envelope = crate::relay::crypto::seal(
+                &psk,
+                "relay-test",
+                &topic,
+                &bytes,
+                (now + offset) as u64,
+            )
+            .unwrap();
 
-        assert!(db.get_instance_full("luna:ABCD").unwrap().is_some());
+            assert!(!handle_state_message(
+                &db,
+                device_id,
+                &envelope,
+                "own-device-5678",
+                &mut InboundContext {
+                    psk: &psk,
+                    relay_id: "relay-test",
+                    topic: &topic,
+                    replay_guard: &mut guard,
+                },
+            ));
+            assert!(
+                db.get_instance_full(&format!("luna:{short_id}"))
+                    .unwrap()
+                    .is_some()
+            );
+        }
     }
 
     #[test]
     #[serial]
-    fn test_handle_retained_state_message_rejects_rollback_behind_watermark() {
+    fn test_handle_state_message_rejects_rollback_behind_watermark() {
         let (_dir, _hcom_dir, _home, _guard) = isolated_test_env();
         let db = HcomDb::open().unwrap();
         safe_kv_set(&db, "relay_state_ts_device-1234", Some("1500"));
@@ -1032,7 +1046,6 @@ mod tests {
             "device-1234",
             &envelope,
             "own-device-5678",
-            true,
             &mut InboundContext {
                 psk: &psk,
                 relay_id: "relay-test",
@@ -1074,7 +1087,6 @@ mod tests {
             "device-1234",
             &bad_envelope,
             "own-device-5678",
-            false,
             &mut InboundContext {
                 psk: &psk,
                 relay_id: "relay-test",
@@ -1093,7 +1105,6 @@ mod tests {
             "device-1234",
             &good_envelope,
             "own-device-5678",
-            false,
             &mut InboundContext {
                 psk: &psk,
                 relay_id: "relay-test",
@@ -1133,7 +1144,6 @@ mod tests {
             "device-1234",
             &envelope,
             "own-device-5678",
-            true,
             &mut InboundContext {
                 psk: &psk,
                 relay_id: "relay-test",

--- a/src/relay/replay.rs
+++ b/src/relay/replay.rs
@@ -1,18 +1,17 @@
 //! Replay protection for relay envelopes.
 //!
-//! Two cheap layers stacked on top of the AEAD:
+//! Two replay policies stacked on top of the AEAD:
 //!
-//! 1. **Clock skew window** — drop envelopes whose `ts_secs` deviates from
-//!    local time by more than `MAX_SKEW_SECS`. The timestamp is bound into the
-//!    AAD, so an attacker cannot forge a fresher one without invalidating the
-//!    AEAD tag.
-//! 2. **Nonce LRU** — bounded set of `(device_short, nonce)` pairs. Drops exact
+//! 1. **Control freshness** — drop control envelopes whose `ts_secs` deviates
+//!    from local time by more than `MAX_SKEW_SECS`.
+//! 2. **State ordering** — accept state snapshots independently of receiver
+//!    wall time, but reject snapshots older than the sender watermark.
+//! 3. **Nonce LRU** — bounded set of `(device_short, nonce)` pairs. Drops exact
 //!    nonce replays inside the window. Capped so a chatty fleet cannot exhaust
 //!    memory; oldest entries are evicted first.
 //!
-//! The two layers together close the "replay later" and "replay-now-with-forged-
-//! timestamp" cases. The id-based dedup in `pull.rs` still runs for in-session
-//! ordering and remote-DB regression detection.
+//! The id-based dedup in `pull.rs` still runs for in-session ordering and
+//! remote-DB regression detection.
 
 use std::num::NonZeroUsize;
 
@@ -27,7 +26,7 @@ pub const NONCE_LRU_CAP: usize = 8192;
 pub enum ReplayError {
     /// Envelope timestamp is too far from `now`.
     ClockSkew { delta_secs: i64 },
-    /// Retained state envelope predates the newest state we've already accepted.
+    /// State envelope predates the newest state we've already accepted.
     OlderThanWatermark { ts_secs: u64, min_secs: u64 },
     /// Nonce already seen for this sender within the window.
     DuplicateNonce,
@@ -38,11 +37,7 @@ impl std::fmt::Display for ReplayError {
         match self {
             Self::ClockSkew { delta_secs } => write!(f, "clock skew {}s", delta_secs),
             Self::OlderThanWatermark { ts_secs, min_secs } => {
-                write!(
-                    f,
-                    "retained rollback ts={} < watermark={}",
-                    ts_secs, min_secs
-                )
+                write!(f, "state rollback ts={} < watermark={}", ts_secs, min_secs)
             }
             Self::DuplicateNonce => write!(f, "duplicate nonce"),
         }
@@ -89,10 +84,10 @@ impl ReplayGuard {
         self.check_inner(sender, nonce, ts_secs, now_secs, true)
     }
 
-    /// Retained MQTT state snapshots may legitimately be older than the live
-    /// skew window, but they must never roll back behind the newest state
+    /// State snapshots use sender ordering, not receiver wall time or MQTT
+    /// delivery metadata. They must never roll back behind the newest state
     /// already accepted for that sender.
-    pub fn check_retained(
+    pub fn check_state(
         &mut self,
         sender: &str,
         nonce: [u8; NONCE_LEN],
@@ -102,8 +97,7 @@ impl ReplayGuard {
     ) -> Result<(), ReplayError> {
         if let Some(min_secs) = min_accepted_ts {
             // Strict `<` preserves reconnect behavior: if the broker re-delivers
-            // the exact retained snapshot we already accepted, equal timestamps
-            // must still pass instead of looking like a rollback.
+            // the same snapshot, equal timestamps must still pass.
             if ts_secs < min_secs {
                 return Err(ReplayError::OlderThanWatermark { ts_secs, min_secs });
             }
@@ -142,8 +136,8 @@ impl ReplayGuard {
         self.record_nonce(sender, nonce, now_secs)
     }
 
-    /// Backwards-compatible helper for retained snapshots.
-    pub fn check_and_record_retained(
+    /// Helper for state snapshots.
+    pub fn check_and_record_state(
         &mut self,
         sender: &str,
         nonce: [u8; NONCE_LEN],
@@ -151,7 +145,7 @@ impl ReplayGuard {
         now_secs: u64,
         min_accepted_ts: Option<u64>,
     ) -> Result<(), ReplayError> {
-        self.check_retained(sender, nonce, ts_secs, now_secs, min_accepted_ts)?;
+        self.check_state(sender, nonce, ts_secs, now_secs, min_accepted_ts)?;
         self.record_nonce(sender, nonce, now_secs)
     }
 
@@ -270,21 +264,21 @@ mod tests {
     }
 
     #[test]
-    fn retained_accepts_old_snapshot_without_watermark() {
+    fn state_accepts_old_snapshot_without_watermark() {
         let mut g = ReplayGuard::default();
         let stale_now = 1000 + (MAX_SKEW_SECS as u64) + 120;
         assert!(
-            g.check_and_record_retained("a", nonce(9), 1000, stale_now, None)
+            g.check_and_record_state("a", nonce(9), 1000, stale_now, None)
                 .is_ok()
         );
     }
 
     #[test]
-    fn retained_rejects_rollback_behind_watermark() {
+    fn state_rejects_rollback_behind_watermark() {
         let mut g = ReplayGuard::default();
         let stale_now = 2000;
         let err = g
-            .check_and_record_retained("a", nonce(9), 1000, stale_now, Some(1500))
+            .check_and_record_state("a", nonce(9), 1000, stale_now, Some(1500))
             .unwrap_err();
         assert!(matches!(err, ReplayError::OlderThanWatermark { .. }));
     }


### PR DESCRIPTION
## Problem

Relay state acceptance depended on MQTT's `PUBLISH.retain` flag:

- live snapshots used a ±60-second receiver-clock check;
- subscription replays skipped that check and used a sender watermark.

Devices whose clocks differed by more than 60 seconds could therefore accept a peer after reconnecting but reject all subsequent live updates. This matches the asymmetric discovery and missing-message behavior in #63.

Graceful shutdown also published an empty retained payload. Receivers deliberately ignore empty payloads because they are unauthenticated, so peers remained visible until the stale-device timeout expired.

## Changes

- Authenticate envelopes before applying replay checks.
- Apply one sender-watermark policy to all state snapshots.
- Remove MQTT RETAIN metadata from state acceptance decisions.
- Retain the clock freshness check for control messages.
- Publish an authenticated retained `state:null` tombstone on graceful shutdown.
- Share tombstone construction with explicit relay cleanup.
- Keep ungraceful LWT handling on the existing stale-device fallback.
- Add regression tests for ±61-second clock skew, rollback rejection, and authenticated tombstones.

## Validation

- Focused relay tests passed: 19.
- `just ci` passed.
- The gate ran 1,858 unit tests plus integration and real-tool tests.
- The live public-MQTT relay roundtrip passed.
- `git diff --check` passed.

Closes #63.