### PR TITLE
fix(launcher): inherit HCOM_NOTES in the Codex bootstrap path

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -315,6 +315,33 @@ pub fn build_launch_env(
     build_launch_env_with_resolver(hcom_config, regime, crate::shell_env::resolved_shell_env)
 }
 
+fn build_codex_bootstrap(
+    db: &HcomDb,
+    hcom_dir: &Path,
+    instance_name: &str,
+    background: bool,
+    instance_env: &HashMap<String, String>,
+    tag: &str,
+    relay_enabled: bool,
+) -> String {
+    let notes = instance_env
+        .get("HCOM_NOTES")
+        .map(String::as_str)
+        .unwrap_or("");
+    crate::bootstrap::get_bootstrap(
+        db,
+        hcom_dir,
+        instance_name,
+        "codex",
+        background,
+        true,
+        notes,
+        tag,
+        relay_enabled,
+        None,
+    )
+}
+
 fn build_launch_env_with_resolver<F>(
     hcom_config: &HcomConfig,
     regime: LaunchEnvRegime,
@@ -2044,17 +2071,14 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
                     }
 
                     // Generate bootstrap text for preprocessing
-                    let bootstrap = crate::bootstrap::get_bootstrap(
+                    let bootstrap = build_codex_bootstrap(
                         db,
                         &paths::hcom_dir(),
                         &instance_name,
-                        "codex",
                         params.background,
-                        true, // is_launched
-                        "",
+                        &instance_env,
                         &effective_tag,
                         hcom_config.relay_enabled,
-                        None,
                     );
 
                     let sandbox_mode = instance_env
@@ -2975,6 +2999,47 @@ mod tests {
         assert_eq!(env.get("HCOM_TAG").map(String::as_str), Some("config-tag"));
 
         unsafe { std::env::remove_var("HCOM_TAG") }
+    }
+
+    #[test]
+    fn test_codex_bootstrap_includes_notes_from_effective_instance_env() {
+        let db = launcher_test_db();
+        let hcom_dir = tempfile::tempdir().unwrap();
+        let instance_env = HashMap::from([(
+            "HCOM_NOTES".to_string(),
+            "instance-specific notes".to_string(),
+        )]);
+
+        let bootstrap = build_codex_bootstrap(
+            &db,
+            hcom_dir.path(),
+            "luna",
+            false,
+            &instance_env,
+            "",
+            false,
+        );
+
+        assert!(bootstrap.contains("## NOTES"));
+        assert!(bootstrap.contains("instance-specific notes"));
+    }
+
+    #[test]
+    fn test_codex_bootstrap_omits_notes_section_when_effective_env_has_none() {
+        let db = launcher_test_db();
+        let hcom_dir = tempfile::tempdir().unwrap();
+
+        let bootstrap = build_codex_bootstrap(
+            &db,
+            hcom_dir.path(),
+            "luna",
+            false,
+            &HashMap::new(),
+            "",
+            false,
+        );
+
+        assert!(!bootstrap.contains("## NOTES"));
     }
 
     #[test]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -3144,6 +3144,72 @@ mod tests {
     }
 
     #[test]
+    fn test_codex_bootstrap_omits_notes_section_for_empty_env_value() {
+        // `HCOM_NOTES=""` is the documented way to clear notes; it is
+        // structurally different from a missing key and must still produce no
+        // `## NOTES` section.
+        let db = launcher_test_db();
+        let hcom_dir = tempfile::tempdir().unwrap();
+        let instance_env = HashMap::from([("HCOM_NOTES".to_string(), String::new())]);
+
+        let bootstrap = build_codex_bootstrap(
+            &db,
+            hcom_dir.path(),
+            "luna",
+            false,
+            &instance_env,
+            "",
+            false,
+        );
+
+        assert!(!bootstrap.contains("## NOTES"));
+    }
+
+    #[test]
+    fn test_codex_notes_survive_developer_instructions_toml_transport() {
+        // The helper only produces the intermediate bootstrap string. Notes
+        // actually reach Codex through `preprocess_codex_args`, which
+        // TOML-encodes the bootstrap into `-c developer_instructions=...`.
+        // Assert on the final, TOML-decoded argument so quotes, backslashes,
+        // braces, and newlines are proven to survive the real transport.
+        let db = launcher_test_db();
+        let hcom_dir = tempfile::tempdir().unwrap();
+        let notes =
+            "Use \"review mode\".\nWindows path: C:\\work\\repo\n{literal braces}\nSecond line";
+        let instance_env = HashMap::from([("HCOM_NOTES".to_string(), notes.to_string())]);
+
+        let bootstrap = build_codex_bootstrap(
+            &db,
+            hcom_dir.path(),
+            "luna",
+            false,
+            &instance_env,
+            "",
+            false,
+        );
+
+        let args =
+            crate::tools::codex_preprocessing::preprocess_codex_args(&[], &bootstrap, "workspace");
+
+        // Locate the `-c developer_instructions=<TOML>` value and decode it.
+        // preprocess also injects sandbox `-c` args, so match by prefix rather
+        // than by the first `-c` position.
+        let encoded = args
+            .iter()
+            .find_map(|a| a.strip_prefix("developer_instructions="))
+            .expect("developer_instructions arg present");
+        let decoded: toml::Table = toml::from_str(&format!("x = {encoded}"))
+            .expect("developer_instructions is valid TOML");
+        let dev_instructions = decoded["x"].as_str().expect("string value");
+
+        assert!(dev_instructions.contains("## NOTES"));
+        assert!(dev_instructions.contains("Use \"review mode\"."));
+        assert!(dev_instructions.contains("C:\\work\\repo"));
+        assert!(dev_instructions.contains("{literal braces}"));
+        assert!(dev_instructions.contains("Second line"));
+    }
+
+    #[test]
     #[serial]
     fn test_background_runner_env_uses_upstream_resolved_base() {
         let _guard = EnvVarGuard::remove(vec!["RORI_BACKGROUND_CONTAMINATION".to_string()]);


### PR DESCRIPTION
## Problem

The Codex-specific launch path hard-coded the bootstrap `notes` argument to an empty string, so a newly launched Codex session never received the global behavior notes (`HCOM_NOTES`) that every other tool's launch path passes through. Sessions started via other tools read `HCOM_NOTES` and include a NOTES section in their bootstrap; Codex was the lone exception and started without it.

## Fix

Extract a `build_codex_bootstrap` helper that reads `HCOM_NOTES` from the effective launch environment and feeds it to the shared `bootstrap::get_bootstrap` used by both production and tests. Behavior is unchanged when `HCOM_NOTES` is unset — this only fills the gap where Codex diverged from the other tools.

## Tests

Adds a unit test covering both cases: the NOTES section is present when `HCOM_NOTES` has a value, and behavior is unchanged when it is absent.

Verified locally with `cargo fmt --all -- --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked` (all green).

Only `src/launcher.rs` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
