### PR TITLE
fix(test): prevent relay push subprocesses in unit tests

### DIFF
--- a/src/commands/bundle.rs
+++ b/src/commands/bundle.rs
@@ -1196,15 +1196,7 @@ fn create_and_log_bundle(
     match bundles::create_bundle_event(bundle, &instance, created_by, db) {
         Ok(bundle_id) => {
             // Trigger relay push (best-effort)
-            let prefix = crate::runtime_env::get_hcom_prefix();
-            if let Some((cmd, prefix_args)) = prefix.split_first() {
-                let _ = std::process::Command::new(cmd)
-                    .args(prefix_args)
-                    .args(["relay", "push"])
-                    .stdout(std::process::Stdio::null())
-                    .stderr(std::process::Stdio::null())
-                    .spawn();
-            }
+            crate::relay::spawn_background_push();
 
             if json_mode {
                 println!("{}", json!({"bundle_id": bundle_id}));

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -734,7 +734,7 @@ fn config_instance(
     }
 
     // C4 fix: push config changes to relay
-    trigger_relay_push();
+    crate::relay::spawn_background_push();
 
     0
 }
@@ -2198,20 +2198,6 @@ fn update_auto_approve_permissions(value: &str) -> bool {
         eprintln!("Failed to update {tool} auto-approve permissions: {error}");
     }
     failures.is_empty()
-}
-
-/// Trigger relay push (best-effort, silent failure). C4 fix.
-fn trigger_relay_push() {
-    // Trigger relay push (best-effort)
-    let prefix = crate::runtime_env::get_hcom_prefix();
-    if let Some((cmd, prefix_args)) = prefix.split_first() {
-        let _ = std::process::Command::new(cmd)
-            .args(prefix_args)
-            .args(["relay", "push"])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn();
-    }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────

--- a/src/hooks/common.rs
+++ b/src/hooks/common.rs
@@ -1154,15 +1154,7 @@ fn stop_instance_inner(
     crate::notify::wake_ports(&wake_ports, crate::notify::WAKE_TARGETED_MS);
 
     // Trigger relay push (best-effort)
-    let prefix = crate::runtime_env::get_hcom_prefix();
-    if let Some((cmd, prefix_args)) = prefix.split_first() {
-        let _ = std::process::Command::new(cmd)
-            .args(prefix_args)
-            .args(["relay", "push"])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn();
-    }
+    crate::relay::spawn_background_push();
 }
 
 /// Soft session end for Antigravity: mark inactive without deleting the `instances` row.

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -2306,15 +2306,7 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
     .ok();
 
     // Push launch event to relay (best-effort)
-    let prefix = crate::runtime_env::get_hcom_prefix();
-    if let Some((cmd, prefix_args)) = prefix.split_first() {
-        let _ = std::process::Command::new(cmd)
-            .args(prefix_args)
-            .args(["relay", "push"])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn();
-    }
+    crate::relay::spawn_background_push();
 
     Ok(LaunchResult {
         // User-facing identity. The PTY-vs-print backend distinction lives in

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -689,6 +689,10 @@ pub fn spawn_background_push() {
     spawn_background_push_with(&crate::runtime_env::get_hcom_prefix());
 }
 
+// Callers: `spawn_background_push` under `not(test)`, and the unix-only
+// regression test under `test`. Gate to match so a Windows test build (no unix
+// test, no production caller) doesn't flag it as dead code.
+#[cfg(any(not(test), unix))]
 fn spawn_background_push_with(prefix: &[String]) {
     #[cfg(not(test))]
     if let Some((cmd, prefix_args)) = prefix.split_first() {

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -678,15 +678,15 @@ pub fn notify_relay_daemon() -> bool {
         .unwrap_or(false)
 }
 
-/// Fire-and-forget `hcom relay push` in a detached subprocess so remote devices
-/// see local changes (session end, launch) without waiting for the worker's next
-/// periodic cycle. Best-effort: spawn failures are ignored.
+/// Fire-and-forget `hcom relay push` in a background child process so remote
+/// devices see local changes (session end, launch) without waiting for the
+/// worker's next periodic cycle. Best-effort: spawn failures are ignored.
 ///
 /// Unit tests must not spawn the real hcom binary: a child process can outlive
 /// the test's temporary environment and fall back to the developer's `~/.hcom`.
 pub fn spawn_background_push() {
-    let prefix = crate::runtime_env::get_hcom_prefix();
-    spawn_background_push_with(&prefix);
+    #[cfg(not(test))]
+    spawn_background_push_with(&crate::runtime_env::get_hcom_prefix());
 }
 
 fn spawn_background_push_with(prefix: &[String]) {

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -678,6 +678,32 @@ pub fn notify_relay_daemon() -> bool {
         .unwrap_or(false)
 }
 
+/// Fire-and-forget `hcom relay push` in a detached subprocess so remote devices
+/// see local changes (session end, launch) without waiting for the worker's next
+/// periodic cycle. Best-effort: spawn failures are ignored.
+///
+/// Unit tests must not spawn the real hcom binary: a child process can outlive
+/// the test's temporary environment and fall back to the developer's `~/.hcom`.
+pub fn spawn_background_push() {
+    let prefix = crate::runtime_env::get_hcom_prefix();
+    spawn_background_push_with(&prefix);
+}
+
+fn spawn_background_push_with(prefix: &[String]) {
+    #[cfg(not(test))]
+    if let Some((cmd, prefix_args)) = prefix.split_first() {
+        let _ = std::process::Command::new(cmd)
+            .args(prefix_args)
+            .args(["relay", "push"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+    }
+
+    #[cfg(test)]
+    let _ = prefix;
+}
+
 /// Notify the relay daemon to push immediately.
 /// Handles three cases:
 ///  - Daemon running and ready: TCP notify succeeds, returns immediately.
@@ -746,6 +772,28 @@ pub fn set_relay_status(db: &HcomDb, status: &str, error: Option<&str>, is_worke
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn test_background_push_is_disabled_in_unit_tests() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("spawned");
+        let shim = temp.path().join("hcom-shim");
+        std::fs::write(&shim, format!("#!/bin/sh\ntouch '{}'\n", marker.display())).unwrap();
+        let mut permissions = std::fs::metadata(&shim).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&shim, permissions).unwrap();
+
+        spawn_background_push_with(&[shim.to_string_lossy().into_owned()]);
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        assert!(
+            !marker.exists(),
+            "unit tests must never spawn a real hcom relay push subprocess"
+        );
+    }
 
     #[test]
     fn test_parse_broker_url_mqtts() {


### PR DESCRIPTION
## Summary

- centralize the duplicated best-effort `hcom relay push` spawn sites
- compile the child-process spawn out under `cfg(test)`
- add a regression test using an executable shim and marker file

## Why

A unit-test process can spawn the real `hcom` binary after its temporary environment has been removed. The child may then fall back to the developer's real `~/.hcom`, so in-process test isolation alone cannot protect that boundary.

Production and integration-test builds retain the existing fire-and-forget relay push behavior through the `cfg(not(test))` branch.

## Test plan

- `cargo fmt -- --check`
- `HCOM_DIR=$(mktemp -d) cargo clippy --all-targets --all-features -- -D warnings`
- `HCOM_DIR=$(mktemp -d) cargo test`
- focused regression: `HCOM_DIR=$(mktemp -d) cargo test relay::tests::test_background_push_is_disabled_in_unit_tests -- --exact`

Local result: 1993 passed, 0 failed, 15 ignored.