### PR TITLE
fix: restrict hcom data permissions on POSIX

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -68,64 +68,19 @@ fn get_inode(path: &std::path::Path) -> u64 {
     crate::sys::fs::file_id(path)
 }
 
-#[cfg(unix)]
-fn sqlite_sidecar_path(db_path: &std::path::Path, suffix: &str) -> std::path::PathBuf {
-    let mut path = db_path.as_os_str().to_os_string();
-    path.push(suffix);
-    path.into()
-}
-
 impl HcomDb {
+    /// Open a hardened connection: secure the directory and database files to
+    /// owner-only modes (see `paths::ensure_private_db`), then open with the
+    /// standard hcom PRAGMAs. The single write path for opening the DB.
     fn open_connection(db_path: &std::path::Path) -> Result<Connection> {
-        if db_path != std::path::Path::new(":memory:") {
-            if let Some(parent) = db_path.parent() {
-                std::fs::create_dir_all(parent).with_context(|| {
-                    format!("Failed to create db directory: {}", parent.display())
-                })?;
-            }
-
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-
-                std::fs::OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .create(true)
-                    .truncate(false)
-                    .mode(0o600)
-                    .open(db_path)
-                    .with_context(|| format!("Failed to create database: {}", db_path.display()))?;
-                std::fs::set_permissions(db_path, std::fs::Permissions::from_mode(0o600))
-                    .with_context(|| {
-                        format!("Failed to restrict database: {}", db_path.display())
-                    })?;
-            }
-        }
+        crate::paths::ensure_private_db(db_path)
+            .with_context(|| format!("Failed to secure database: {}", db_path.display()))?;
 
         let conn = Connection::open(db_path)
             .with_context(|| format!("Failed to open database: {}", db_path.display()))?;
         conn.execute_batch(
             "PRAGMA foreign_keys=ON; PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;",
         )?;
-
-        #[cfg(unix)]
-        if db_path != std::path::Path::new(":memory:") {
-            use std::os::unix::fs::PermissionsExt;
-
-            for path in [
-                db_path.to_path_buf(),
-                sqlite_sidecar_path(db_path, "-wal"),
-                sqlite_sidecar_path(db_path, "-shm"),
-            ] {
-                if path.exists() {
-                    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-                        .with_context(|| {
-                            format!("Failed to restrict database file: {}", path.display())
-                        })?;
-                }
-            }
-        }
 
         Ok(conn)
     }
@@ -144,9 +99,8 @@ impl HcomDb {
     pub fn open() -> Result<Self> {
         let hcom_dir = crate::paths::hcom_dir();
         crate::paths::ensure_private_directory(&hcom_dir)
-            .with_context(|| format!("Failed to create hcom directory: {}", hcom_dir.display()))?;
-        let db_path = hcom_dir.join("hcom.db");
-        Self::open_at(&db_path)
+            .with_context(|| format!("Failed to secure hcom directory: {}", hcom_dir.display()))?;
+        Self::open_at(&hcom_dir.join("hcom.db"))
     }
 
     /// Open the hcom database at a specific path with schema migration/compat.
@@ -180,6 +134,17 @@ impl HcomDb {
         }
         // DB file replaced — reconnect
         use crate::log::{log_error, log_info};
+        // Best-effort re-harden: the replacement was written by another hcom
+        // process (reset/archive) that already secured it, so failing here must
+        // not wedge a live delivery/listener loop — log and continue.
+        if let Err(e) = crate::paths::ensure_private_db(&self.db_path) {
+            use crate::log::log_warn;
+            log_warn(
+                "native",
+                "db.secure_fail",
+                &format!("Failed to re-secure DB after replacement: {}", e),
+            );
+        }
         match Connection::open(&self.db_path) {
             Ok(new_conn) => {
                 if let Err(e) = new_conn.execute_batch(
@@ -904,8 +869,8 @@ pub(super) mod tests {
             .unwrap();
 
         assert_eq!(mode(&db_path), 0o600);
-        assert_eq!(mode(&sqlite_sidecar_path(&db_path, "-wal")), 0o600);
-        assert_eq!(mode(&sqlite_sidecar_path(&db_path, "-shm")), 0o600);
+        assert_eq!(mode(&crate::paths::sidecar_path(&db_path, "-wal")), 0o600);
+        assert_eq!(mode(&crate::paths::sidecar_path(&db_path, "-shm")), 0o600);
     }
 
     #[cfg(unix)]
@@ -927,8 +892,8 @@ pub(super) mod tests {
 
         for path in [
             db_path.clone(),
-            sqlite_sidecar_path(&db_path, "-wal"),
-            sqlite_sidecar_path(&db_path, "-shm"),
+            crate::paths::sidecar_path(&db_path, "-wal"),
+            crate::paths::sidecar_path(&db_path, "-shm"),
         ] {
             std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).unwrap();
         }
@@ -936,8 +901,8 @@ pub(super) mod tests {
         let _second = HcomDb::open_raw(&db_path).unwrap();
 
         assert_eq!(mode(&db_path), 0o600);
-        assert_eq!(mode(&sqlite_sidecar_path(&db_path, "-wal")), 0o600);
-        assert_eq!(mode(&sqlite_sidecar_path(&db_path, "-shm")), 0o600);
+        assert_eq!(mode(&crate::paths::sidecar_path(&db_path, "-wal")), 0o600);
+        assert_eq!(mode(&crate::paths::sidecar_path(&db_path, "-shm")), 0o600);
     }
 
     #[cfg(unix)]
@@ -979,6 +944,27 @@ pub(super) mod tests {
 
         assert_eq!(mode(&hcom_dir), 0o700);
         assert_eq!(mode(db.path()), 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reconnect_if_stale_resecures_replaced_database() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("hcom.db");
+        let mut db = HcomDb::open_raw(&db_path).unwrap();
+
+        // Simulate another process replacing the DB with a broad-mode file
+        // (new inode), as reset/schema-archive does.
+        std::fs::remove_file(&db_path).unwrap();
+        let _ = std::fs::remove_file(crate::paths::sidecar_path(&db_path, "-wal"));
+        let _ = std::fs::remove_file(crate::paths::sidecar_path(&db_path, "-shm"));
+        drop(HcomDb::open_raw(&db_path).unwrap());
+        std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert!(db.reconnect_if_stale());
+        assert_eq!(mode(&db_path), 0o600);
     }
 
     #[test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -106,8 +106,12 @@ impl HcomDb {
 
         let conn = Connection::open(db_path)
             .with_context(|| format!("Failed to open database: {}", db_path.display()))?;
+        // busy_timeout first: converting a fresh db to WAL takes a brief
+        // exclusive lock, so with a 0 timeout a concurrent first-open (or heavy
+        // load) fails instantly with SQLITE_BUSY. Setting the timeout up front
+        // makes the WAL conversion retry instead.
         conn.execute_batch(
-            "PRAGMA foreign_keys=ON; PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;",
+            "PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON; PRAGMA journal_mode=WAL;",
         )?;
 
         Ok(conn)
@@ -178,7 +182,7 @@ impl HcomDb {
         match Connection::open(&self.db_path) {
             Ok(new_conn) => {
                 if let Err(e) = new_conn.execute_batch(
-                    "PRAGMA foreign_keys=ON; PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;",
+                    "PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON; PRAGMA journal_mode=WAL;",
                 ) {
                     use crate::log::log_warn;
                     log_warn(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -68,7 +68,68 @@ fn get_inode(path: &std::path::Path) -> u64 {
     crate::sys::fs::file_id(path)
 }
 
+#[cfg(unix)]
+fn sqlite_sidecar_path(db_path: &std::path::Path, suffix: &str) -> std::path::PathBuf {
+    let mut path = db_path.as_os_str().to_os_string();
+    path.push(suffix);
+    path.into()
+}
+
 impl HcomDb {
+    fn open_connection(db_path: &std::path::Path) -> Result<Connection> {
+        if db_path != std::path::Path::new(":memory:") {
+            if let Some(parent) = db_path.parent() {
+                std::fs::create_dir_all(parent).with_context(|| {
+                    format!("Failed to create db directory: {}", parent.display())
+                })?;
+            }
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+                std::fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .mode(0o600)
+                    .open(db_path)
+                    .with_context(|| format!("Failed to create database: {}", db_path.display()))?;
+                std::fs::set_permissions(db_path, std::fs::Permissions::from_mode(0o600))
+                    .with_context(|| {
+                        format!("Failed to restrict database: {}", db_path.display())
+                    })?;
+            }
+        }
+
+        let conn = Connection::open(db_path)
+            .with_context(|| format!("Failed to open database: {}", db_path.display()))?;
+        conn.execute_batch(
+            "PRAGMA foreign_keys=ON; PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;",
+        )?;
+
+        #[cfg(unix)]
+        if db_path != std::path::Path::new(":memory:") {
+            use std::os::unix::fs::PermissionsExt;
+
+            for path in [
+                db_path.to_path_buf(),
+                sqlite_sidecar_path(db_path, "-wal"),
+                sqlite_sidecar_path(db_path, "-shm"),
+            ] {
+                if path.exists() {
+                    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                        .with_context(|| {
+                            format!("Failed to restrict database file: {}", path.display())
+                        })?;
+                }
+            }
+        }
+
+        Ok(conn)
+    }
+
     /// Access the underlying SQLite connection (for direct queries).
     pub fn conn(&self) -> &Connection {
         &self.conn
@@ -81,7 +142,10 @@ impl HcomDb {
 
     /// Open the hcom database at ~/.hcom/hcom.db with schema migration/compat.
     pub fn open() -> Result<Self> {
-        let db_path = crate::paths::db_path();
+        let hcom_dir = crate::paths::hcom_dir();
+        crate::paths::ensure_private_directory(&hcom_dir)
+            .with_context(|| format!("Failed to create hcom directory: {}", hcom_dir.display()))?;
+        let db_path = hcom_dir.join("hcom.db");
         Self::open_at(&db_path)
     }
 
@@ -94,17 +158,7 @@ impl HcomDb {
 
     /// Open DB connection without schema checks (for testing only).
     pub fn open_raw(db_path: &std::path::Path) -> Result<Self> {
-        if let Some(parent) = db_path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("Failed to create db directory: {}", parent.display()))?;
-        }
-        let conn = Connection::open(db_path)
-            .with_context(|| format!("Failed to open database: {}", db_path.display()))?;
-
-        // Enable WAL mode for concurrent access + foreign keys for CASCADE
-        conn.execute_batch(
-            "PRAGMA foreign_keys=ON; PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;",
-        )?;
+        let conn = Self::open_connection(db_path)?;
 
         let inode = get_inode(db_path);
 
@@ -385,15 +439,12 @@ impl HcomDb {
                 }
 
                 // Reconnect to fresh DB file
-                let new_conn = Connection::open(&self.db_path).with_context(|| {
+                let new_conn = Self::open_connection(&self.db_path).with_context(|| {
                     format!(
                         "Failed to reopen DB after archive: {}",
                         self.db_path.display()
                     )
                 })?;
-                new_conn.execute_batch(
-                    "PRAGMA foreign_keys=ON; PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;",
-                )?;
                 self.conn = new_conn;
                 self.db_inode = get_inode(&self.db_path);
 
@@ -830,6 +881,104 @@ pub(super) mod tests {
         let _ = std::fs::remove_file(&path);
         let _ = std::fs::remove_file(PathBuf::from(format!("{}-wal", path.display())));
         let _ = std::fs::remove_file(PathBuf::from(format!("{}-shm", path.display())));
+    }
+
+    #[cfg(unix)]
+    fn mode(path: &std::path::Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_raw_creates_private_database_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("hcom.db");
+
+        let db = HcomDb::open_raw(&db_path).unwrap();
+        db.conn()
+            .execute("CREATE TABLE permission_probe (id INTEGER)", [])
+            .unwrap();
+        db.conn()
+            .execute("INSERT INTO permission_probe VALUES (1)", [])
+            .unwrap();
+
+        assert_eq!(mode(&db_path), 0o600);
+        assert_eq!(mode(&sqlite_sidecar_path(&db_path, "-wal")), 0o600);
+        assert_eq!(mode(&sqlite_sidecar_path(&db_path, "-shm")), 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_raw_restricts_existing_database_files() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("hcom.db");
+        let first = HcomDb::open_raw(&db_path).unwrap();
+        first
+            .conn()
+            .execute("CREATE TABLE permission_probe (id INTEGER)", [])
+            .unwrap();
+        first
+            .conn()
+            .execute("INSERT INTO permission_probe VALUES (1)", [])
+            .unwrap();
+
+        for path in [
+            db_path.clone(),
+            sqlite_sidecar_path(&db_path, "-wal"),
+            sqlite_sidecar_path(&db_path, "-shm"),
+        ] {
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        let _second = HcomDb::open_raw(&db_path).unwrap();
+
+        assert_eq!(mode(&db_path), 0o600);
+        assert_eq!(mode(&sqlite_sidecar_path(&db_path, "-wal")), 0o600);
+        assert_eq!(mode(&sqlite_sidecar_path(&db_path, "-shm")), 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_raw_restricts_sidecars_for_non_db_filename() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = tmp.path().join("state.sqlite");
+
+        let db = HcomDb::open_raw(&db_path).unwrap();
+        db.conn()
+            .execute("CREATE TABLE permission_probe (id INTEGER)", [])
+            .unwrap();
+        db.conn()
+            .execute("INSERT INTO permission_probe VALUES (1)", [])
+            .unwrap();
+
+        let wal_path = tmp.path().join("state.sqlite-wal");
+        let shm_path = tmp.path().join("state.sqlite-shm");
+        std::fs::set_permissions(&wal_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::fs::set_permissions(&shm_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let _second = HcomDb::open_raw(&db_path).unwrap();
+
+        assert_eq!(mode(&wal_path), 0o600);
+        assert_eq!(mode(&shm_path), 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_restricts_the_configured_hcom_directory_and_database() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_tmp, hcom_dir, _home, _guard) = crate::hooks::test_helpers::isolated_test_env();
+        std::fs::set_permissions(&hcom_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let db = HcomDb::open().unwrap();
+
+        assert_eq!(mode(&hcom_dir), 0o700);
+        assert_eq!(mode(db.path()), 0o600);
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -139,12 +139,26 @@ pub fn ensure_hcom_directories() -> bool {
 
 /// Ensure directories under a given base (testable without global config).
 pub fn ensure_hcom_directories_at(base: &Path) -> bool {
+    if ensure_private_directory(base).is_err() {
+        return false;
+    }
     for dir_name in [LOGS_DIR, LAUNCH_DIR, FLAGS_DIR, LAUNCHES_DIR, ARCHIVE_DIR] {
         if fs::create_dir_all(base.join(dir_name)).is_err() {
             return false;
         }
     }
     true
+}
+
+/// Create an hcom-owned directory and keep its contents private on POSIX.
+pub(crate) fn ensure_private_directory(path: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
 }
 
 /// Write content to file atomically (temp file + rename).
@@ -242,6 +256,36 @@ mod tests {
 
         // Idempotent — second call succeeds too
         assert!(ensure_hcom_directories_at(tmp.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_hcom_directories_creates_private_base_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path().join("state").join(".hcom");
+
+        assert!(ensure_hcom_directories_at(&base));
+
+        let mode = fs::metadata(&base).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_hcom_directories_restricts_existing_base_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path().join(".hcom");
+        fs::create_dir(&base).unwrap();
+        fs::set_permissions(&base, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(ensure_hcom_directories_at(&base));
+
+        let mode = fs::metadata(&base).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -150,13 +150,52 @@ pub fn ensure_hcom_directories_at(base: &Path) -> bool {
     true
 }
 
-/// Create an hcom-owned directory and keep its contents private on POSIX.
+/// Create an hcom-owned directory and keep it private on POSIX (`0o700`).
 pub(crate) fn ensure_private_directory(path: &Path) -> std::io::Result<()> {
     fs::create_dir_all(path)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    crate::sys::fs::set_private_dir(path)
+}
+
+/// SQLite sidecar path (`-wal` / `-shm`), appending the suffix to the *full*
+/// database filename so custom names like `state.sqlite` map to
+/// `state.sqlite-wal`, not `state.db-wal`.
+pub(crate) fn sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
+    let mut os = db_path.as_os_str().to_os_string();
+    os.push(suffix);
+    os.into()
+}
+
+/// Keep an hcom SQLite database and any WAL/SHM sidecars owner-private on POSIX
+/// (`0o600`). No-op on `:memory:` and on Windows.
+///
+/// This secures the *files* only; the containing directory's `0o700` mode is
+/// owned by the caller that creates the hcom directory (`ensure_private_db` is
+/// also handed arbitrary temp paths under a shared, sometimes un-chmoddable
+/// parent, so it must not touch the parent's mode).
+///
+/// Newly created sidecars inherit `0o600` from the main file via SQLite's Unix
+/// VFS, but a pre-existing broad `-wal`/`-shm` (legacy install) is not
+/// re-chmodded by SQLite on reopen — so we repair existing ones explicitly.
+pub(crate) fn ensure_private_db(db_path: &Path) -> std::io::Result<()> {
+    if db_path == Path::new(":memory:") {
+        return Ok(());
+    }
+    if let Some(parent) = db_path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)?;
+    }
+    // Create the main db private, or repair an existing broad mode.
+    match crate::sys::fs::create_private_new(db_path) {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            crate::sys::fs::set_private(db_path)?;
+        }
+        Err(e) => return Err(e),
+    }
+    for suffix in ["-wal", "-shm"] {
+        let sidecar = sidecar_path(db_path, suffix);
+        if sidecar.exists() {
+            crate::sys::fs::set_private(&sidecar)?;
+        }
     }
     Ok(())
 }

--- a/src/sys/fs.rs
+++ b/src/sys/fs.rs
@@ -106,6 +106,24 @@ pub fn set_private(path: &Path) -> io::Result<()> {
     }
 }
 
+/// Restrict a directory to owner-only access (`0o700` on Unix).
+///
+/// No-op on Windows, where Unix mode bits do not apply. Same caveat as
+/// `set_private`: a shared `HCOM_DIR`/`HOME` location isn't actually locked
+/// down on Windows until real ACL restriction is implemented.
+pub fn set_private_dir(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
 /// Mark a file as executable (`0o755` on Unix).
 ///
 /// No-op on Windows, where executability is determined by file extension rather

--- a/src/tui/db.rs
+++ b/src/tui/db.rs
@@ -80,7 +80,7 @@ impl DbDataSource {
             // query_only=ON: TUI is read-only; any accidental write will
             // error immediately rather than silently succeed.
             if let Err(e) = conn.execute_batch(
-                "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=3000; PRAGMA query_only=ON;",
+                "PRAGMA busy_timeout=3000; PRAGMA journal_mode=WAL; PRAGMA query_only=ON;",
             ) {
                 self.last_error = Some(format!(
                     "init database pragmas {}: {}",
@@ -1438,24 +1438,37 @@ mod tests {
     };
     use rusqlite::Connection;
 
+    // Blocker 1 regression: the no-arg TUI must route through the owner-only
+    // permission boundary rather than leaving/creating a broad database. `db_path`
+    // is pinned to the isolated temp rather than left to be re-read from global
+    // `Config` mid-test, whose process-wide cache other parallel tests can reset.
     #[cfg(unix)]
     #[test]
-    fn ensure_conn_secures_directory_and_database() {
+    fn ensure_conn_secures_existing_broad_database() {
         use std::os::unix::fs::PermissionsExt;
 
         let (_tmp, hcom_dir, _home, _guard) = crate::hooks::test_helpers::isolated_test_env();
-        // Legacy broad install opened only through the no-arg TUI.
-        std::fs::set_permissions(&hcom_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        // Pre-existing broad db (legacy install opened only through the TUI).
         let db_path = hcom_dir.join("hcom.db");
         std::fs::write(&db_path, b"").unwrap();
         std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
+        // Opening the TUI data source must run the permission boundary, which
+        // secures the db with a lock-free chmod before any connection is
+        // opened. Assert on the resulting mode, not the connection: whether the
+        // read open itself succeeds is irrelevant to the security invariant and
+        // would otherwise couple the test to SQLite locking under parallel load.
         let mut ds = super::DbDataSource::new();
-        assert!(ds.ensure_conn().is_some());
+        ds.db_path = db_path.clone();
+        let _ = ds.ensure_conn();
 
         let mode = |p: &std::path::Path| std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode(&hcom_dir), 0o700);
-        assert_eq!(mode(&db_path), 0o600);
+        assert_eq!(
+            mode(&db_path),
+            0o600,
+            "TUI open left db broad: {:?}",
+            ds.last_error
+        );
     }
 
     fn setup_conn() -> Connection {

--- a/src/tui/db.rs
+++ b/src/tui/db.rs
@@ -60,6 +60,16 @@ impl DbDataSource {
     /// Lazy-open persistent connection; reconnects on failure.
     fn ensure_conn(&mut self) -> Option<&Connection> {
         if self.conn.is_none() {
+            // Harden before opening: the TUI is the no-arg default entry point,
+            // so it must apply the same owner-only permission boundary as the
+            // CLI rather than letting SQLite create/leave a broad db.
+            let hcom_dir = paths::hcom_dir();
+            if let Err(e) = paths::ensure_private_directory(&hcom_dir)
+                .and_then(|()| paths::ensure_private_db(&self.db_path))
+            {
+                self.last_error = Some(format!("secure {}: {}", self.db_path.display(), e));
+                return None;
+            }
             let conn = match Connection::open(&self.db_path) {
                 Ok(c) => c,
                 Err(e) => {
@@ -1427,6 +1437,26 @@ mod tests {
         ActivityKind, Agent, AgentStatus, EventKind, MessageScope, SenderKind, Tool,
     };
     use rusqlite::Connection;
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_conn_secures_directory_and_database() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_tmp, hcom_dir, _home, _guard) = crate::hooks::test_helpers::isolated_test_env();
+        // Legacy broad install opened only through the no-arg TUI.
+        std::fs::set_permissions(&hcom_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let db_path = hcom_dir.join("hcom.db");
+        std::fs::write(&db_path, b"").unwrap();
+        std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let mut ds = super::DbDataSource::new();
+        assert!(ds.ensure_conn().is_some());
+
+        let mode = |p: &std::path::Path| std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode(&hcom_dir), 0o700);
+        assert_eq!(mode(&db_path), 0o600);
+    }
 
     fn setup_conn() -> Connection {
         let conn = Connection::open_in_memory().unwrap();


### PR DESCRIPTION
## Summary

- create and repair the configured hcom data directory with mode `0700` on POSIX
- create and reopen the SQLite main database, WAL, and SHM files with mode `0600`
- derive SQLite sidecar paths by appending `-wal` / `-shm` to the complete database path
- leave Windows behavior unchanged

## Why

The hcom database contains session metadata and message history. Default process umasks can leave the data directory or database files readable by other local users. Existing installations can also retain broader permissions from earlier runs.

This change extracts the small filesystem-permission fix that was first validated in a local integration build and reapplies it directly on upstream `main`. It intentionally contains no unrelated session-identity or routing changes.

On POSIX, normal directory and database-open paths now repair overly broad existing modes as well as using private modes for newly created files. This is filesystem permission hardening only: it does not add encryption, same-UID isolation, or other process-authentication mechanisms.

## Regression coverage

- new configured hcom directory is `0700`
- existing configured hcom directory is tightened from `0755` to `0700`
- newly created SQLite main database, WAL, and SHM are `0600`
- existing database files are tightened from `0644` to `0600`
- a non-`.db` database name such as `state.sqlite` correctly targets `state.sqlite-wal` and `state.sqlite-shm`
- the production `HcomDb::open()` path tightens both the configured directory and main database

## Test plan

- `cargo fmt --all -- --check`
- `HCOM_DIR=$(mktemp -d) cargo clippy --locked --all-targets --all-features -- -D warnings`
- `HCOM_DIR=$(mktemp -d) cargo test --locked`
- focused POSIX permission regressions for directory, main database, and arbitrary-filename sidecars

Local result: 1998 passed, 0 failed, 15 ignored.
