### PR TITLE
fix(ci): unblock current pull request checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,10 +148,6 @@ jobs:
           echo "CC_aarch64_linux_android=$NDK_BIN/aarch64-linux-android24-clang" >> "$GITHUB_ENV"
           echo "AR_aarch64_linux_android=$NDK_BIN/llvm-ar" >> "$GITHUB_ENV"
         shell: "bash"
-      - uses: swatinem/rust-cache@v2
-        with:
-          key: ${{ join(matrix.targets, '-') }}
-          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -831,7 +831,7 @@ fn cmd_list_stopped(db: &HcomDb, args: &ListArgs) -> i32 {
         let data: serde_json::Value = serde_json::from_str(&entry.data).unwrap_or_default();
         let snapshot = &data["snapshot"];
         println!("Stopped: {}", entry.instance);
-        println!("  Time:       {}", &entry.timestamp);
+        println!("  Time:       {}", entry.timestamp);
         if let Some(by) = data["by"].as_str() {
             println!("  By:         {by}");
         }


### PR DESCRIPTION
## Summary

- remove the Rust 1.97 Clippy `useless_borrows_in_formatting` failure already present on `main`
- refresh the cargo-dist 0.31.0 generated release workflow with the exact diff reported by `dist plan`

These two baseline failures currently make unrelated PRs #88, #89, and #90 red. This PR keeps the cleanup separate from those feature changes.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- cargo-dist plan and Rust 1.97 Clippy are revalidated by this PR CI
