### PR TITLE
fix(launch): preserve authored reply semantics across launch and resume

### DIFF
--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -198,7 +198,10 @@ pub fn run(argv: &[String], flags: &GlobalFlags) -> Result<i32> {
             name: None, // --name is caller identity, not instance name
             skip_validation: false,
             terminal,
-            append_reply_handoff: true,
+            // CLI launches never append the reply footer: the dispatcher's
+            // prompt owns the reply semantics (a hardcoded footer contradicts
+            // prompts that say "report to X" or "no report needed").
+            append_reply_handoff: false,
         },
     )?;
 

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -553,9 +553,8 @@ fn prepare_resume_plan_from_source(
             name: launch_name,
             skip_validation: false,
             terminal: launch_flags.terminal.clone(),
-            // Codex tracked-instance fork uses initial_prompt for an identity
-            // reset; don't dilute it with a reply-handoff suffix. Adoption-fork
-            // has no identity-reset prompt, so normal handoff rules apply.
+            // Always false on resume/fork: the prompt author owns reply
+            // semantics (see build_resume_prompts). Matches the CLI launch path.
             append_reply_handoff,
         },
         last_event_id,
@@ -846,9 +845,15 @@ fn build_resume_prompts(input: ResumePromptInput<'_>) -> (Option<String>, Option
         (None, _) => None,
     };
 
-    // Codex tracked-instance fork uses initial_prompt for an identity reset;
-    // don't dilute it with a reply-handoff suffix. Adoption-fork has no reset.
-    let append_reply_handoff = !(fork && tool == "codex" && !is_adoption);
+    // Resume/fork never append the reply-handoff footer, for any tool. The
+    // prompt author owns reply semantics: the custom -p prompt (or the codex
+    // identity-reset prompt) is authoritative, and a hardcoded "send your
+    // result back to @<launcher>" footer contradicts prompts that say
+    // "report to X" or "no report needed". This matches the CLI launch path,
+    // which also opts out. Fork sessions don't even receive the reception-
+    // discipline primer, so there is no downstream rule to override a stray
+    // footer — all the more reason not to inject one.
+    let append_reply_handoff = false;
     (system_prompt, initial_prompt, append_reply_handoff)
 }
 
@@ -2308,6 +2313,53 @@ mod tests {
     fn test_build_resume_args_codex_resume() {
         let args = build_resume_args("codex", "sess-456", false);
         assert_eq!(args, s(&["resume", "sess-456"]));
+    }
+
+    // Reply-handoff footer must never be appended on resume/fork, for any tool
+    // or path. The prompt author owns reply semantics; a hardcoded
+    // "send your result back to @<launcher>" footer contradicts prompts that
+    // say "report to X" or "no report needed". Mirrors the CLI launch path.
+    fn append_reply_handoff_for(
+        tool: &str,
+        fork: bool,
+        is_adoption: bool,
+        child_name: Option<&str>,
+    ) -> bool {
+        let (_system, _initial, append) = build_resume_prompts(ResumePromptInput {
+            tool,
+            display_name: "luna",
+            fork,
+            is_adoption,
+            child_name,
+            effective_tag: None,
+            custom_system_prompt: None,
+            custom_initial_prompt: None,
+        });
+        append
+    }
+
+    #[test]
+    fn test_resume_never_appends_reply_handoff() {
+        // Plain tracked resume (claude / codex).
+        assert!(!append_reply_handoff_for("claude", false, false, None));
+        assert!(!append_reply_handoff_for("codex", false, false, None));
+        // Claude tracked fork (hcom f) — previously still appended the footer.
+        assert!(!append_reply_handoff_for(
+            "claude",
+            true,
+            false,
+            Some("nova")
+        ));
+        // Codex tracked fork — already suppressed before; stays suppressed.
+        assert!(!append_reply_handoff_for(
+            "codex",
+            true,
+            false,
+            Some("nova")
+        ));
+        // Adoption resume / fork (on-disk session, no prior hcom identity).
+        assert!(!append_reply_handoff_for("claude", false, true, None));
+        assert!(!append_reply_handoff_for("claude", true, true, None));
     }
 
     #[test]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1737,15 +1737,10 @@ pub fn launch(db: &HcomDb, mut params: LaunchParams) -> Result<LaunchResult> {
     });
 
     // Inject --hcom-prompt into tool args (translated per-tool).
-    // When a real hcom participant launched us, append a reply instruction so
-    // the spawned agent knows to send its result back.
+    // When a real hcom participant launched us, optionally append a reply
+    // instruction so the spawned agent knows to send its result back.
     if let Some(ref prompt) = params.initial_prompt {
-        let reply_suffix =
-            if params.append_reply_handoff && launcher_name != "api" && launcher_name != "user" {
-                format!("\n\nWhen done, send your result back to @{launcher_name} via hcom.")
-            } else {
-                String::new()
-            };
+        let reply_suffix = reply_handoff_suffix(params.append_reply_handoff, &launcher_name);
         let full_prompt = format!("{prompt}{reply_suffix}");
         append_initial_prompt_args(&normalized, &mut params.args, full_prompt)?;
     }
@@ -2359,6 +2354,17 @@ pub(crate) fn validate_tool_args(tool: &LaunchTool, args: &[String]) -> Vec<Stri
 fn cleanup_instance(db: &HcomDb, name: &str, process_id: &str) {
     db.delete_instance(name).ok();
     db.delete_process_binding(process_id).ok();
+}
+
+/// Reply-handoff suffix appended after the initial prompt. The prompt is
+/// authored by the dispatcher; any reply instruction written there must stay
+/// authoritative, so callers opt in explicitly instead of always appending.
+fn reply_handoff_suffix(append: bool, launcher_name: &str) -> String {
+    if append && launcher_name != "api" && launcher_name != "user" {
+        format!("\n\nWhen done, send your result back to @{launcher_name} via hcom.")
+    } else {
+        String::new()
+    }
 }
 
 #[cfg(test)]
@@ -3398,5 +3404,19 @@ mod tests {
         assert!(win.contains_key("MY_SECRET") && !win.contains_key("HCOM_X"));
         let unix = sidecar_ambient_env(&env, strip.iter().copied(), false);
         assert!(!unix.contains_key("NO_COLOR") && unix.contains_key("no_color")); // Unix exact-case preserved
+    }
+
+    #[test]
+    fn test_reply_handoff_suffix_opt_in_only() {
+        // Opted out: prompt must stay exactly as authored, whoever launched us.
+        assert_eq!(reply_handoff_suffix(false, "huro"), "");
+        // Opted in from a real participant: suffix names the launcher.
+        assert_eq!(
+            reply_handoff_suffix(true, "huro"),
+            "\n\nWhen done, send your result back to @huro via hcom."
+        );
+        // Never appended for non-participant launchers, even when opted in.
+        assert_eq!(reply_handoff_suffix(true, "api"), "");
+        assert_eq!(reply_handoff_suffix(true, "user"), "");
     }
 }


### PR DESCRIPTION
## Summary

- stop appending a hardcoded reply-handoff footer to CLI launch prompts
- apply the same rule to tracked/adoption resume and fork paths for every supported tool
- preserve the shared suffix helper as an explicit opt-in for callers that intentionally request it

Dispatcher-authored prompts already define whether and where a spawned session should report. Appending `When done, send your result back to @<launcher>` could contradict an explicit different report target or a no-report instruction, so these CLI-managed paths now preserve the prompt exactly as authored.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --locked`: 1971 unit tests and 20 CLI smoke tests passed; 0 failed
- focused regressions cover suffix opt-in, launch, tracked/adoption resume, and Claude/Codex fork behavior

## Upstream CI baseline

Current `main` has independent Rust 1.97 Clippy and cargo-dist workflow failures addressed by #91. This PR deliberately does not include those baseline changes; it should be refreshed after #91 lands.
