### PR TITLE
respect the `pane_id_env` set by the terminal preset.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1071,6 +1071,38 @@ pub fn get_merged_preset_pane_id_env(name: &str) -> Option<String> {
     get_merged_preset(name).and_then(|p| p.pane_id_env)
 }
 
+/// Environment variables that identify a terminal-local pane/window/workspace.
+///
+/// New-window runner sidecars must not replay these values from the parent:
+/// the terminal backend supplies fresh identity to the child. Include both
+/// built-in detection variables and user-configured `pane_id_env` values.
+pub fn pane_identity_env_vars() -> std::collections::HashSet<String> {
+    pane_identity_env_vars_from_path(&paths::config_toml_path())
+}
+
+fn pane_identity_env_vars_from_path(
+    toml_path: &std::path::Path,
+) -> std::collections::HashSet<String> {
+    let mut vars = crate::shared::terminal_presets::TERMINAL_ENV_MAP
+        .iter()
+        .map(|(env_var, _)| (*env_var).to_string())
+        .collect::<std::collections::HashSet<_>>();
+
+    if let Some(presets) = load_toml_presets(toml_path).and_then(|value| value.as_table().cloned())
+    {
+        vars.extend(presets.values().filter_map(|value| {
+            value
+                .as_table()
+                .and_then(|preset| preset.get("pane_id_env"))
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+        }));
+    }
+
+    vars
+}
+
 /// Get a fully merged terminal preset: TOML overrides on top of built-in defaults.
 ///
 /// Returns None if the name matches neither a TOML preset nor a built-in preset.
@@ -2226,6 +2258,27 @@ binary = "myterm"
         assert!(presets.is_some());
         let presets = presets.unwrap();
         assert!(presets.as_table().unwrap().contains_key("myterm"));
+    }
+
+    #[test]
+    fn test_pane_identity_env_vars_include_builtin_and_custom_vars() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+[terminal.presets.myterm]
+open = "myterm spawn -- bash {script}"
+close = "myterm close {pane_id}"
+pane_id_env = "MYTERM_PANE_ID"
+"#,
+        )
+        .unwrap();
+
+        let vars = pane_identity_env_vars_from_path(&path);
+        assert!(vars.contains("HERDR_PANE_ID"));
+        assert!(vars.contains("KITTY_WINDOW_ID"));
+        assert!(vars.contains("MYTERM_PANE_ID"));
     }
 
     #[test]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -757,6 +757,7 @@ fn create_runner_script_windows(
     instance_name: &str,
     env: &HashMap<String, String>,
     tool_args: &[String],
+    run_here: bool,
 ) -> Result<String> {
     let tool_spec = tool.parse::<crate::tool::Tool>().map(|t| t.spec()).ok();
     let instance_state_env: &[&str] = tool_spec.map(|s| s.instance_state_env).unwrap_or(&[]);
@@ -782,6 +783,11 @@ fn create_runner_script_windows(
 
     // Non-HCOM ambient env (may carry secrets) goes through a private sidecar
     // that is dot-sourced then deleted, matching the bash runner.
+    let pane_identity_vars = if run_here {
+        std::collections::HashSet::new()
+    } else {
+        crate::config::pane_identity_env_vars()
+    };
     let ambient_env = sidecar_ambient_env(
         env,
         tool_marker_vars()
@@ -789,7 +795,8 @@ fn create_runner_script_windows(
             .chain(HCOM_IDENTITY_VARS.iter())
             .chain(instance_state_env.iter())
             .chain(crate::terminal::TERMINAL_COLOR_VARS.iter())
-            .copied(),
+            .copied()
+            .chain(pane_identity_vars.iter().map(String::as_str)),
         true,
     );
     let sidecar_source = if ambient_env.is_empty() {
@@ -965,7 +972,7 @@ pub fn create_runner_script(
     run_here: bool,
 ) -> Result<String> {
     if cfg!(windows) {
-        return create_runner_script_windows(tool, cwd, instance_name, env, tool_args);
+        return create_runner_script_windows(tool, cwd, instance_name, env, tool_args, run_here);
     }
     // Resolve the tool's IntegrationSpec for instance-state env stripping
     let tool_spec = tool.parse::<crate::tool::Tool>().map(|t| t.spec()).ok();
@@ -993,6 +1000,11 @@ pub fn create_runner_script(
         .filter(|(k, _)| k.starts_with("HCOM_"))
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
+    let pane_identity_vars = if run_here {
+        std::collections::HashSet::new()
+    } else {
+        crate::config::pane_identity_env_vars()
+    };
     let ambient_env = sidecar_ambient_env(
         env,
         tool_marker_vars()
@@ -1000,7 +1012,8 @@ pub fn create_runner_script(
             .chain(HCOM_IDENTITY_VARS.iter())
             .chain(instance_state_env.iter())
             .chain(crate::terminal::TERMINAL_COLOR_VARS.iter())
-            .copied(),
+            .copied()
+            .chain(pane_identity_vars.iter().map(String::as_str)),
         false,
     );
     let env_block = terminal::build_env_string(&hcom_env, "bash_export");
@@ -3009,6 +3022,12 @@ mod tests {
             ("GEMINI_PTY_INFO".to_string(), "child_process".to_string()),
             ("GEMINI_API_KEY".to_string(), "gem-key".to_string()),
             ("GEMINI_CLI".to_string(), "1".to_string()),
+            ("HERDR_PANE_ID".to_string(), "w1:old".to_string()),
+            (
+                "HERDR_SOCKET_PATH".to_string(),
+                "/tmp/herdr.sock".to_string(),
+            ),
+            ("KITTY_WINDOW_ID".to_string(), "17".to_string()),
             ("TERM".to_string(), "dumb".to_string()),
             ("COLORTERM".to_string(), "truecolor".to_string()),
             ("NO_COLOR".to_string(), "1".to_string()),
@@ -3036,8 +3055,33 @@ mod tests {
         assert!(!sidecar.contains("COLORTERM="));
         assert!(!sidecar.contains("NO_COLOR="));
         assert!(!sidecar.contains("FORCE_COLOR="));
+        assert!(!sidecar.contains("HERDR_PANE_ID="));
+        assert!(!sidecar.contains("KITTY_WINDOW_ID="));
+        assert!(sidecar.contains("HERDR_SOCKET_PATH="));
         assert!(sidecar.contains("GEMINI_API_KEY"));
         assert!(sidecar.contains("RORI_MY_VAR"));
+
+        std::fs::remove_file(&script).ok();
+        std::fs::remove_file(env_file).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_run_here_runner_preserves_current_pane_identity() {
+        let env = HashMap::from([
+            ("HERDR_PANE_ID".to_string(), "w1:current".to_string()),
+            ("RORI_MY_VAR".to_string(), "myval".to_string()),
+        ]);
+
+        let script = create_runner_script("gemini", "/tmp", "test", &env, &[], true).unwrap();
+        let content = std::fs::read_to_string(&script).unwrap();
+        let env_file = content
+            .lines()
+            .find_map(|line| line.trim().strip_prefix(". "))
+            .map(|path| path.trim_matches('\'').to_string())
+            .expect("runner script should source a sidecar env file");
+        let sidecar = std::fs::read_to_string(&env_file).unwrap();
+        assert!(sidecar.contains("HERDR_PANE_ID="));
 
         std::fs::remove_file(&script).ok();
         std::fs::remove_file(env_file).ok();
@@ -3047,9 +3091,17 @@ mod tests {
     // site is, via a runtime cfg!(windows) check), so this runs on any host.
     #[test]
     fn test_runner_script_windows_has_bom_and_propagates_exit_code() {
-        let env = HashMap::from([("SOME_SECRET".to_string(), "sekrit".to_string())]);
+        let env = HashMap::from([
+            ("SOME_SECRET".to_string(), "sekrit".to_string()),
+            ("herdr_pane_id".to_string(), "w1:old".to_string()),
+            (
+                "HERDR_SOCKET_PATH".to_string(),
+                r"C:\tmp\herdr.sock".to_string(),
+            ),
+        ]);
 
-        let script = create_runner_script_windows("gemini", "/tmp", "test-win", &env, &[]).unwrap();
+        let script =
+            create_runner_script_windows("gemini", "/tmp", "test-win", &env, &[], false).unwrap();
 
         let bytes = std::fs::read(&script).unwrap();
         assert_eq!(
@@ -3074,7 +3126,14 @@ mod tests {
             b"\xEF\xBB\xBF",
             "sidecar env file needs the same BOM as the runner script"
         );
-        assert!(String::from_utf8_lossy(&sidecar_bytes).contains("SOME_SECRET"));
+        let sidecar_content = String::from_utf8_lossy(&sidecar_bytes);
+        assert!(sidecar_content.contains("SOME_SECRET"));
+        assert!(
+            !sidecar_content
+                .to_ascii_lowercase()
+                .contains("herdr_pane_id")
+        );
+        assert!(sidecar_content.contains("HERDR_SOCKET_PATH"));
 
         std::fs::remove_file(&script).ok();
         std::fs::remove_file(sidecar).ok();
@@ -3095,7 +3154,7 @@ mod tests {
         ];
 
         let script =
-            create_runner_script_windows("codex", "/tmp", "test-args", &env, &args).unwrap();
+            create_runner_script_windows("codex", "/tmp", "test-args", &env, &args, false).unwrap();
         let content = std::fs::read_to_string(&script).unwrap();
 
         let run_line = content
@@ -3126,7 +3185,8 @@ mod tests {
     fn test_runner_script_windows_no_args_skips_sidecar_file() {
         let env = HashMap::new();
         let script =
-            create_runner_script_windows("gemini", "/tmp", "test-noargs", &env, &[]).unwrap();
+            create_runner_script_windows("gemini", "/tmp", "test-noargs", &env, &[], false)
+                .unwrap();
         let content = std::fs::read_to_string(&script).unwrap();
         let run_line = content
             .lines()

--- a/src/pty/shared.rs
+++ b/src/pty/shared.rs
@@ -602,18 +602,21 @@ pub(super) fn build_early_launch_context() -> String {
         ctx.insert("kitty_listen_on".into(), Value::String(listen));
     }
 
-    // Preset-declared pane-id env var wins over generic terminal vars.
-    if let Ok(preset) = std::env::var("HCOM_LAUNCHED_PRESET")
-        && !preset.is_empty()
-        && let Some(var) = crate::config::get_merged_preset_pane_id_env(&preset)
+    // A selected preset defines the pane-ID namespace. Never pair its close
+    // command with an ID inherited from another backend.
+    let launched_preset = std::env::var("HCOM_LAUNCHED_PRESET")
+        .ok()
+        .filter(|preset| !preset.is_empty());
+    if let Some(preset) = launched_preset.as_deref()
+        && let Some(var) = crate::config::get_merged_preset_pane_id_env(preset)
         && let Ok(val) = std::env::var(&var)
         && !val.is_empty()
     {
         ctx.insert("pane_id".into(), Value::String(val));
     }
 
-    // Fallback: capture pane_id from generic terminal env vars (same-window launches).
-    if !ctx.contains_key("pane_id") {
+    // Legacy fallback for launches that predate effective-preset propagation.
+    if launched_preset.is_none() {
         let pane_id_vars: &[&str] = &[
             "WEZTERM_PANE",
             "TMUX_PANE",
@@ -1385,5 +1388,20 @@ mod tests {
         clear_launch_context_env();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed["pane_id"], "w2:p1A");
+    }
+
+    #[test]
+    #[serial]
+    fn build_early_launch_context_known_preset_rejects_foreign_fallback() {
+        clear_launch_context_env();
+        // SAFETY: test is #[serial].
+        unsafe {
+            std::env::set_var("HCOM_LAUNCHED_PRESET", "herdr");
+            std::env::set_var("WEZTERM_PANE", "4");
+        }
+        let json = build_early_launch_context();
+        clear_launch_context_env();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.get("pane_id").is_none());
     }
 }

--- a/src/pty/shared.rs
+++ b/src/pty/shared.rs
@@ -602,19 +602,31 @@ pub(super) fn build_early_launch_context() -> String {
         ctx.insert("kitty_listen_on".into(), Value::String(listen));
     }
 
-    // Capture pane_id from terminal env vars for same-window launches.
-    let pane_id_vars: &[&str] = &[
-        "WEZTERM_PANE",
-        "TMUX_PANE",
-        "KITTY_WINDOW_ID",
-        "ZELLIJ_PANE_ID",
-    ];
-    for &var in pane_id_vars {
-        if let Ok(val) = std::env::var(var)
-            && !val.is_empty()
-        {
-            ctx.insert("pane_id".into(), Value::String(val));
-            break;
+    // Preset-declared pane-id env var wins over generic terminal vars.
+    if let Ok(preset) = std::env::var("HCOM_LAUNCHED_PRESET")
+        && !preset.is_empty()
+        && let Some(var) = crate::config::get_merged_preset_pane_id_env(&preset)
+        && let Ok(val) = std::env::var(&var)
+        && !val.is_empty()
+    {
+        ctx.insert("pane_id".into(), Value::String(val));
+    }
+
+    // Fallback: capture pane_id from generic terminal env vars (same-window launches).
+    if !ctx.contains_key("pane_id") {
+        let pane_id_vars: &[&str] = &[
+            "WEZTERM_PANE",
+            "TMUX_PANE",
+            "KITTY_WINDOW_ID",
+            "ZELLIJ_PANE_ID",
+        ];
+        for &var in pane_id_vars {
+            if let Ok(val) = std::env::var(var)
+                && !val.is_empty()
+            {
+                ctx.insert("pane_id".into(), Value::String(val));
+                break;
+            }
         }
     }
 
@@ -1298,6 +1310,8 @@ mod tests {
             std::env::remove_var("TMUX_PANE");
             std::env::remove_var("KITTY_WINDOW_ID");
             std::env::remove_var("ZELLIJ_PANE_ID");
+            std::env::remove_var("HCOM_LAUNCHED_PRESET");
+            std::env::remove_var("HERDR_PANE_ID");
         }
     }
 
@@ -1355,5 +1369,21 @@ mod tests {
         clear_launch_context_env();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed["pane_id"], "kitty-window-1");
+    }
+
+    #[test]
+    #[serial]
+    fn build_early_launch_context_preset_pane_id_env_wins_over_generic_vars() {
+        clear_launch_context_env();
+        // SAFETY: test is #[serial].
+        unsafe {
+            std::env::set_var("HCOM_LAUNCHED_PRESET", "herdr");
+            std::env::set_var("HERDR_PANE_ID", "w2:p1A");
+            std::env::set_var("WEZTERM_PANE", "0");
+        }
+        let json = build_early_launch_context();
+        clear_launch_context_env();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["pane_id"], "w2:p1A");
     }
 }


### PR DESCRIPTION
This updates `build_early_launch_context` to respect the `pane_id_env` set by the terminal preset.

## Problem

`hcom kill <name>` fails to close terminal panes for agents launched in a multiplexer (herdr, tmux, etc.) running inside an outer terminal (WezTerm, etc). It targets the `pane_id` of the outer terminal instead of the multiplexer's pane id.

`build_early_launch_context` resolves `pane_id` from a hardcoded list of generic terminal env vars (`WEZTERM_PANE`, `TMUX_PANE`, etc.) and the terminal wins. This fails because hcom will run the preset's close command with the terminal's pane id.

## Reproduction

Requires starting the multiplexer's server inside the terminal, so that it inherits the terminal's env. I ran the following in an opencode session.

WezTerm > herdr > hcom opencode:
```sh
$ env | grep -E "^(HERDR_PANE_ID|TMUX_PANE|WEZTERM_PANE)"
HERDR_PANE_ID=w3:pG
WEZTERM_PANE=0

$ hcom opencode | grep -E '^Names:'
Names: mini

$ hcom kill mini
{"error":{"code":"pane_not_found","message":"pane 0 not found"},"id":"cli:pane:close"}
Failed to close herdr pane 0: exit status: 1
Process terminated, but pane remains. Retry this command with approval/escalation:
herdr pane close 0
Sent SIGTERM to process group 15539 for 'mini' (pane close failed for herdr)
  To resume: hcom r mini
```

WezTerm > tmux > hcom opencode:
```sh
$ env | grep -E "^(HERDR_PANE_ID|TMUX_PANE|WEZTERM_PANE)"
TMUX_PANE=%205
WEZTERM_PANE=4

$ hcom opencode | grep -E '^Names:'
Names: tipi

$ hcom kill tipi
can't find pane: 4
Failed to close tmux-split pane 4: exit status: 1
Sent SIGTERM to process group 18363 for 'tipi' (pane close failed for tmux-split)
  To resume: hcom r tipi
Process terminated, but pane remains. Retry this command with approval/escalation:
tmux kill-pane -t 4
```

## Fix

Make `build_early_launch_context` preset-aware. The preset has already been resolved so we know the pane id env var. The generic loop becomes a fallback. Has the nice effect of resolving panes in custom terminal presets.