### PR TITLE
Stabilize Codex and Claude real-tool CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             tool: codex
             package: "@openai/codex@0.141.0"
             cache: codex-0.141.0
@@ -99,6 +99,15 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+      - name: Configure Codex Linux sandbox
+        if: runner.os == 'Linux' && matrix.tool == 'codex'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends bubblewrap apparmor-profiles apparmor-utils
+          sudo install -m 0644 \
+            /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
+            /etc/apparmor.d/bwrap-userns-restrict
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
       - uses: Swatinem/rust-cache@v2.9.1
       - uses: actions/cache@v4
         with:
@@ -112,6 +121,9 @@ jobs:
       - name: Add pinned tool to PATH (Unix)
         if: runner.os != 'Windows'
         run: echo "$PWD/target/mock-tools/bin" >> "$GITHUB_PATH"
+      - name: Verify Codex Linux sandbox
+        if: runner.os == 'Linux' && matrix.tool == 'codex'
+        run: codex sandbox -- /bin/true
       - name: Install pinned tool (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/tests/support/claude_mock.rs
+++ b/tests/support/claude_mock.rs
@@ -30,6 +30,82 @@ const TOOL_FILE: &str = "toolu_lifecycle_file";
 const TOOL_SHELL: &str = "toolu_lifecycle_shell";
 const TOOL_SEND: &str = "toolu_lifecycle_send";
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ClaudeStartupGate {
+    Theme,
+    Trust,
+    Continue,
+}
+
+impl ClaudeStartupGate {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Theme => "theme prompt",
+            Self::Trust => "workspace trust prompt",
+            Self::Continue => "continue prompt",
+        }
+    }
+}
+
+pub fn claude_startup_gate(screen: &str) -> Option<ClaudeStartupGate> {
+    let low = screen.to_lowercase();
+    if low.contains("text style") {
+        Some(ClaudeStartupGate::Theme)
+    } else if low.contains("i trust this folder")
+        || low.contains("is this a project")
+        || low.contains("accessing workspace")
+        || low.contains("do you trust")
+    {
+        // Check trust before the generic continue prompt: Claude may render
+        // both phrases on one screen, but they still describe one gate.
+        Some(ClaudeStartupGate::Trust)
+    } else if low.contains("press enter to continue") {
+        Some(ClaudeStartupGate::Continue)
+    } else {
+        None
+    }
+}
+
+#[derive(Default)]
+pub struct ClaudeStartupAnswers {
+    theme: bool,
+    trust: bool,
+    continue_prompt: bool,
+}
+
+impl ClaudeStartupAnswers {
+    pub fn answer_once(&mut self, gate: ClaudeStartupGate) -> bool {
+        let answered = match gate {
+            ClaudeStartupGate::Theme => &mut self.theme,
+            ClaudeStartupGate::Trust => &mut self.trust,
+            ClaudeStartupGate::Continue => &mut self.continue_prompt,
+        };
+        if *answered {
+            false
+        } else {
+            *answered = true;
+            true
+        }
+    }
+}
+
+#[test]
+fn startup_gate_treats_overlapping_trust_and_continue_text_as_one_gate() {
+    assert_eq!(
+        claude_startup_gate("Do you trust this folder? Press Enter to continue"),
+        Some(ClaudeStartupGate::Trust)
+    );
+}
+
+#[test]
+fn startup_answers_each_gate_once() {
+    let mut answers = ClaudeStartupAnswers::default();
+    assert!(answers.answer_once(ClaudeStartupGate::Trust));
+    assert!(!answers.answer_once(ClaudeStartupGate::Trust));
+    assert!(answers.answer_once(ClaudeStartupGate::Continue));
+    assert!(!answers.answer_once(ClaudeStartupGate::Continue));
+}
+
 /// Frame `(event, json)` pairs into a Messages SSE body.
 fn sse(events: &[(&str, Value)]) -> Vec<u8> {
     let mut out = String::new();
@@ -211,18 +287,16 @@ impl ToolCase for ClaudeCase {
     }
 
     fn launch_args(&self, _h: &Hcom) -> Vec<String> {
-        // bypassPermissions keeps the main lifecycle deterministic (approval is a
-        // separate test) without disabling hooks; --bare/--safe-mode would kill
-        // the hooks under test, so they are forbidden.
+        // The lifecycle only needs Write and Bash. Auto-allow those tools while
+        // denying every other prompt; the separate approval test uses Claude's
+        // default mode. --bare/--safe-mode would disable the hooks under test.
         vec![
             "--model".to_string(),
             MODEL.to_string(),
-            // bypassPermissions keeps per-tool approvals deterministic (approval
-            // is a separate test) without disabling hooks; --bare/--safe-mode
-            // would kill the hooks under test, so they are forbidden. It does NOT
-            // accept workspace trust — that is driven via the PTY in drive_startup.
             "--permission-mode".to_string(),
-            "bypassPermissions".to_string(),
+            "dontAsk".to_string(),
+            "--allowedTools".to_string(),
+            "Write,Bash".to_string(),
             // hcom installs its hooks into the user settings.json under
             // CLAUDE_CONFIG_DIR; load that source so they activate.
             "--setting-sources".to_string(),
@@ -239,37 +313,23 @@ impl ToolCase for ClaudeCase {
         // fallback for Claude versions that ignore the seeded state.
         let deadline = Instant::now() + Duration::from_secs(90);
         let mut last_screen = String::new();
+        let mut answers = ClaudeStartupAnswers::default();
         while Instant::now() < deadline {
             let (_, json, _) = h.run(["term", name, "--json"]);
             let (screen_code, screen, _) = h.run(["term", name]);
             last_screen = screen.clone();
-            let low = screen.to_lowercase();
-            let bypass_confirm =
-                low.contains("yes, i accept") && low.contains("bypass permissions");
-            let onboarding = bypass_confirm
-                || low.contains("text style")
-                || low.contains("i trust this folder")
-                || low.contains("is this a project")
-                || low.contains("accessing workspace")
-                || low.contains("do you trust")
-                || low.contains("press enter to continue");
+            let gate = claude_startup_gate(&screen);
             // Ready once the empty input prompt is up and no gate is visible —
             // mode-agnostic, so it also serves the default-mode approval test.
-            if screen_code == 0 && json.contains("\"prompt_empty\":true") && !onboarding {
+            if screen_code == 0 && json.contains("\"prompt_empty\":true") && gate.is_none() {
                 return;
             }
-            let (key, what) = if bypass_confirm {
-                // Bypass-mode confirmation defaults to "No, exit" — explicitly
-                // select option 2 ("Yes, I accept") or Claude quits on Enter.
-                ("2", "bypass-mode confirmation")
-            } else if onboarding {
-                // Theme/trust default to the option we want (dark, Yes).
-                ("", "onboarding prompt")
-            } else {
-                ("", "")
-            };
-            if !what.is_empty() {
-                let (code, stdout, stderr) = h.run(["term", "inject", name, key, "--enter"]);
+            if let Some(gate) = gate.filter(|gate| answers.answer_once(*gate)) {
+                let what = gate.label();
+                // term inject reports delivery to the PTY. Send each gate answer
+                // once so a stale frame cannot leak an extra Enter into the
+                // ready input prompt.
+                let (code, stdout, stderr) = h.run(["term", "inject", name, "", "--enter"]);
                 assert_eq!(
                     code, 0,
                     "drive_startup: inject for {what} failed: stdout={stdout} stderr={stderr}"

--- a/tests/test_relay_roundtrip.rs
+++ b/tests/test_relay_roundtrip.rs
@@ -36,7 +36,10 @@ use std::process::{Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use support::claude_mock::{MODEL, claude_text, claude_tool_use, latest_user_turn};
+use support::claude_mock::{
+    ClaudeStartupAnswers, MODEL, claude_startup_gate, claude_text, claude_tool_use,
+    latest_user_turn,
+};
 use support::mock_http::{MockHttp, RecordedRequest, Reply};
 
 // ── Logging ────────────────────────────────────────────────────────────
@@ -135,7 +138,9 @@ fn hcom_with_dir(cmd: &str, hcom_dir: &str) -> Output {
         // (tmux/kitty/etc.) is required in CI.
         .env(
             "HCOM_CLAUDE_ARGS",
-            format!("--model {MODEL} --permission-mode bypassPermissions --setting-sources user"),
+            format!(
+                "--model {MODEL} --permission-mode dontAsk --allowedTools Write,Bash --setting-sources user"
+            ),
         );
 
     let mut path_entries = Vec::new();
@@ -476,10 +481,8 @@ fn poll_rpc_result_on_device(hcom_dir: &str, action: &str) -> serde_json::Value 
 /// True if `text` has Claude's input prompt marker at the start of a rendered
 /// screen line, present whenever the TUI is rendered, independent of the
 /// dontAsk / accept-edits mode that hides the "? for shortcuts" status bar.
-/// `--permission-mode bypassPermissions` (used by this test) renders a plain
-/// `>` instead of the styled `❯`. Requiring the marker to lead the line (not
-/// just appear anywhere) keeps this from matching an unrelated `>` in tips,
-/// diffs, or other screen content.
+/// Requiring the marker to lead the line (not just appear anywhere) keeps this
+/// from matching an unrelated `>` in tips, diffs, or other screen content.
 fn screen_has_claude_prompt(text: &str) -> bool {
     text.lines().any(|line| {
         let trimmed = strip_term_line_number_prefix(line).trim_start();
@@ -636,28 +639,23 @@ fn wait_for_screen_drawn(hcom_dir: &str, name: &str, timeout: Duration) -> serde
 fn drive_claude_startup(hcom_dir: &str, name: &str, timeout: Duration) {
     let deadline = Instant::now() + timeout;
     let mut last_screen = String::new();
+    let mut answers = ClaudeStartupAnswers::default();
     while Instant::now() < deadline {
         let json_out = hcom_with_dir(&format!("term {name} --json"), hcom_dir);
         let screen_out = hcom_with_dir(&format!("term {name}"), hcom_dir);
         last_screen = String::from_utf8_lossy(&screen_out.stdout).to_string();
-        let low = last_screen.to_lowercase();
-        let bypass_confirm = low.contains("yes, i accept") && low.contains("bypass permissions");
-        let onboarding = bypass_confirm
-            || low.contains("text style")
-            || low.contains("i trust this folder")
-            || low.contains("is this a project")
-            || low.contains("accessing workspace")
-            || low.contains("do you trust")
-            || low.contains("press enter to continue");
+        let gate = claude_startup_gate(&last_screen);
         if screen_out.status.success()
             && String::from_utf8_lossy(&json_out.stdout).contains("\"prompt_empty\":true")
-            && !onboarding
+            && gate.is_none()
         {
             return;
         }
-        if bypass_confirm || onboarding {
-            let key = if bypass_confirm { "2 " } else { "" };
-            let inject = hcom_with_dir(&format!("term inject {name} {key}--enter"), hcom_dir);
+        if gate.is_some_and(|gate| answers.answer_once(gate)) {
+            // A successful inject delivered Enter to the PTY. Do not repeat it
+            // while a stale frame still shows the gate: the next Enter could
+            // land in Claude's ready prompt.
+            let inject = hcom_with_dir(&format!("term inject {name} --enter"), hcom_dir);
             assert!(
                 inject.status.success(),
                 "drive startup inject failed\nstdout: {}\nstderr: {}",


### PR DESCRIPTION
## What changed

- Provision Bubblewrap and Ubuntu's AppArmor profile for the Linux Codex job, then smoke-test the sandbox before integration tests.
- Replace Claude lifecycle `bypassPermissions` with `dontAsk` and a `Write,Bash` allowlist.
- Answer each Claude startup gate once and share the gate driver with the relay lifecycle.

## Why

The Linux Codex approval test intermittently reached the approval prompt but failed the approved command because the runner denied the bundled Bubblewrap helper's UID map. The Windows Claude lifecycle could repeatedly inject the bypass confirmation choice while a stale TUI frame remained visible, allowing the input to land in Claude's ready prompt.

The Codex test still exercises the real sandbox and approval boundary. Claude's separate approval test remains in default permission mode, while non-approval lifecycle tests receive only the two tools they require.

## Validation

- `just ci`
- Pinned Claude approval and lifecycle suite repeated locally
- Full 14-phase relay lifecycle repeated locally
- Startup-gate regression tests and Clippy