### PR TITLE
fix(terminal): repair herdr adapter for herdr 0.7.5 (#102)

### DIFF
--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -203,13 +203,38 @@ mod host_label {
     #[cfg(unix)]
     const SOCKET_TIMEOUT: Duration = Duration::from_millis(200);
 
+    /// A run of this many consecutive transient socket failures (with no
+    /// intervening success) disables the backend, as a safety valve against a
+    /// wedged-but-connectable socket. Set high enough that ordinary
+    /// busy-at-startup EAGAIN churn — several ops per tick during pane creation
+    /// — doesn't trip it; any single success resets the count. herdr actually
+    /// *exiting* is caught immediately by the connect-failure (Unreachable)
+    /// path, so this only guards the rare "socket alive but server stuck" case.
+    const MAX_CONSECUTIVE_FAILURES: u32 = 10;
+
     /// Per-loop state: which backend (if any) we resolved at startup, and the
-    /// last label we successfully pushed (for dedupe). On the first I/O error
-    /// we drop the backend so subsequent iterations are no-ops — avoids log
-    /// spam and per-tick socket churn when herdr exits mid-session.
+    /// last label we successfully pushed (for dedupe). A connect failure (herdr
+    /// exited) drops the backend immediately; transient I/O only skips the
+    /// current op and retries next tick, so a momentary EAGAIN no longer
+    /// permanently kills label/state/rename updates (issue #102, F1).
     pub(super) struct HostLabel {
         backend: Option<Backend>,
         last_pushed: Option<String>,
+        /// Last agent state we reported via `pane.report_agent` (dedupe).
+        last_reported_state: Option<&'static str>,
+        /// Monotonic per-source sequence number for `pane.report_agent`; herdr
+        /// rejects stale (non-increasing) reports.
+        seq: u64,
+        /// Whether we've set herdr's canonical agent `name` via `agent.rename`
+        /// (once, after the pane is classified). Restores `herdr agent
+        /// send/prompt <name>` targeting that the old `agent start {name}`
+        /// flow provided — the new `tab create` launch doesn't set it. Flips
+        /// only when the rename returns a real success envelope, so it retries
+        /// across the classification race instead of latching on a bare ack.
+        name_set: bool,
+        /// Consecutive transient socket failures since the last success; any
+        /// success resets it. See [`MAX_CONSECUTIVE_FAILURES`].
+        consecutive_failures: u32,
     }
 
     enum Backend {
@@ -222,9 +247,9 @@ mod host_label {
     impl HostLabel {
         pub(super) fn resolve() -> Self {
             // `last_pushed` starts unset so the first delivery-loop iteration
-            // *always* pushes a styled label. The built-in herdr preset
-            // invokes `agent start {instance_name}` which leaves the pane
-            // labeled with the bare instance name; the styled
+            // *always* pushes a styled label. The built-in herdr preset opens
+            // the pane via `tab create --label {instance_name}`, so herdr's
+            // initial label is the bare instance name; the styled
             // `◉ luna [claude]` label only appears once we push it. Seeding
             // from HCOM_PANE_TITLE (which a custom template might or might
             // not have applied) would silently skip that first push and leave
@@ -232,6 +257,10 @@ mod host_label {
             Self {
                 backend: Backend::resolve(),
                 last_pushed: None,
+                last_reported_state: None,
+                seq: 0,
+                name_set: false,
+                consecutive_failures: 0,
             }
         }
 
@@ -239,26 +268,150 @@ mod host_label {
             if self.backend.is_none() {
                 return;
             }
+
+            // 1. Styled visual label via `pane.rename`, deduped on the last
+            //    pushed string. On failure we leave `last_pushed` unset so the
+            //    label retries next tick, but we do NOT abort — the state report
+            //    and rename below are independent ops and shouldn't be starved
+            //    by a transient label hiccup (issue #102, F1). If the failure
+            //    disabled the backend, those later `send`s are no-ops anyway.
             let label = pane_title_label(db, name, status, tool);
-            if label.is_empty() || self.last_pushed.as_deref() == Some(label.as_str()) {
-                return;
+            if !label.is_empty()
+                && self.last_pushed.as_deref() != Some(label.as_str())
+                && self.send(|backend| backend.push(&label))
+            {
+                self.last_pushed = Some(label);
             }
-            // Take the backend so we can drop it on failure without holding a
-            // borrow across the I/O call.
-            let backend = self.backend.take().expect("backend present");
-            match backend.push(&label) {
-                Ok(()) => {
-                    self.backend = Some(backend);
-                    self.last_pushed = Some(label);
+
+            // 2. Agent state via `pane.report_agent` so herdr classifies the
+            //    pane as an agent (its foreground process is `hcom pty`, not the
+            //    tool). Best-effort and deduped on the mapped state. Skipped
+            //    when the tool name is unknown — herdr needs a real agent label.
+            if !tool.is_empty() {
+                let state = map_report_state(status);
+                if self.last_reported_state != Some(state) {
+                    let seq = self.next_seq();
+                    if self.send(|backend| backend.report_agent(tool, state, seq)) {
+                        self.last_reported_state = Some(state);
+                    }
                 }
-                Err(err) => {
+            }
+
+            // 3. Set herdr's canonical agent `name` once so `herdr agent
+            //    send/prompt/focus <name>` resolves — parity with the retired
+            //    `agent start {name}` flow. herdr's `agent.rename` requires the
+            //    pane to already be a classified agent terminal; that classifier
+            //    is EITHER our `report_agent` above OR herdr's own installed
+            //    integration for the tool (which shadows ours — issue #102, F2).
+            //    We can't tell which from hcom's side, and an ignored
+            //    `report_agent` still returns a success envelope, so we don't
+            //    try to. Instead we attempt the rename each tick once we've
+            //    entered the agent regime and let it self-heal: `name_set` flips
+            //    only when `agent.rename` returns a real success — before
+            //    classification it returns an `error` envelope (Rejected), which
+            //    leaves `name_set` false so the next tick retries. The styled
+            //    label stays on `pane.rename`; this only sets the plain name
+            //    field, so the two don't clobber each other.
+            if !self.name_set
+                && self.last_reported_state.is_some()
+                && !name.is_empty()
+                && self.send(|backend| backend.rename_agent(name))
+            {
+                self.name_set = true;
+            }
+        }
+
+        /// Run one socket op against the backend, taking it so we can drop it on
+        /// failure without holding a borrow across the I/O call. Returns whether
+        /// the op *applied* (herdr answered with success). The backend is only
+        /// disabled (dropped) when herdr is unreachable, or after a run of
+        /// transient failures — a single EAGAIN/timeout just skips this op and
+        /// retries next tick, and a semantic `Rejected` keeps the healthy
+        /// backend so the caller can retry (issue #102, F1/F2).
+        fn send<F>(&mut self, op: F) -> bool
+        where
+            F: FnOnce(&Backend) -> Result<(), SocketError>,
+        {
+            let Some(backend) = self.backend.take() else {
+                return false;
+            };
+            match op(&backend) {
+                Ok(()) => {
+                    self.consecutive_failures = 0;
+                    self.backend = Some(backend);
+                    true
+                }
+                Err(SocketError::Rejected(msg)) => {
+                    // herdr is alive and answered "no" (e.g. rename before the
+                    // pane is a classified agent). Keep the backend and let the
+                    // caller retry; this isn't a connectivity problem.
+                    self.consecutive_failures = 0;
                     crate::log::log_info(
                         "host_label",
-                        "push_failed_disabling",
-                        &format!("{}: {err}", backend.kind()),
+                        "op_rejected",
+                        &format!("{}: {msg}", backend.kind()),
                     );
+                    self.backend = Some(backend);
+                    false
+                }
+                Err(SocketError::Transient(msg)) => {
+                    self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+                    if self.consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
+                        crate::log::log_info(
+                            "host_label",
+                            "disabling_after_transient",
+                            &format!(
+                                "{}: {msg} ({} consecutive)",
+                                backend.kind(),
+                                self.consecutive_failures
+                            ),
+                        );
+                        // Drop the backend (leave self.backend = None).
+                    } else {
+                        self.backend = Some(backend);
+                    }
+                    false
+                }
+                Err(SocketError::Unreachable(msg)) => {
+                    crate::log::log_info(
+                        "host_label",
+                        "disabling_unreachable",
+                        &format!("{}: {msg}", backend.kind()),
+                    );
+                    // Drop the backend (leave self.backend = None).
+                    false
                 }
             }
+        }
+
+        /// Next `pane.report_agent` sequence. herdr keeps the last seq per
+        /// source *per terminal* and rejects any `seq <= last_seq`, and that map
+        /// outlives a delivery-loop restart in the same pane — so a plain
+        /// counter reset to 1 would be silently dropped after a restart. Anchor
+        /// to a wall-clock nanosecond timestamp (like herdr's own hook does)
+        /// while forcing strict monotonicity, so reports survive restarts and
+        /// never collide even on a coarse clock.
+        fn next_seq(&mut self) -> u64 {
+            let now_ns = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as u64)
+                .unwrap_or(0);
+            self.seq = self.seq.saturating_add(1).max(now_ns);
+            self.seq
+        }
+    }
+
+    /// Map an hcom status constant to a herdr `pane_agent_state` value.
+    ///
+    /// listening → idle, active → working, blocked → blocked; everything else
+    /// (inactive/launching/error) → unknown.
+    fn map_report_state(status: &str) -> &'static str {
+        use crate::shared::{ST_ACTIVE, ST_BLOCKED, ST_LISTENING};
+        match status {
+            ST_LISTENING => "idle",
+            ST_ACTIVE => "working",
+            ST_BLOCKED => "blocked",
+            _ => "unknown",
         }
     }
 
@@ -289,7 +442,7 @@ mod host_label {
         /// than `agent.rename` (which would also overwrite the herdr-canonical
         /// agent name with the status-icon-prefixed string and break
         /// `herdr agent send <name>` targeting).
-        fn push(&self, label: &str) -> Result<(), String> {
+        fn push(&self, label: &str) -> Result<(), SocketError> {
             match self {
                 Backend::Herdr {
                     socket_path,
@@ -304,6 +457,65 @@ mod host_label {
                 }
             }
         }
+
+        /// Report the agent and its state via `pane.report_agent`. When no other
+        /// source owns the pane, this establishes hcom as the `hook_authority`,
+        /// making `is_agent_terminal()` true independent of the foreground
+        /// process — so herdr tracks the pane as an agent even though `hcom pty`
+        /// is what's actually running.
+        ///
+        /// Caveat (issue #102, F2): if herdr has its *own* integration installed
+        /// for this tool (pi, omp, claude, codex, opencode, …), that
+        /// `herdr:<tool>` source owns lifecycle authority and our `source:
+        /// "hcom"` report is accepted-and-ignored — herdr still returns a
+        /// success envelope, so we can't detect the shadowing from here. That's
+        /// fine: herdr's own integration is then tracking state, and the report
+        /// still pays off for tools herdr doesn't integrate. herdr accepts any
+        /// `agent` string (nothing is rejected on that field), so this is purely
+        /// best-effort. `state` is a herdr snake_case `pane_agent_state`.
+        fn report_agent(&self, agent: &str, state: &str, seq: u64) -> Result<(), SocketError> {
+            match self {
+                Backend::Herdr {
+                    socket_path,
+                    pane_id,
+                } => {
+                    let request = serde_json::json!({
+                        "id": "hcom:pane:report_agent",
+                        "method": "pane.report_agent",
+                        "params": {
+                            "pane_id": pane_id,
+                            "source": "hcom",
+                            "agent": agent,
+                            "state": state,
+                            "seq": seq,
+                        },
+                    });
+                    send_unix_request(socket_path, &request)
+                }
+            }
+        }
+
+        /// Set herdr's canonical agent `name` (the targetable field) via
+        /// `agent.rename`, so `herdr agent send/prompt/focus <name>` resolves.
+        /// Only valid once the pane is a classified agent terminal — our
+        /// `report_agent` establishes that. Kept separate from the styled
+        /// `pane.rename` label so the status-icon string never clobbers the
+        /// plain name (herdr composes its own title from name + agent title).
+        fn rename_agent(&self, name: &str) -> Result<(), SocketError> {
+            match self {
+                Backend::Herdr {
+                    socket_path,
+                    pane_id,
+                } => {
+                    let request = serde_json::json!({
+                        "id": "hcom:agent:rename",
+                        "method": "agent.rename",
+                        "params": { "target": pane_id, "name": name },
+                    });
+                    send_unix_request(socket_path, &request)
+                }
+            }
+        }
     }
 
     /// Build the same label hcom writes into OSC 1/2 (`◉ tag-luna [claude]`).
@@ -312,33 +524,108 @@ mod host_label {
         format_pane_title(status, &display, tool)
     }
 
+    /// Outcome of one socket round-trip, classified so the caller can react
+    /// correctly instead of failing closed on every hiccup (issue #102, F1).
+    enum SocketError {
+        /// herdr is unreachable (connect failed, or the connection dropped
+        /// mid-request). Treated as fatal — the backend is disabled.
+        Unreachable(String),
+        /// Transient I/O against a live-looking socket (EAGAIN / timeout /
+        /// interrupt). herdr is likely just busy; skip this op and retry next
+        /// tick. Only a run of these disables the backend.
+        Transient(String),
+        /// herdr received the request and answered with a JSON `error` (e.g.
+        /// `agent.rename` before the pane is a classified agent terminal). The
+        /// socket is healthy; only this specific op didn't apply, so we neither
+        /// disable the backend nor record the op as done — we retry next tick.
+        Rejected(String),
+    }
+
     #[cfg(unix)]
-    fn send_unix_request(socket_path: &str, request: &serde_json::Value) -> Result<(), String> {
-        use std::io::{BufRead, BufReader, Write};
+    fn send_unix_request(
+        socket_path: &str,
+        request: &serde_json::Value,
+    ) -> Result<(), SocketError> {
+        use std::io::{BufRead, BufReader, ErrorKind, Write};
         use std::os::unix::net::UnixStream;
 
-        let mut stream =
-            UnixStream::connect(socket_path).map_err(|e| format!("connect: {socket_path}: {e}"))?;
+        // A read/write error against an already-connected socket: EAGAIN /
+        // timeout / interrupt are transient (retry), anything else means herdr
+        // dropped the connection (fatal).
+        fn classify_io(stage: &str, e: &std::io::Error) -> SocketError {
+            match e.kind() {
+                ErrorKind::WouldBlock | ErrorKind::TimedOut | ErrorKind::Interrupted => {
+                    SocketError::Transient(format!("{stage}: {e}"))
+                }
+                _ => SocketError::Unreachable(format!("{stage}: {e}")),
+            }
+        }
+
+        let mut stream = UnixStream::connect(socket_path)
+            .map_err(|e| SocketError::Unreachable(format!("connect: {socket_path}: {e}")))?;
         let _ = stream.set_read_timeout(Some(SOCKET_TIMEOUT));
         let _ = stream.set_write_timeout(Some(SOCKET_TIMEOUT));
-        writeln!(stream, "{request}").map_err(|e| format!("write: {e}"))?;
+        writeln!(stream, "{request}").map_err(|e| classify_io("write", &e))?;
         let mut response = String::new();
         BufReader::new(&stream)
             .read_line(&mut response)
-            .map_err(|e| format!("read: {e}"))?;
-        Ok(())
+            .map_err(|e| classify_io("read", &e))?;
+
+        classify_response(&response)
+    }
+
+    /// Inspect herdr's one-line JSON response. A top-level `error` field means a
+    /// semantic rejection; a `result` (or any other parseable body) is success.
+    /// An empty line means herdr closed the connection without answering —
+    /// treated as unreachable.
+    #[cfg(unix)]
+    fn classify_response(response: &str) -> Result<(), SocketError> {
+        let trimmed = response.trim();
+        if trimmed.is_empty() {
+            return Err(SocketError::Unreachable("empty response".into()));
+        }
+        match serde_json::from_str::<serde_json::Value>(trimmed) {
+            Ok(val) => match val.get("error") {
+                Some(err) => {
+                    let msg = err
+                        .get("message")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("rejected");
+                    Err(SocketError::Rejected(msg.to_string()))
+                }
+                None => Ok(()),
+            },
+            // A non-empty but unparseable line: herdr answered with something, so
+            // it's alive — be lenient and count it as success rather than
+            // wedging retries on a body we mostly don't read anyway.
+            Err(_) => Ok(()),
+        }
     }
 
     #[cfg(not(unix))]
-    fn send_unix_request(_socket_path: &str, _request: &serde_json::Value) -> Result<(), String> {
-        Err("unix sockets unavailable on this platform".into())
+    fn send_unix_request(
+        _socket_path: &str,
+        _request: &serde_json::Value,
+    ) -> Result<(), SocketError> {
+        Err(SocketError::Unreachable(
+            "unix sockets unavailable on this platform".into(),
+        ))
     }
 
     #[cfg(test)]
     mod tests {
         use super::*;
-        use crate::shared::ST_LISTENING;
+        use crate::shared::{ST_ACTIVE, ST_BLOCKED, ST_INACTIVE, ST_LAUNCHING, ST_LISTENING};
         use serial_test::serial;
+
+        #[test]
+        fn map_report_state_covers_hcom_statuses() {
+            assert_eq!(map_report_state(ST_LISTENING), "idle");
+            assert_eq!(map_report_state(ST_ACTIVE), "working");
+            assert_eq!(map_report_state(ST_BLOCKED), "blocked");
+            assert_eq!(map_report_state(ST_INACTIVE), "unknown");
+            assert_eq!(map_report_state(ST_LAUNCHING), "unknown");
+        }
 
         #[test]
         #[serial]
@@ -352,11 +639,11 @@ mod host_label {
         #[test]
         #[serial]
         fn resolve_does_not_seed_last_pushed_from_pane_title_env() {
-            // The built-in herdr preset launches with `agent start
-            // {instance_name}`, so herdr's initial pane label is the bare
-            // name (e.g. `luna`). Seeding `last_pushed` from HCOM_PANE_TITLE
-            // would silently swallow the first push and leave the pane
-            // stuck on `luna` until the next status transition.
+            // The built-in herdr preset opens the pane via `tab create --label
+            // {instance_name}`, so herdr's initial tab label is the bare name
+            // (e.g. `luna`). Seeding `last_pushed` from HCOM_PANE_TITLE would
+            // silently swallow the first push and leave the pane stuck on
+            // `luna` until the next status transition.
             // SAFETY: test is #[serial].
             unsafe {
                 std::env::set_var("HCOM_PANE_TITLE", "\u{25c9} luna [claude]");
@@ -371,6 +658,37 @@ mod host_label {
                 "last_pushed must start unset so the first delivery-loop \
                  iteration always pushes a styled label"
             );
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn classify_response_distinguishes_error_success_and_closed() {
+            // A JSON `error` envelope is a semantic rejection (herdr alive but
+            // said no) — keep the backend, retry the op (issue #102, F1/F2).
+            let err = r#"{"id":"hcom:agent:rename","error":{"code":"not_agent","message":"pane w1:p1 is not an agent"}}"#;
+            match classify_response(err) {
+                Err(SocketError::Rejected(msg)) => assert!(msg.contains("not an agent")),
+                _ => panic!("expected Rejected for an error envelope"),
+            }
+
+            // A `result` envelope is success — the op applied.
+            let ok = r#"{"id":"hcom:agent:rename","result":{"type":"agent_renamed"}}"#;
+            assert!(classify_response(ok).is_ok());
+
+            // An ignored `report_agent` still comes back as a success envelope,
+            // so it must classify as Ok (we can't detect the shadowing — F2).
+            let ignored = r#"{"id":"hcom:pane:report_agent","result":{"type":"agent_reported"}}"#;
+            assert!(classify_response(ignored).is_ok());
+
+            // A non-empty but unparseable line: herdr answered, so treat as Ok
+            // rather than wedging retries on a body we don't read.
+            assert!(classify_response("not json at all\n").is_ok());
+
+            // An empty line means herdr closed the connection without a reply.
+            assert!(matches!(
+                classify_response("   \n"),
+                Err(SocketError::Unreachable(_))
+            ));
         }
     }
 }

--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -526,6 +526,11 @@ mod host_label {
 
     /// Outcome of one socket round-trip, classified so the caller can react
     /// correctly instead of failing closed on every hiccup (issue #102, F1).
+    ///
+    /// `Transient`/`Rejected` are only produced by the `#[cfg(unix)]`
+    /// round-trip; on non-unix the stub yields `Unreachable`, so allow the
+    /// otherwise-unconstructed variants there.
+    #[cfg_attr(not(unix), allow(dead_code))]
     enum SocketError {
         /// herdr is unreachable (connect failed, or the connection dropped
         /// mid-request). Treated as fatal — the backend is disabled.

--- a/src/shared/terminal_presets.rs
+++ b/src/shared/terminal_presets.rs
@@ -540,11 +540,17 @@ pub static TERMINAL_PRESETS: LazyLock<Vec<(&'static str, TerminalPreset)>> = Laz
                 DL,
             ),
         ),
-        // Herdr workspace manager. `agent start <name>` sets both the herdr
-        // agent name AND the manual pane label, so we pass a stable
-        // `{instance_name}` here (e.g. `luna`) — that keeps `herdr agent send
-        // luna ...` working. The styled status label (`◉ luna [claude]`) is
-        // pushed separately via `pane.rename` from the delivery loop.
+        // Herdr workspace manager. Launched natively in two steps (see
+        // `launch_herdr_two_step` in `terminal.rs`): first this `tab create`
+        // opens a pane (its stdout JSON carries the pane id), then
+        // `herdr pane run <pane_id> "bash {script}"` starts hcom's normal
+        // `hcom pty` runner inside it. `agent start` can't be used — current
+        // herdr forces the executable and won't run hcom's wrapper script.
+        // `--label {instance_name}` labels the *tab* (e.g. `luna`) — herdr's
+        // `tab create --label` sets the tab label, not the pane label, which
+        // stays null until the delivery loop's first `pane.rename`. The styled
+        // status label (`◉ luna [claude]`) and the agent state are reported
+        // separately from the delivery loop (`pane.rename` / `pane.report_agent`).
         (
             "herdr",
             p(
@@ -552,15 +558,13 @@ pub static TERMINAL_PRESETS: LazyLock<Vec<(&'static str, TerminalPreset)>> = Laz
                 None,
                 argv(&[
                     "herdr",
-                    "agent",
-                    "start",
-                    "{instance_name}",
+                    "tab",
+                    "create",
                     "--cwd",
                     "{cwd}",
                     "--no-focus",
-                    "--",
-                    "bash",
-                    "{script}",
+                    "--label",
+                    "{instance_name}",
                 ]),
                 argv(&["herdr", "pane", "close", "{pane_id}"]),
                 Some("HERDR_PANE_ID"),

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -144,10 +144,12 @@ pub(crate) const TERMINAL_CONTEXT_VARS: &[&str] = &[
     "TERMINATOR_UUID",
     "TILIX_ID",
     "WT_SESSION",
-    // HERDR_* not stripped: the herdr preset's CLI (`herdr agent start ...`)
-    // resolves its server socket from $HERDR_SOCKET_PATH; other presets pass
-    // the socket via CLI flag (e.g. `kitty @ --to {kitty_listen}`) and don't
-    // need their identity vars to survive in the launcher env.
+    // HERDR_* not stripped: the herdr preset's CLI (`herdr tab create` /
+    // `herdr pane run ...`) resolves its server socket from $HERDR_SOCKET_PATH;
+    // the delivery loop also reuses it for `pane.rename` / `pane.report_agent`.
+    // Other presets pass the socket via CLI flag (e.g. `kitty @ --to
+    // {kitty_listen}`) and don't need their identity vars to survive in the
+    // launcher env.
     // Generic terminal identity
     "TERM_PROGRAM",
     "TERM_SESSION_ID",
@@ -1839,25 +1841,120 @@ fn normalize_captured_terminal_id(captured_id: &str) -> String {
     }
 }
 
-/// Parse herdr `agent start` JSON output and extract `result.agent.pane_id`.
+/// Parse a herdr CLI JSON response and extract the launched pane's id.
 ///
-/// Gated on the response `id` field (`cli:agent:start`) so non-herdr terminal
-/// outputs that happen to be JSON don't accidentally match this shape.
+/// Handles the envelopes hcom launches through:
+/// - `cli:tab:create` (the default herdr preset) → `result.root_pane.pane_id`
+/// - `cli:pane:split` → `result.root_pane.pane_id`
+/// - `cli:agent:start` (legacy) → `result.agent.pane_id`
+///
+/// Gated on the response `id` field so non-herdr terminal outputs that happen
+/// to be JSON don't accidentally match this shape.
 fn parse_herdr_pane_id(captured: &str) -> Option<String> {
     let trimmed = captured.trim_start();
     if !trimmed.starts_with('{') {
         return None;
     }
     let val: serde_json::Value = serde_json::from_str(trimmed).ok()?;
-    if val.get("id").and_then(|v| v.as_str()) != Some("cli:agent:start") {
-        return None;
-    }
-    val.get("result")?
-        .get("agent")?
-        .get("pane_id")?
+    let result = val.get("result")?;
+    let pane_id = match val.get("id").and_then(|v| v.as_str())? {
+        "cli:tab:create" | "cli:pane:split" => result.get("root_pane")?.get("pane_id")?,
+        "cli:agent:start" => result.get("agent")?.get("pane_id")?,
+        _ => return None,
+    };
+    pane_id
         .as_str()
         .filter(|s| !s.is_empty())
         .map(str::to_string)
+}
+
+/// Launch a herdr pane in two steps: `tab create` (whose stdout JSON carries
+/// the new pane id) then `pane run <pane_id> "bash <script>"` to start hcom's
+/// normal runner inside it. Returns `(success, captured_stdout)` where the
+/// captured stdout is the `tab create` envelope — `write_terminal_id` re-parses
+/// the pane id out of it exactly like every other terminal's captured id.
+fn launch_herdr_two_step(
+    create_template: &[String],
+    ctx: TerminalCommandContext<'_>,
+    inside_ai_tool: bool,
+) -> Result<(bool, String)> {
+    // Step 1: open the pane. `tab create` takes no script, so substitute
+    // placeholders directly — the generic `substitute_open_argv` requires a
+    // `{script}` slot this command intentionally lacks.
+    let create_argv = substitute_herdr_create_argv(create_template, &ctx);
+    let (created, captured) = spawn_terminal_process(&create_argv, inside_ai_tool)?;
+    let Some(pane_id) = parse_herdr_pane_id(captured.trim()) else {
+        // Couldn't open/parse a pane. Either `tab create` failed outright (no
+        // pane exists) or returned something unparseable; without a pane id
+        // there's nothing to close. Surface failure but keep the raw stdout so
+        // callers/logs can see what herdr returned.
+        return Ok((false, captured));
+    };
+
+    // Step 2: run hcom's generated runner script in the new pane. `pane run`
+    // sends the text and presses Enter, so `bash <script>` is the whole line.
+    // The script path is shell-quoted: herdr types it into the pane's shell,
+    // and hcom's launch dir lives under $HOME, which can contain spaces.
+    let run_argv = vec![
+        "herdr".to_string(),
+        "pane".to_string(),
+        "run".to_string(),
+        pane_id.clone(),
+        format!("bash {}", shell_quote(ctx.script)),
+    ];
+    // Don't `?`-propagate a step-2 failure directly: step 1 already opened the
+    // pane, so bailing here would orphan an empty pane that looks like a live
+    // agent in herdr's sidebar (issue #102, F3). Unlike the old single-command
+    // `agent start` preset — where a spawn failure left nothing behind — the
+    // two-step split has to clean up the half it created. Close it best-effort,
+    // then surface the original error.
+    let ran = match spawn_terminal_process(&run_argv, inside_ai_tool) {
+        Ok((ran, _)) => ran,
+        Err(run_err) => {
+            let close_argv = vec![
+                "herdr".to_string(),
+                "pane".to_string(),
+                "close".to_string(),
+                pane_id,
+            ];
+            let _ = spawn_terminal_process(&close_argv, inside_ai_tool);
+            return Err(run_err);
+        }
+    };
+
+    // Return the `tab create` stdout so `write_terminal_id` records the pane id.
+    Ok((created && ran, captured))
+}
+
+/// Substitute placeholders into herdr's `tab create` argv. Mirrors
+/// `substitute_open_argv` but without the mandatory `{script}` slot (herdr's
+/// `tab create` takes no script; the runner is sent separately via `pane run`).
+fn substitute_herdr_create_argv(
+    template: &[String],
+    ctx: &TerminalCommandContext<'_>,
+) -> Vec<String> {
+    let pane_title = ctx
+        .pane_title
+        .filter(|s| !s.is_empty())
+        .unwrap_or(ctx.instance_name);
+    template
+        .iter()
+        .map(|part| {
+            let mut part = part.clone();
+            for (placeholder, value) in [
+                ("{process_id}", ctx.process_id),
+                ("{cwd}", ctx.cwd),
+                ("{instance_name}", ctx.instance_name),
+                ("{tool}", ctx.tool),
+                ("{pane_title}", pane_title),
+            ] {
+                if part.contains(placeholder) {
+                    part = part.replace(placeholder, value);
+                }
+            }
+            part
+        })
+        .collect()
 }
 
 /// Launch terminal with command.
@@ -2130,10 +2227,18 @@ pub fn launch_terminal(
                 .map(|s| s.as_str())
                 .filter(|s| !s.is_empty()),
         };
-        // The Windows `.ps1`-via-PowerShell variant is already selected by the
-        // preset's `open_argv(cfg!(windows))`; no text rewrite needed.
-        let final_argv = substitute_open_argv(&cmd_template, ctx)?;
-        let (success, captured_id) = spawn_terminal_process(&final_argv, inside_ai_tool)?;
+        // Herdr launches in two steps: `tab create` (stdout carries the pane
+        // id) then `pane run <pane_id> "bash {script}"`. This doesn't fit the
+        // single-argv preset model, so handle it natively. Everything else is a
+        // single spawn.
+        let (success, captured_id) = if terminal_mode == "herdr" {
+            launch_herdr_two_step(&cmd_template, ctx, inside_ai_tool)?
+        } else {
+            // The Windows `.ps1`-via-PowerShell variant is already selected by
+            // the preset's `open_argv(cfg!(windows))`; no text rewrite needed.
+            let final_argv = substitute_open_argv(&cmd_template, ctx)?;
+            spawn_terminal_process(&final_argv, inside_ai_tool)?
+        };
         write_terminal_id(env, &captured_id);
         if success {
             Ok((LaunchResult::Success, terminal_mode))
@@ -3387,18 +3492,78 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_herdr_tab_create_json() {
+        // The default herdr preset launches via `tab create`; the pane id lives
+        // at result.root_pane.pane_id.
+        let json = r#"{"id":"cli:tab:create","result":{"type":"tab_created","tab":{"tab_id":"w1:2"},"root_pane":{"pane_id":"p_7","terminal_id":"term_x","workspace_id":"w1","tab_id":"w1:2","focused":false}}}"#;
+        assert_eq!(normalize_captured_terminal_id(json), "p_7");
+    }
+
+    #[test]
+    fn test_normalize_herdr_pane_split_json() {
+        let json = r#"{"id":"cli:pane:split","result":{"root_pane":{"pane_id":"p_9"}}}"#;
+        assert_eq!(normalize_captured_terminal_id(json), "p_9");
+    }
+
+    #[test]
+    fn test_substitute_herdr_create_argv_uses_instance_name_and_cwd() {
+        let template = argv(&[
+            "herdr",
+            "tab",
+            "create",
+            "--cwd",
+            "{cwd}",
+            "--no-focus",
+            "--label",
+            "{instance_name}",
+        ]);
+        let out = substitute_herdr_create_argv(
+            &template,
+            &TerminalCommandContext {
+                script: "/tmp/test.sh",
+                process_id: "abc-123",
+                cwd: "/home/user/project",
+                instance_name: "luna",
+                tool: "claude",
+                pane_title: Some("\u{25c9} luna [claude]"),
+            },
+        );
+        assert_eq!(
+            out,
+            vec![
+                "herdr",
+                "tab",
+                "create",
+                "--cwd",
+                "/home/user/project",
+                "--no-focus",
+                "--label",
+                "luna",
+            ]
+        );
+    }
+
+    #[test]
     fn test_herdr_preset_template_uses_stable_instance_name() {
-        // The herdr preset must launch with a stable agent name so
-        // `herdr agent send <name>` keeps working — the styled status label
-        // (`◉ luna [claude]`) is pushed separately via `pane.rename` from the
-        // delivery loop, not baked into the agent name.
+        // The herdr preset opens the pane with `tab create` and a stable
+        // `--label {instance_name}` (e.g. `luna`). The runner script is sent
+        // separately via `pane run` (handled natively in `launch_terminal`), so
+        // the open argv carries no `{script}` slot. The styled status label
+        // (`◉ luna [claude]`) is pushed via `pane.rename` from the delivery
+        // loop, not baked into the pane label.
         let preset = crate::shared::terminal_presets::get_terminal_preset("herdr").unwrap();
         let open = preset.open.select(false).unwrap();
-        assert!(open.contains(&"{script}"));
+        assert!(open.contains(&"tab"));
+        assert!(open.contains(&"create"));
+        assert!(
+            !open.contains(&"{script}"),
+            "herdr's `tab create` open argv must not carry {{script}} — the \
+             runner is sent separately via `pane run`"
+        );
         assert!(open.contains(&"{instance_name}"));
         assert!(
             !open.contains(&"{pane_title}"),
-            "herdr preset must not use {{pane_title}} as agent name"
+            "herdr preset must not use {{pane_title}} as the pane label"
         );
         assert!(open.contains(&"{cwd}"));
         assert!(!open.contains(&"{process_id}"));


### PR DESCRIPTION
Fixes #102.

hcom's built-in `herdr` terminal adapter broke against **herdr 0.7.5** in two ways:

1. `agent start --cwd/--no-focus` — those flags were retired, so launches failed with `unknown option: --cwd`.
2. Even when it launched, herdr never classified the pane as an agent: hcom's `hcom pty` idle-injection wrapper is the foreground process, which defeats herdr's foreground-process agent detection.

Idle message injection is hcom's core feature, so the fix **keeps the `hcom pty` wrapper** and teaches herdr about the pane over its control socket instead.

## Launch (`terminal_presets.rs`, `terminal.rs`)
- Two-step native launch: `herdr tab create --cwd {cwd} --no-focus --label {instance_name}` opens the pane (stdout JSON carries the pane id), then `herdr pane run <pane_id> "bash {script}"` starts hcom's normal runner inside it. `agent start` is unusable now (forces the executable, won't run hcom's wrapper).
- `parse_herdr_pane_id` now reads `cli:tab:create` / `cli:pane:split` (`root_pane.pane_id`) alongside legacy `cli:agent:start`.
- A `pane run` failure closes the pane opened in step 1 rather than orphaning it.

## Classification / state / name (`delivery.rs` `host_label`)
- `pane.report_agent` (source `"hcom"`) so herdr tracks the `hcom pty`-wrapped pane as an agent. Where herdr has its own integration for the tool it owns authority and our report is accepted-and-ignored — harmless, and the report still pays off for tools herdr doesn't integrate.
- `agent.rename` restores `herdr agent send/prompt/focus <name>` targeting (the retired `agent start {name}` set the canonical agent name for free; `tab create --label` only labels the tab). Kept separate from the styled `pane.rename` label.
- `pane.report_agent` seq anchored to a monotonic wall-clock nanosecond timestamp so reports survive a delivery-loop restart in the same pane.

## Robust socket handling (`delivery.rs`)
- Classify socket outcomes instead of failing closed: **Unreachable** (connect fail / dropped conn / empty reply) disables the backend; **Transient** (EAGAIN/timeout/interrupt) skips just that op and retries next tick; **Rejected** (herdr JSON `error`) keeps the healthy backend. Only a run of transient failures trips a safety valve. Previously a single EAGAIN — now likelier with 3 socket ops/tick at startup — permanently killed all label/state/name updates for the agent's life.
- Response-envelope parsing lets the rename self-heal (commits `name_set` only on a real `result`, retrying across the classification race).
- Dropped the step-1 early return so a transient label push no longer starves the state report and rename.

## Docs
Corrected to herdr's actual behavior: `--label` labels the tab; herdr accepts any `agent` string in `pane.report_agent`; the report can be shadowed by an installed integration.

## Testing
- New unit tests: envelope parsing, create-argv substitution, report-state mapping, socket response classification. All herdr/delivery unit tests green; clippy clean on the touched files.
- Live-tested on real herdr 0.7.5: launch, agent classification, idle message delivery, and name targeting all confirmed working. 3 unrelated tests (`shell_env`, `resolve_termux_tool_launcher_*`) fail identically on clean `main` — pre-existing device/env issues, not this diff.

## Known follow-ups (not in this PR)
- herdr's **resume-on-restore** relaunches the bare tool, bypassing `hcom pty` — a documented herdr edge case.
- Tools that crash *inside* the pane after a successful `pane run` leave a pane holding the tool's error output (diagnostic); left intentionally rather than auto-closing on runner exit.