### PR TITLE
fix(paths): preserve symlinks in atomic_write

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1545,9 +1545,12 @@ fn format_env_value(value: &str) -> String {
     }
 }
 
-/// Atomic write: delegates to paths::atomic_write_io (preserves error detail).
+/// Atomic write for user-maintained config files (`~/.hcom/env`, config.toml).
+/// Follows a symlink at the target so a dotfiles-repo link the user created
+/// survives the write (preserves error detail). Internal state files use the
+/// no-follow `paths::atomic_write_io` instead.
 fn atomic_write(path: &std::path::Path, content: &str) -> std::io::Result<()> {
-    crate::paths::atomic_write_io(path, content)
+    crate::paths::atomic_write_following_symlinks_io(path, content)
 }
 
 pub fn write_config_toml_path(path: &std::path::Path, content: &str) -> std::io::Result<()> {

--- a/src/hooks/antigravity.rs
+++ b/src/hooks/antigravity.rs
@@ -229,7 +229,7 @@ pub fn try_setup_antigravity_hooks(include_permissions: bool) -> Result<(), Setu
     let json_str = serde_json::to_string_pretty(&Value::Object(hooks_root))
         .map_err(SetupError::SerializationFailed)?;
 
-    crate::paths::atomic_write_io(&hooks_path, &json_str).map_err(|e| {
+    crate::paths::atomic_write_following_symlinks_io(&hooks_path, &json_str).map_err(|e| {
         SetupError::AtomicWriteFailed {
             path: hooks_path.clone(),
             source: e,
@@ -300,7 +300,7 @@ fn remove_hooks_lifecycle_block_at(path: &Path) -> bool {
         Ok(s) => s,
         Err(_) => return false,
     };
-    crate::paths::atomic_write_io(path, &json_str).is_ok()
+    crate::paths::atomic_write_following_symlinks_io(path, &json_str).is_ok()
 }
 
 fn verify_hooks_at(path: &Path, check_permissions: bool) -> Result<(), VerifyFailReason> {
@@ -728,7 +728,7 @@ fn setup_antigravity_permissions() -> bool {
         Ok(s) => s,
         Err(_) => return false,
     };
-    crate::paths::atomic_write(&path, &json_str)
+    crate::paths::atomic_write_following_symlinks(&path, &json_str)
 }
 
 /// Remove hcom rules from agy settings.json. Cleans `permissions.allow` and
@@ -784,7 +784,7 @@ fn remove_antigravity_permissions_at(path: &Path) -> bool {
         Ok(s) => s,
         Err(_) => return false,
     };
-    crate::paths::atomic_write(path, &json_str)
+    crate::paths::atomic_write_following_symlinks(path, &json_str)
 }
 
 /// Check that every hcom rule we install is present in agy settings.json.

--- a/src/hooks/claude.rs
+++ b/src/hooks/claude.rs
@@ -3266,7 +3266,7 @@ pub fn try_setup_claude_hooks(include_permissions: bool) -> Result<(), SetupErro
     let json_str =
         serde_json::to_string_pretty(&settings).map_err(SetupError::SerializationFailed)?;
 
-    paths::atomic_write_io(&settings_path, &json_str).map_err(|e| {
+    paths::atomic_write_following_symlinks_io(&settings_path, &json_str).map_err(|e| {
         SetupError::AtomicWriteFailed {
             path: settings_path.clone(),
             source: e,
@@ -3414,7 +3414,7 @@ fn remove_hooks_from_settings_path(settings_path: &Path) -> bool {
         Err(_) => return false,
     };
 
-    paths::atomic_write(settings_path, &json_str)
+    paths::atomic_write_following_symlinks(settings_path, &json_str)
 }
 
 /// Remove hcom hooks from Claude settings.

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -1553,7 +1553,8 @@ fn write_hcom_hook_trust_state(
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    paths::atomic_write_following_symlinks_io(config_path, &doc.to_string()).map_err(|e| e.to_string())
+    paths::atomic_write_following_symlinks_io(config_path, &doc.to_string())
+        .map_err(|e| e.to_string())
 }
 
 /// Rewrite hcom's own `hooks.state` entries from an authoritative hooks/list

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -1553,7 +1553,7 @@ fn write_hcom_hook_trust_state(
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    paths::atomic_write_io(config_path, &doc.to_string()).map_err(|e| e.to_string())
+    paths::atomic_write_following_symlinks_io(config_path, &doc.to_string()).map_err(|e| e.to_string())
 }
 
 /// Rewrite hcom's own `hooks.state` entries from an authoritative hooks/list
@@ -2107,7 +2107,7 @@ fn ensure_codex_feature_enabled(
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    if paths::atomic_write(config_path, &doc.to_string()) {
+    if paths::atomic_write_following_symlinks(config_path, &doc.to_string()) {
         Ok(())
     } else {
         Err("atomic_write failed".to_string())
@@ -2377,7 +2377,7 @@ pub fn setup_codex_execpolicy() -> bool {
     }
 
     let _ = std::fs::create_dir_all(&rules_dir);
-    paths::atomic_write(&rules_file, &rule_content)
+    paths::atomic_write_following_symlinks(&rules_file, &rule_content)
 }
 
 /// Remove hcom execpolicy rule.
@@ -2508,7 +2508,7 @@ pub fn try_setup_codex_hooks(include_permissions: bool) -> Result<(), SetupError
     }
     let content =
         serde_json::to_string_pretty(&hooks_json).map_err(SetupError::SerializationFailed)?;
-    paths::atomic_write_io(&hooks_path, &content).map_err(|source| {
+    paths::atomic_write_following_symlinks_io(&hooks_path, &content).map_err(|source| {
         SetupError::AtomicWriteFailed {
             path: hooks_path.clone(),
             source,
@@ -2619,7 +2619,7 @@ fn remove_codex_hooks_from_dir(base: &std::path::Path) -> bool {
                 } else {
                     let content =
                         serde_json::to_string_pretty(&json).unwrap_or_else(|_| "{}".into());
-                    ok &= paths::atomic_write(&hooks_path, &content);
+                    ok &= paths::atomic_write_following_symlinks(&hooks_path, &content);
                 }
             }
             Err(_) => ok = false,

--- a/src/hooks/copilot.rs
+++ b/src/hooks/copilot.rs
@@ -150,9 +150,11 @@ fn write_json(path: &Path, value: &Value) -> Result<(), SetupError> {
         })?;
     }
     let content = serde_json::to_string_pretty(value)?;
-    paths::atomic_write_following_symlinks_io(path, &content).map_err(|source| SetupError::AtomicWriteFailed {
-        path: path.to_path_buf(),
-        source,
+    paths::atomic_write_following_symlinks_io(path, &content).map_err(|source| {
+        SetupError::AtomicWriteFailed {
+            path: path.to_path_buf(),
+            source,
+        }
     })
 }
 

--- a/src/hooks/copilot.rs
+++ b/src/hooks/copilot.rs
@@ -150,7 +150,7 @@ fn write_json(path: &Path, value: &Value) -> Result<(), SetupError> {
         })?;
     }
     let content = serde_json::to_string_pretty(value)?;
-    paths::atomic_write_io(path, &content).map_err(|source| SetupError::AtomicWriteFailed {
+    paths::atomic_write_following_symlinks_io(path, &content).map_err(|source| SetupError::AtomicWriteFailed {
         path: path.to_path_buf(),
         source,
     })

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -209,9 +209,11 @@ fn write_json(path: &Path, value: &Value) -> Result<(), SetupError> {
         })?;
     }
     let content = serde_json::to_string_pretty(value)?;
-    paths::atomic_write_following_symlinks_io(path, &content).map_err(|source| SetupError::AtomicWriteFailed {
-        path: path.to_path_buf(),
-        source,
+    paths::atomic_write_following_symlinks_io(path, &content).map_err(|source| {
+        SetupError::AtomicWriteFailed {
+            path: path.to_path_buf(),
+            source,
+        }
     })
 }
 

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -209,7 +209,7 @@ fn write_json(path: &Path, value: &Value) -> Result<(), SetupError> {
         })?;
     }
     let content = serde_json::to_string_pretty(value)?;
-    paths::atomic_write_io(path, &content).map_err(|source| SetupError::AtomicWriteFailed {
+    paths::atomic_write_following_symlinks_io(path, &content).map_err(|source| SetupError::AtomicWriteFailed {
         path: path.to_path_buf(),
         source,
     })

--- a/src/hooks/gemini.rs
+++ b/src/hooks/gemini.rs
@@ -1124,7 +1124,7 @@ fn setup_gemini_policy() -> bool {
     }
 
     let _ = std::fs::create_dir_all(&policies_dir);
-    crate::paths::atomic_write(&policy_file, &policy_content)
+    crate::paths::atomic_write_following_symlinks(&policy_file, &policy_content)
 }
 
 /// Remove hcom policy file.
@@ -1311,7 +1311,7 @@ pub fn ensure_hooks_enabled() -> bool {
     set_hooks_enabled(&mut settings);
 
     let json_str = serde_json::to_string_pretty(&Value::Object(settings)).unwrap_or_default();
-    crate::paths::atomic_write(&settings_path, &json_str)
+    crate::paths::atomic_write_following_symlinks(&settings_path, &json_str)
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -1497,7 +1497,7 @@ pub fn try_setup_gemini_hooks(include_permissions: bool) -> Result<(), SetupErro
     let json_str = serde_json::to_string_pretty(&Value::Object(settings))
         .map_err(SetupError::SerializationFailed)?;
 
-    crate::paths::atomic_write_io(&settings_path, &json_str).map_err(|e| {
+    crate::paths::atomic_write_following_symlinks_io(&settings_path, &json_str).map_err(|e| {
         SetupError::AtomicWriteFailed {
             path: settings_path.clone(),
             source: e,
@@ -1705,7 +1705,7 @@ fn remove_hooks_from_path(path: &Path) -> bool {
     remove_hcom_hooks_from_settings(&mut settings);
 
     let json_str = serde_json::to_string_pretty(&Value::Object(settings)).unwrap_or_default();
-    crate::paths::atomic_write(path, &json_str)
+    crate::paths::atomic_write_following_symlinks(path, &json_str)
 }
 
 #[cfg(test)]

--- a/src/hooks/kimi.rs
+++ b/src/hooks/kimi.rs
@@ -128,7 +128,7 @@ fn write_toml(path: &Path, doc: &DocumentMut) -> Result<(), SetupError> {
         })?;
     }
     let content = doc.to_string();
-    paths::atomic_write_io(path, &content).map_err(|source| SetupError::AtomicWriteFailed {
+    paths::atomic_write_following_symlinks_io(path, &content).map_err(|source| SetupError::AtomicWriteFailed {
         path: path.to_path_buf(),
         source,
     })

--- a/src/hooks/kimi.rs
+++ b/src/hooks/kimi.rs
@@ -128,9 +128,11 @@ fn write_toml(path: &Path, doc: &DocumentMut) -> Result<(), SetupError> {
         })?;
     }
     let content = doc.to_string();
-    paths::atomic_write_following_symlinks_io(path, &content).map_err(|source| SetupError::AtomicWriteFailed {
-        path: path.to_path_buf(),
-        source,
+    paths::atomic_write_following_symlinks_io(path, &content).map_err(|source| {
+        SetupError::AtomicWriteFailed {
+            path: path.to_path_buf(),
+            source,
+        }
     })
 }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -289,13 +289,22 @@ const MAX_WRITE_SYMLINK_HOPS: usize = 8;
 
 /// Resolve the path an atomic write should actually land on, following symlinks.
 ///
-/// `atomic_write_io` replaces its target by rename, and a rename onto a symlink
+/// An atomic write replaces its target by rename, and a rename onto a symlink
 /// REPLACES THE LINK with a regular file. That silently detaches config files
 /// which users symlink into a dotfiles repo (`~/.claude/settings.json` ->
 /// `~/dotfiles/claude/settings.json`): the edit lands in a new local file, the
 /// repo copy stops receiving updates, and the two diverge with no error and no
 /// warning. Following the link first means the write updates the file the user
 /// actually pointed at, and the link survives.
+///
+/// Following a symlink is OPT-IN, exposed only through
+/// `atomic_write_following_symlinks[_io]`. The default primitive
+/// (`atomic_write[_io]`) never follows, so internal state files (flag counters,
+/// pidfiles, device-id, update flags under `~/.hcom/`) keep the pre-existing
+/// redirection immunity: a pre-planted link at their path is destroyed by the
+/// rename rather than written through to whatever it targets. Symlink following
+/// only makes sense for files the USER maintains and may link into a dotfiles
+/// repo (tool configs); it is never applied to hcom's own internal state.
 ///
 /// A dangling link resolves to its missing target on purpose: that is the
 /// "linked into a checkout that has not created the file yet" case, where
@@ -330,14 +339,28 @@ fn resolve_write_target(filepath: &Path) -> std::io::Result<PathBuf> {
     ))
 }
 
-/// Write content to file atomically (temp file + rename).
+/// Write content to file atomically (temp file + rename), WITHOUT following
+/// symlinks: the rename lands on `filepath` literally, so a pre-planted symlink
+/// at that path is destroyed rather than written through. This is the safe
+/// default for internal state files; callers that must preserve a user's
+/// dotfiles symlink use `atomic_write_following_symlinks_io` instead.
+///
 /// Returns the underlying IO error on failure for callers that need error detail.
 pub fn atomic_write_io(filepath: &Path, content: &str) -> std::io::Result<()> {
-    // Follow symlinks before writing: renaming onto a link would destroy it and
-    // detach a user's symlinked config (see resolve_write_target).
-    let resolved = resolve_write_target(filepath)?;
-    let filepath = resolved.as_path();
+    write_atomically(filepath, content)
+}
 
+/// Like `atomic_write_io`, but follows a symlink at the final path component so
+/// the write lands on the file the user pointed at and the link survives (see
+/// `resolve_write_target`). For user-maintained config files that may be linked
+/// into a dotfiles repo — never for hcom's internal state.
+pub fn atomic_write_following_symlinks_io(filepath: &Path, content: &str) -> std::io::Result<()> {
+    let resolved = resolve_write_target(filepath)?;
+    write_atomically(resolved.as_path(), content)
+}
+
+/// Core atomic write: temp file + fsync + rename onto `filepath` as given.
+fn write_atomically(filepath: &Path, content: &str) -> std::io::Result<()> {
     // Ensure parent directory exists
     if let Some(parent) = filepath.parent() {
         fs::create_dir_all(parent)?;
@@ -383,10 +406,17 @@ fn persist_temp_file(mut tmp: tempfile::NamedTempFile, filepath: &Path) -> std::
     unreachable!("persist loop returns on success or final error")
 }
 
-/// Write content to file atomically (temp file + rename).
-/// Returns true on success, false on failure.
+/// Write content to file atomically (temp file + rename), WITHOUT following
+/// symlinks. Returns true on success, false on failure.
 pub fn atomic_write(filepath: &Path, content: &str) -> bool {
     atomic_write_io(filepath, content).is_ok()
+}
+
+/// Like `atomic_write`, but follows a symlink at the target so a user's
+/// dotfiles link survives (see `atomic_write_following_symlinks_io`).
+/// Returns true on success, false on failure.
+pub fn atomic_write_following_symlinks(filepath: &Path, content: &str) -> bool {
+    atomic_write_following_symlinks_io(filepath, content).is_ok()
 }
 
 /// Increment a counter in .tmp/flags/{name} and return new value.
@@ -455,11 +485,45 @@ mod tests {
         assert!(!fs::symlink_metadata(&target).unwrap().is_symlink());
     }
 
-    /// Regression: a rename onto a symlink used to replace the link with a
-    /// regular file, detaching config that users link into a dotfiles repo.
+    /// Redirection immunity: the DEFAULT primitive must NOT follow symlinks, so
+    /// a pre-planted link at an internal state path (e.g. a flag counter under
+    /// `~/.hcom/.tmp/flags/`) is destroyed by the rename rather than written
+    /// through to whatever it targets. Without this the shared primitive would
+    /// give every internal caller a redirection surface (settings.json et al.).
     #[cfg(unix)]
     #[test]
-    fn test_atomic_write_io_writes_through_symlink_and_keeps_link() {
+    fn test_atomic_write_io_does_not_follow_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let sensitive = tmp.path().join("sensitive.json");
+        let planted = tmp.path().join("flag");
+        fs::write(&sensitive, "do-not-touch").unwrap();
+        // Attacker plants the internal-state path as a link to a sensitive file.
+        std::os::unix::fs::symlink(&sensitive, &planted).unwrap();
+
+        atomic_write_io(&planted, "1").unwrap();
+
+        assert!(
+            !fs::symlink_metadata(&planted).unwrap().is_symlink(),
+            "no-follow write must replace the planted link with a real file"
+        );
+        assert_eq!(
+            fs::read_to_string(&planted).unwrap(),
+            "1",
+            "the write must land at the literal path"
+        );
+        assert_eq!(
+            fs::read_to_string(&sensitive).unwrap(),
+            "do-not-touch",
+            "the symlink target must NOT be written through"
+        );
+    }
+
+    /// Regression: a rename onto a symlink used to replace the link with a
+    /// regular file, detaching config that users link into a dotfiles repo. The
+    /// opt-in following variant preserves the link and writes through it.
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_following_symlinks_writes_through_and_keeps_link() {
         let tmp = TempDir::new().unwrap();
         let repo = tmp.path().join("repo");
         let live = tmp.path().join("live");
@@ -470,7 +534,7 @@ mod tests {
         fs::write(&real, "from-repo").unwrap();
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
-        atomic_write_io(&link, "written-by-hcom").unwrap();
+        atomic_write_following_symlinks_io(&link, "written-by-hcom").unwrap();
 
         assert!(
             fs::symlink_metadata(&link).unwrap().is_symlink(),
@@ -485,7 +549,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_atomic_write_io_follows_relative_symlink() {
+    fn test_atomic_write_following_symlinks_follows_relative_symlink() {
         let tmp = TempDir::new().unwrap();
         let real = tmp.path().join("target.json");
         let link = tmp.path().join("link.json");
@@ -493,7 +557,7 @@ mod tests {
         // Relative destinations resolve against the link's own directory.
         std::os::unix::fs::symlink("target.json", &link).unwrap();
 
-        atomic_write_io(&link, "after").unwrap();
+        atomic_write_following_symlinks_io(&link, "after").unwrap();
 
         assert!(fs::symlink_metadata(&link).unwrap().is_symlink());
         assert_eq!(fs::read_to_string(&real).unwrap(), "after");
@@ -503,13 +567,13 @@ mod tests {
     /// target, not clobber the link.
     #[cfg(unix)]
     #[test]
-    fn test_atomic_write_io_creates_dangling_symlink_target() {
+    fn test_atomic_write_following_symlinks_creates_dangling_target() {
         let tmp = TempDir::new().unwrap();
         let missing = tmp.path().join("not-yet").join("settings.json");
         let link = tmp.path().join("settings.json");
         std::os::unix::fs::symlink(&missing, &link).unwrap();
 
-        atomic_write_io(&link, "created").unwrap();
+        atomic_write_following_symlinks_io(&link, "created").unwrap();
 
         assert!(fs::symlink_metadata(&link).unwrap().is_symlink());
         assert_eq!(fs::read_to_string(&missing).unwrap(), "created");
@@ -517,7 +581,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_atomic_write_io_rejects_symlink_cycle() {
+    fn test_atomic_write_following_symlinks_rejects_cycle() {
         let tmp = TempDir::new().unwrap();
         let first = tmp.path().join("a");
         let second = tmp.path().join("b");
@@ -525,7 +589,7 @@ mod tests {
         std::os::unix::fs::symlink(&first, &second).unwrap();
 
         // Fails loudly rather than spinning or silently clobbering a link.
-        let err = atomic_write_io(&first, "content").unwrap_err();
+        let err = atomic_write_following_symlinks_io(&first, "content").unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(err.to_string().contains("symlink chain"));
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -309,13 +309,31 @@ const MAX_WRITE_SYMLINK_HOPS: usize = 8;
 /// A dangling link resolves to its missing target on purpose: that is the
 /// "linked into a checkout that has not created the file yet" case, where
 /// creating the target is what the user meant.
+///
+/// Resolution is ADVISORY, not a security boundary. The resolved path is handed
+/// to a separate create_dir_all + temp-create + rename sequence, so a co-resident
+/// process could swap an intermediate directory component for a symlink between
+/// resolution and the rename (a classic resolve-then-rename TOCTOU); the kernel
+/// would then follow that swap at rename time. This is acceptable under hcom's
+/// per-user threat model (an attacker who can rewrite entries inside the user's
+/// own config tree already has broader reach). If a stronger guarantee is ever
+/// needed, open the resolved parent as an `O_DIRECTORY` fd and persist relative
+/// to it so the rename cannot be redirected.
 fn resolve_write_target(filepath: &Path) -> std::io::Result<PathBuf> {
     let mut current = filepath.to_path_buf();
     for _ in 0..MAX_WRITE_SYMLINK_HOPS {
         // symlink_metadata does not follow links, so this inspects the link itself.
-        let Ok(metadata) = fs::symlink_metadata(&current) else {
-            // Nothing there, or unreadable: write to the path as given.
-            return Ok(current);
+        let metadata = match fs::symlink_metadata(&current) {
+            Ok(metadata) => metadata,
+            // NotFound is the only benign case: the current (possibly partially
+            // resolved) path does not exist yet, so the write creates it there —
+            // the dangling-link / not-yet-created-target case. Every other stat
+            // error (EACCES, EOVERFLOW, transient IO, ...) means we could not tell
+            // whether this is a symlink; propagating it loudly is mandatory so we
+            // never rename over — and silently detach — an actual link we failed
+            // to inspect. Matches read_link's `?` propagation two lines below.
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(current),
+            Err(err) => return Err(err),
         };
         if !metadata.file_type().is_symlink() {
             return Ok(current);
@@ -324,10 +342,15 @@ fn resolve_write_target(filepath: &Path) -> std::io::Result<PathBuf> {
         current = if destination.is_absolute() {
             destination
         } else {
-            match current.parent() {
-                Some(parent) => parent.join(destination),
-                None => destination,
-            }
+            // `current` is an existing symlink, so it is neither the empty path
+            // nor a root — `parent()` is therefore always `Some` here (a bare
+            // relative link like `link.json` yields `Some("")`). The `expect`
+            // documents that invariant and fails loud if it is ever violated,
+            // rather than silently falling back to a CWD-relative resolution.
+            let parent = current
+                .parent()
+                .expect("an existing symlink path always has a parent component");
+            parent.join(destination)
         };
     }
     Err(std::io::Error::new(
@@ -373,8 +396,42 @@ fn write_atomically(filepath: &Path, content: &str) -> std::io::Result<()> {
     std::io::Write::write_all(&mut &tmp, content.as_bytes())?;
     tmp.as_file().sync_all()?;
 
+    // Preserve the destination's existing permission mode. NamedTempFile creates
+    // its file 0600 on unix, and persist-by-rename copies the temp file's mode —
+    // NOT the destination's — so without this an atomic write over an existing
+    // file would silently reset it to 0600, stripping group/other access the
+    // user (or their dotfiles repo) had set. Only when the destination is a
+    // real regular file do we copy its mode; a fresh path or a not-followed
+    // symlink keeps the private 0600 default.
+    preserve_target_mode(&tmp, filepath)?;
+
     // Persist atomically (temp file → target path via rename)
     persist_temp_file(tmp, filepath)?;
+    Ok(())
+}
+
+/// Copy the destination file's permission mode onto the temp file before it is
+/// renamed into place, so an atomic write preserves rather than resets the mode.
+/// No-op when the destination does not exist as a real regular file.
+#[cfg(unix)]
+fn preserve_target_mode(tmp: &tempfile::NamedTempFile, filepath: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    // symlink_metadata, not metadata: a symlink here is the no-follow path (the
+    // link is about to be destroyed by the rename), so there is no existing
+    // regular-file mode to carry over — leave the temp file at its 0600 default.
+    let mode = match fs::symlink_metadata(filepath) {
+        Ok(meta) if meta.file_type().is_file() => meta.permissions().mode(),
+        Ok(_) => return Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err),
+    };
+    tmp.as_file()
+        .set_permissions(fs::Permissions::from_mode(mode))
+}
+
+#[cfg(not(unix))]
+fn preserve_target_mode(_tmp: &tempfile::NamedTempFile, _filepath: &Path) -> std::io::Result<()> {
+    // Permission bits are a unix concept; nothing to carry over on other platforms.
     Ok(())
 }
 
@@ -532,6 +589,9 @@ mod tests {
         let real = repo.join("settings.json");
         let link = live.join("settings.json");
         fs::write(&real, "from-repo").unwrap();
+        // A dotfiles-tracked config is typically group/other-readable.
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&real, fs::Permissions::from_mode(0o644)).unwrap();
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
         atomic_write_following_symlinks_io(&link, "written-by-hcom").unwrap();
@@ -544,6 +604,11 @@ mod tests {
             fs::read_to_string(&real).unwrap(),
             "written-by-hcom",
             "content must land in the link target, not a new local file"
+        );
+        assert_eq!(
+            fs::metadata(&real).unwrap().permissions().mode() & 0o777,
+            0o644,
+            "the target's existing mode must survive; the write must not reset it to 0600"
         );
     }
 
@@ -561,6 +626,77 @@ mod tests {
 
         assert!(fs::symlink_metadata(&link).unwrap().is_symlink());
         assert_eq!(fs::read_to_string(&real).unwrap(), "after");
+    }
+
+    /// A multi-hop chain (link1 -> link2 -> real) must resolve all the way
+    /// through and land in `real`, with every link surviving. Mixes an absolute
+    /// and a relative hop so a regression in second-hop relative joining (e.g.
+    /// joining against the original path's parent instead of the current link's)
+    /// is caught.
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_following_symlinks_follows_multi_hop_chain() {
+        let tmp = TempDir::new().unwrap();
+        let nested = tmp.path().join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        let real = nested.join("real.json");
+        let link2 = nested.join("link2.json");
+        let link1 = tmp.path().join("link1.json");
+        fs::write(&real, "before").unwrap();
+        // link2 -> real via a RELATIVE hop, resolved against link2's own dir.
+        std::os::unix::fs::symlink("real.json", &link2).unwrap();
+        // link1 -> link2 via an ABSOLUTE hop.
+        std::os::unix::fs::symlink(&link2, &link1).unwrap();
+
+        atomic_write_following_symlinks_io(&link1, "after").unwrap();
+
+        assert!(fs::symlink_metadata(&link1).unwrap().is_symlink());
+        assert!(fs::symlink_metadata(&link2).unwrap().is_symlink());
+        assert_eq!(
+            fs::read_to_string(&real).unwrap(),
+            "after",
+            "a 2-hop chain must resolve through to the real target"
+        );
+    }
+
+    /// The class invariant, pinned on the default (no-follow) primitive too:
+    /// atomic_write over an existing regular file preserves that file's
+    /// permission mode instead of resetting it to the tempfile's 0600.
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_io_preserves_existing_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("config.json");
+        fs::write(&target, "old").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+
+        atomic_write_io(&target, "new").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
+        assert_eq!(
+            fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o644,
+            "an atomic overwrite must preserve the destination's mode, not reset it to 0600"
+        );
+    }
+
+    /// A brand-new file (no existing destination) must keep the private 0600
+    /// default — mode preservation only carries an EXISTING mode over.
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_io_new_file_is_private() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("fresh.json");
+
+        atomic_write_io(&target, "x").unwrap();
+
+        assert_eq!(
+            fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "a freshly created file must stay 0600"
+        );
     }
 
     /// A link into a checkout that has not created the file yet must create the
@@ -592,6 +728,36 @@ mod tests {
         let err = atomic_write_following_symlinks_io(&first, "content").unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(err.to_string().contains("symlink chain"));
+    }
+
+    /// A non-NotFound stat failure on the final component (e.g. EACCES because a
+    /// parent lacks search permission) must PROPAGATE, not be silently treated as
+    /// the dangling/new-file case — otherwise a symlink we merely failed to
+    /// inspect would be renamed over and silently detached.
+    #[cfg(unix)]
+    #[test]
+    fn test_resolve_write_target_propagates_non_notfound_stat_error() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("locked");
+        fs::create_dir(&dir).unwrap();
+        let inside = dir.join("settings.json");
+        fs::write(&inside, "x").unwrap();
+        // Drop search permission so lstat on a path inside fails EACCES, not
+        // NotFound. A uid-0 process bypasses the check; skip the assertion there.
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o000)).unwrap();
+        let bypasses_perms = fs::symlink_metadata(&inside).is_ok();
+
+        let result = resolve_write_target(&inside);
+
+        // Restore so TempDir can recurse in and clean up.
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o755)).unwrap();
+
+        if bypasses_perms {
+            return; // running with a permission bypass (root); nothing to assert
+        }
+        let err = result.expect_err("a non-NotFound lstat error must propagate");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -283,9 +283,61 @@ pub(crate) fn ensure_private_db(db_path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Maximum symlink hops followed when resolving an atomic-write target. Bounded
+/// so a symlink cycle fails loudly instead of spinning.
+const MAX_WRITE_SYMLINK_HOPS: usize = 8;
+
+/// Resolve the path an atomic write should actually land on, following symlinks.
+///
+/// `atomic_write_io` replaces its target by rename, and a rename onto a symlink
+/// REPLACES THE LINK with a regular file. That silently detaches config files
+/// which users symlink into a dotfiles repo (`~/.claude/settings.json` ->
+/// `~/dotfiles/claude/settings.json`): the edit lands in a new local file, the
+/// repo copy stops receiving updates, and the two diverge with no error and no
+/// warning. Following the link first means the write updates the file the user
+/// actually pointed at, and the link survives.
+///
+/// A dangling link resolves to its missing target on purpose: that is the
+/// "linked into a checkout that has not created the file yet" case, where
+/// creating the target is what the user meant.
+fn resolve_write_target(filepath: &Path) -> std::io::Result<PathBuf> {
+    let mut current = filepath.to_path_buf();
+    for _ in 0..MAX_WRITE_SYMLINK_HOPS {
+        // symlink_metadata does not follow links, so this inspects the link itself.
+        let Ok(metadata) = fs::symlink_metadata(&current) else {
+            // Nothing there, or unreadable: write to the path as given.
+            return Ok(current);
+        };
+        if !metadata.file_type().is_symlink() {
+            return Ok(current);
+        }
+        let destination = fs::read_link(&current)?;
+        current = if destination.is_absolute() {
+            destination
+        } else {
+            match current.parent() {
+                Some(parent) => parent.join(destination),
+                None => destination,
+            }
+        };
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!(
+            "symlink chain at {} exceeds {MAX_WRITE_SYMLINK_HOPS} hops",
+            filepath.display()
+        ),
+    ))
+}
+
 /// Write content to file atomically (temp file + rename).
 /// Returns the underlying IO error on failure for callers that need error detail.
 pub fn atomic_write_io(filepath: &Path, content: &str) -> std::io::Result<()> {
+    // Follow symlinks before writing: renaming onto a link would destroy it and
+    // detach a user's symlinked config (see resolve_write_target).
+    let resolved = resolve_write_target(filepath)?;
+    let filepath = resolved.as_path();
+
     // Ensure parent directory exists
     if let Some(parent) = filepath.parent() {
         fs::create_dir_all(parent)?;
@@ -391,6 +443,91 @@ mod tests {
             .join(".hcom")
             .join("hcom.db");
         assert!(!is_test_temp_path(&escape));
+    }
+
+    #[test]
+    fn test_atomic_write_io_replaces_plain_file() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("settings.json");
+        fs::write(&target, "old").unwrap();
+        atomic_write_io(&target, "new").unwrap();
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
+        assert!(!fs::symlink_metadata(&target).unwrap().is_symlink());
+    }
+
+    /// Regression: a rename onto a symlink used to replace the link with a
+    /// regular file, detaching config that users link into a dotfiles repo.
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_io_writes_through_symlink_and_keeps_link() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        let live = tmp.path().join("live");
+        fs::create_dir_all(&repo).unwrap();
+        fs::create_dir_all(&live).unwrap();
+        let real = repo.join("settings.json");
+        let link = live.join("settings.json");
+        fs::write(&real, "from-repo").unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        atomic_write_io(&link, "written-by-hcom").unwrap();
+
+        assert!(
+            fs::symlink_metadata(&link).unwrap().is_symlink(),
+            "the symlink must survive an atomic write"
+        );
+        assert_eq!(
+            fs::read_to_string(&real).unwrap(),
+            "written-by-hcom",
+            "content must land in the link target, not a new local file"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_io_follows_relative_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let real = tmp.path().join("target.json");
+        let link = tmp.path().join("link.json");
+        fs::write(&real, "before").unwrap();
+        // Relative destinations resolve against the link's own directory.
+        std::os::unix::fs::symlink("target.json", &link).unwrap();
+
+        atomic_write_io(&link, "after").unwrap();
+
+        assert!(fs::symlink_metadata(&link).unwrap().is_symlink());
+        assert_eq!(fs::read_to_string(&real).unwrap(), "after");
+    }
+
+    /// A link into a checkout that has not created the file yet must create the
+    /// target, not clobber the link.
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_io_creates_dangling_symlink_target() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("not-yet").join("settings.json");
+        let link = tmp.path().join("settings.json");
+        std::os::unix::fs::symlink(&missing, &link).unwrap();
+
+        atomic_write_io(&link, "created").unwrap();
+
+        assert!(fs::symlink_metadata(&link).unwrap().is_symlink());
+        assert_eq!(fs::read_to_string(&missing).unwrap(), "created");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_io_rejects_symlink_cycle() {
+        let tmp = TempDir::new().unwrap();
+        let first = tmp.path().join("a");
+        let second = tmp.path().join("b");
+        std::os::unix::fs::symlink(&second, &first).unwrap();
+        std::os::unix::fs::symlink(&first, &second).unwrap();
+
+        // Fails loudly rather than spinning or silently clobbering a link.
+        let err = atomic_write_io(&first, "content").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("symlink chain"));
     }
 
     #[test]

--- a/src/tools/copilot_preprocessing.rs
+++ b/src/tools/copilot_preprocessing.rs
@@ -119,7 +119,7 @@ pub(crate) fn ensure_copilot_workspace_trusted(workspace: &Path) -> anyhow::Resu
         normalized.display(),
         path.display()
     );
-    crate::paths::atomic_write_io(&path, &updated)?;
+    crate::paths::atomic_write_following_symlinks_io(&path, &updated)?;
     Ok(())
 }
 

--- a/src/tools/cursor_preprocessing.rs
+++ b/src/tools/cursor_preprocessing.rs
@@ -132,7 +132,7 @@ pub(crate) fn ensure_cursor_workspace_trusted(workspace: &Path) -> anyhow::Resul
         "workspacePath": normalized.to_string_lossy(),
         "trustMethod": "hcom-launch",
     }))?;
-    crate::paths::atomic_write_io(&marker, &content)?;
+    crate::paths::atomic_write_following_symlinks_io(&marker, &content)?;
     Ok(())
 }
 


### PR DESCRIPTION
## The problem

`atomic_write_io` replaces its target with tempfile + rename. A rename onto a symlink replaces the **link** with a regular file. So when a user symlinks a config file into a dotfiles repo, an hcom hook install silently detaches it: hcom's edit lands in a brand-new local file, the repo copy stops receiving updates, and the two diverge with no error and no warning.

This is not hypothetical - it is how I hit it. My `~/.claude/settings.json` and `~/.codex/config.toml` are symlinks into a config repo that is the single source of truth for my machine setup.

Reproduction against 0.7.25:

```
$ ln -s "$R/repo/settings.json" "$R/home/.claude/settings.json"
$ ls -l "$R/home/.claude/settings.json"
lrwxr-xr-x  ... settings.json -> .../repo/settings.json

$ HCOM_DIR="$R/home/.hcom" hcom hooks add claude
Added Claude hooks  (.../home/.claude/settings.json)

$ ls -l "$R/home/.claude/settings.json"
-rw-------  4905  settings.json          # link is gone
$ grep -c hcom "$R/repo/settings.json"
0                                        # repo copy never got the hooks
```

## The fix: opt-in, not a change to the shared default

My first attempt made the shared primitive follow symlinks for every caller. That was wrong, and I'm glad I checked before you read it: `atomic_write` is used both by user-owned config writers (which want link preservation) and by hcom's own internal state files - the flag counters in `paths.rs`, the pidfile in `pidtrack.rs`, the update flags in `update.rs`, the relay pidfile in `relay/worker.rs`, the device id in `relay/mod.rs`. Those live under `~/.hcom` and gain nothing from following a link; making them follow one only hands them a redirection surface they didn't have before.

So the split is explicit:

- `atomic_write` / `atomic_write_io` - **unchanged behavior**: rename onto the literal path. Every internal state writer keeps its pre-PR redirection immunity by construction, with no edits at those call sites, and any future internal writer reaching for the default gets the safe behavior for free.
- `atomic_write_following_symlinks` / `_io` - **new, named opt-in** that resolves the link chain first. Wired only to the writers that legitimately need dotfiles-link preservation: the `config.rs` env/config.toml wrappers, the `hooks/*.rs` modules, and the cursor/copilot preprocessing writers.

Both funnel through one `write_atomically` so the pieces below apply to every atomic write, not just the symlink-following path.

Details worth noting in `resolve_write_target`:

- Relative link destinations resolve against the link's own directory; multi-hop chains mixing absolute and relative hops are covered by a test.
- A dangling link resolves to its missing target deliberately - that is the "linked into a checkout that has not created the file yet" case, where creating the target is what the user meant.
- Only `ErrorKind::NotFound` from `symlink_metadata` falls through to "write as given". Every other stat error propagates, so an `EACCES` on the final component can't be misread as "not a symlink" and quietly clobber a link.
- The chain is bounded at 8 hops, so a cycle returns `InvalidInput` rather than spinning.
- Resolution is **advisory, not a security boundary**. The doc comment names the resolve-then-rename TOCTOU explicitly and records the `O_DIRECTORY`-fd + relative-persist remedy if a stronger guarantee is ever wanted. Under hcom's per-user threat model, anyone able to plant a symlink in the config directory can already write the config file directly.

`preserve_target_mode` fixes a second, separate bug in the same primitive: an in-place atomic write over an existing regular file used to reset it to the tempfile's `0600`. Writing through a link into a repo turned a `0644` tracked file into `0600` - which happened to my own config repo before this was fixed. Now an existing regular destination keeps its mode, while a brand-new file still lands private at `0600`.

## Testing

24 tests in the `paths` module pass, `cargo clippy --all-targets -- -D warnings` is clean.

The behavioral tests were each proven to bite by reverting the specific hunk in place and observing the exact failure, then restoring:

| Test | Reverted-state failure |
|---|---|
| `test_atomic_write_io_does_not_follow_symlink` | link survived and the target was written through |
| `test_resolve_write_target_propagates_non_notfound_stat_error` | got `Ok` where `Err` is required |
| `test_atomic_write_io_preserves_existing_file_mode` | `left: 384 (0o600), right: 420 (0o644)` |
| `test_atomic_write_following_symlinks_writes_through_and_keeps_link` | same mode mismatch |

Coverage also includes absolute, relative, multi-hop and dangling links, cycle rejection, plain-file replacement, and that a new file is still created `0600`.

End to end against the real binary and trigger, same setup as the reproduction above:

```
released 0.7.25:  symlink=NO   hcom-hooks-in-repo-file=NO
this branch:      symlink=YES  hcom-hooks-in-repo-file=YES
```

The unrelated `model` key in the repo-side file was preserved, and all 13 hook events landed in it. I then ran the real thing: `hcom hooks add claude` and `hcom hooks add codex` against my live symlinked config, and both symlinks survived with the hook entries landing in the repo files.

## Known gap

Symlink resolution is only exercised on unix. I have no Windows host, and creating a file symlink on Windows needs elevation or Developer Mode, so a `#[cfg(windows)]` test would be unverifiable decoration rather than coverage. The logic is platform-agnostic `std::fs`, and the `cfg(windows)` persist path is untouched. Flagging it rather than pretending it is covered - the Windows CI jobs here exercise the no-follow default, not the following path.

## Note on the local suite

`cargo test` on my machine has 17 failures in `hooks::gemini::tests`. They reproduce identically on unmodified `main` at 79ebde1, and the root cause is machine-local: my `gemini-cli` is 0.19.2 and `try_setup_gemini_hooks` requires 0.26.0, so it returns `VersionUnsupported` before reaching anything this branch changes. Unrelated to this PR. Otherwise 2168 pass.
