### PR TITLE
feat(doing): let an agent advertise what it is working on

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -60,6 +60,8 @@ You MUST use `hcom <cmd+flags> --name {instance_name}` for all hcom commands:
   Or (for code/md/backticks) instead of --: --file <path> | --base64 <string> | pipe/heredoc
   Example: send {target_luna} {target_nova} --intent ack --reply-to 82 --name {instance_name} -- 'ok'
 - See who's active: list [-v] [--json] [--names] [--format '{{name}} {{status}}'] [name]
+- Say what YOU are working on: doing 'short description'
+  Others see it in their `list`. Update it when you switch tasks; `doing ""` clears it.
 - Read another's conversation: transcript [name] [N-M] [--last N] [--full] | transcript search 'text' [--all]
 - View events: events [--last N] [--all] [--sql EXPR] [filters]
   Filters (same flag=OR, different=AND): --agent NAME | --type message|status|life | --status listening|active|blocked | --cmd PATTERN (contains, ^prefix, =exact) | --file PATH (*.py for glob, file.py for contains)
@@ -210,6 +212,7 @@ Commands:
   {hcom_cmd} send {target_name_s} [--intent request|inform|ack] [--reply-to <id>] [--thread <thread_name>] -- <"message"> (or --stdin, --file <path>, --base64 <string>)
   Example: {hcom_cmd} send {target_luna} {target_nova} --intent ack --reply-to 82 --name {subagent_name} -- "ok"  |  Code/markdown: replace "ok" with --file <path>
   {hcom_cmd} list --name {subagent_name}
+  {hcom_cmd} doing 'short description' --name {subagent_name}   (what you are working on)
   {hcom_cmd} events --name {subagent_name}
   {hcom_cmd} <cmd> --help --name {subagent_name}
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -64,7 +64,7 @@ You MUST use `hcom <cmd+flags> --name {instance_name}` for all hcom commands:
   Others see it in their `list`. Update it when you switch tasks; `doing ""` clears it.
 - Read another's conversation: transcript [name] [N-M] [--last N] [--full] | transcript search 'text' [--all]
 - View events: events [--last N] [--all] [--sql EXPR] [filters]
-  Filters (same flag=OR, different=AND): --agent NAME | --type message|status|life | --status listening|active|blocked | --cmd PATTERN (contains, ^prefix, =exact) | --file PATH (*.py for glob, file.py for contains)
+  Filters (same flag=OR, different=AND): --agent NAME | --type message|status|life|doing | --status listening|active|blocked | --cmd PATTERN (contains, ^prefix, =exact) | --file PATH (*.py for glob, file.py for contains)
   Event-based notifications, watch agents, subscribe, react: events sub [filters] | --help
 - Handoff context: bundle prepare
 - Spawn agents: [num] <{launch_tools}> [--tag labelOrGroup] [--terminal tmux|kitty|wezterm|etc]

--- a/src/commands/doing.rs
+++ b/src/commands/doing.rs
@@ -75,6 +75,15 @@ pub fn cmd_doing(db: &HcomDb, args: &DoingArgs, ctx: Option<&CommandContext>) ->
 
     let text = args.text.join(" ");
     let text = text.trim();
+    // Write-boundary guard: `doing` is agent-authored free text rendered raw on
+    // peer terminals (inline roster, `-v`, `list <name>`, TUI) and replicated
+    // relay-wide, so it must satisfy the same control-char / size invariant as
+    // `hcom send`. It renders on a single roster line, so tabs/newlines are
+    // rejected too. Empty stays allowed as the intended clear.
+    if let Err(e) = crate::messages::validate_text_field(text, false) {
+        eprintln!("Error: {e}");
+        return 1;
+    }
     if let Err(e) = db.log_doing_event(&name, text) {
         eprintln!("Error: could not record activity: {e}");
         return 1;

--- a/src/commands/doing.rs
+++ b/src/commands/doing.rs
@@ -1,0 +1,89 @@
+//! `hcom doing` command — advertise what this agent is currently working on.
+//!
+//! First-person only: it records the CALLER's own activity, which other agents
+//! then read through `hcom list`. Stored as a `doing` event rather than an
+//! `instances` column because the hook lifecycle rewrites `status_context` and
+//! `status_detail` on every tool-use tick and would erase agent-authored text.
+
+use crate::db::HcomDb;
+use crate::identity;
+use crate::shared::{CommandContext, SenderKind};
+
+/// Parsed arguments for `hcom doing`.
+#[derive(clap::Parser, Debug)]
+#[command(
+    name = "doing",
+    about = "Set or show what you are currently working on"
+)]
+pub struct DoingArgs {
+    /// Activity text. Omit to print the current value; pass an empty string to clear it.
+    pub text: Vec<String>,
+}
+
+/// Resolve the calling instance's own name.
+///
+/// Returns None when the caller has no instance identity. `doing` is
+/// first-person, so an unidentified caller must be told to register rather than
+/// have its activity silently filed under a fallback name.
+///
+/// A name reaching here must belong to a registered instance: activity recorded
+/// against an unknown name would never surface in any listing, which is a silent
+/// no-op from the caller's point of view.
+fn resolve_self_name(db: &HcomDb, ctx: Option<&CommandContext>) -> Option<String> {
+    let candidate = if let Some(c) = ctx
+        && let Some(ref id) = c.identity
+        && matches!(id.kind, SenderKind::Instance)
+    {
+        id.name.clone()
+    } else if let Some(name) = ctx.and_then(|c| c.explicit_name.as_deref()) {
+        name.to_string()
+    } else {
+        match identity::resolve_identity(db, None, None, None, None, None, None) {
+            Ok(id) if matches!(id.kind, SenderKind::Instance) => id.name,
+            _ => return None,
+        }
+    };
+
+    match db.get_instance_full(&candidate) {
+        Ok(Some(_)) => Some(candidate),
+        _ => None,
+    }
+}
+
+/// Main entry point for `hcom doing`.
+///
+/// Returns exit code (0 = success, 1 = error).
+pub fn cmd_doing(db: &HcomDb, args: &DoingArgs, ctx: Option<&CommandContext>) -> i32 {
+    let Some(name) = resolve_self_name(db, ctx) else {
+        eprintln!(
+            "Error: no registered hcom agent for this session.\n\
+             Run 'hcom start' first, or pass --name <agent> naming one from 'hcom list'."
+        );
+        return 1;
+    };
+
+    if args.text.is_empty() {
+        let current = db.get_doing(&name);
+        if current.is_empty() {
+            println!("{name}: nothing set");
+            println!("Set it with: hcom doing \"what you are working on\"");
+        } else {
+            println!("{name}: {current}");
+        }
+        return 0;
+    }
+
+    let text = args.text.join(" ");
+    let text = text.trim();
+    if let Err(e) = db.log_doing_event(&name, text) {
+        eprintln!("Error: could not record activity: {e}");
+        return 1;
+    }
+
+    if text.is_empty() {
+        println!("{name}: cleared");
+    } else {
+        println!("{name}: {text}");
+    }
+    0
+}

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -1409,8 +1409,16 @@ mod tests {
     #[test]
     fn test_events_args_accept_doing_type() {
         use clap::Parser;
-        let args = EventsArgs::try_parse_from(["events", "--type", "doing"]).unwrap();
-        assert_eq!(args.filters.event_type, vec!["doing"]);
+        // Parse the SSOT const's value, then assert the parsed filter equals the
+        // const — so a rename of DOING_EVENT_TYPE that is not mirrored at the
+        // filter gate fails to compile/parse here rather than silently dropping
+        // `--type doing` results.
+        let args = EventsArgs::try_parse_from(["events", "--type", crate::db::DOING_EVENT_TYPE])
+            .unwrap();
+        assert_eq!(
+            args.filters.event_type,
+            vec![crate::db::DOING_EVENT_TYPE.to_string()]
+        );
     }
 
     #[test]

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -519,7 +519,7 @@ fn cmd_events_sub(db: &HcomDb, args: &EventsSubArgs, caller_name: Option<&str>) 
              \x20   --on-hit <TEXT>                 Attach message (sent from caller) when sub fires\n\n\
              Filters (same flag repeated = OR, different flags = AND):\n\
              \x20 --agent NAME                      Agent name\n\
-             \x20 --type TYPE                       message | status | life\n\
+             \x20 --type TYPE                       message | status | life | doing\n\
              \x20 --status VAL                      listening | active | blocked\n\
              \x20 --context PATTERN                 tool:Bash | deliver:X (supports * wildcard)\n\
              \x20 --action VAL                      created | started | ready | stopped | batch_launched | launch_failed | launch_blocked\n\
@@ -1401,6 +1401,16 @@ mod tests {
         assert_eq!(args.filters.agent, vec!["peso"]);
         assert_eq!(args.filters.event_type, vec!["message"]);
         assert!(args.subcmd.is_none());
+    }
+
+    /// The `--type` filter is a closed clap enum, so a newly logged event type
+    /// is unreachable through `events`/`listen`/`events sub` until it is added
+    /// there too. `doing` is written by `hcom doing`.
+    #[test]
+    fn test_events_args_accept_doing_type() {
+        use clap::Parser;
+        let args = EventsArgs::try_parse_from(["events", "--type", "doing"]).unwrap();
+        assert_eq!(args.filters.event_type, vec!["doing"]);
     }
 
     #[test]

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -151,7 +151,7 @@ const LIST_HELP: &[HelpEntry] = &[
     ),
     (
         "",
-        "  status_age_seconds, description, unread_count, tool, tag, directory,",
+        "  status_age_seconds, description, doing, unread_count, tool, tag, directory,",
     ),
     (
         "",
@@ -364,6 +364,16 @@ const BUNDLE_HELP: &[HelpEntry] = &[
     ("", ""),
     ("bundle chain <id>", "Show bundle lineage"),
     ("  --json", "Output JSON"),
+];
+
+const DOING_HELP: &[HelpEntry] = &[
+    ("doing \"<text>\"", "Say what you are working on"),
+    ("doing", "Show what you last said you were working on"),
+    ("doing \"\"", "Clear it"),
+    ("", ""),
+    ("", "Other agents see it in hcom list and hcom list <name>."),
+    ("", "Survives hook status updates, unlike status_detail."),
+    ("", ""),
 ];
 
 const STOP_HELP: &[HelpEntry] = &[
@@ -915,6 +925,7 @@ Commands:\n\
   send         Send message to your buddies\n\
   listen       Block until message or event arrives\n\
   list         Show agents, status, unread counts\n\
+  doing        Say what you are working on (others see it in list)\n\
   events       Query event stream, manage subscriptions\n\
   bundle       Structured context packages for handoffs\n\
   transcript   Read another agent's conversation\n\
@@ -1031,6 +1042,7 @@ pub fn get_command_help(name: &str) -> String {
 
     let entries: Option<&[HelpEntry]> = match name {
         "list" => Some(LIST_HELP),
+        "doing" => Some(DOING_HELP),
         "send" => Some(SEND_HELP),
         "bundle" => Some(BUNDLE_HELP),
         "stop" => Some(STOP_HELP),

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -52,7 +52,6 @@ pub struct ListArgs {
     pub last: Option<usize>,
 }
 
-/// Get unread message count for a single instance.
 /// Truncate display text at a char boundary, appending an ellipsis when cut.
 fn truncate_display(text: &str, max: usize) -> String {
     if text.len() <= max {
@@ -65,6 +64,7 @@ fn truncate_display(text: &str, max: usize) -> String {
     format!("{}...", &text[..end])
 }
 
+/// Get unread message count for a single instance.
 fn get_unread_count(db: &HcomDb, name: &str, last_event_id: i64) -> i64 {
     db.conn()
         .query_row(

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -53,6 +53,18 @@ pub struct ListArgs {
 }
 
 /// Get unread message count for a single instance.
+/// Truncate display text at a char boundary, appending an ellipsis when cut.
+fn truncate_display(text: &str, max: usize) -> String {
+    if text.len() <= max {
+        return text.to_string();
+    }
+    let end = (0..=max)
+        .rev()
+        .find(|&i| text.is_char_boundary(i))
+        .unwrap_or(0);
+    format!("{}...", &text[..end])
+}
+
 fn get_unread_count(db: &HcomDb, name: &str, last_event_id: i64) -> i64 {
     db.conn()
         .query_row(
@@ -222,6 +234,8 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
 
     if json_output || format_template.is_some() {
         let mut result_list: Vec<serde_json::Value> = Vec::new();
+        // One query for the whole listing rather than one per agent.
+        let doing_map = db.get_doing_map();
 
         for data in &sorted_instances {
             let full_name = get_full_name(data);
@@ -247,6 +261,7 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
                 "status_detail": data.status_detail,
                 "status_age_seconds": age_seconds,
                 "description": description,
+                "doing": doing_map.get(&data.name).cloned().unwrap_or_default(),
                 "unread_count": unread_counts.get(&data.name).copied().unwrap_or(0),
                 "headless": data.background != 0,
                 "session_id": data.session_id.as_deref().unwrap_or(""),
@@ -365,6 +380,8 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
         max_name_len = max_name_len.max(n);
     }
     let name_col_width = (max_name_len + 2).max(14);
+    // One query for the whole listing rather than one per agent.
+    let doing_map = db.get_doing_map();
 
     for data in &sorted_instances {
         let name = get_full_name(data);
@@ -452,9 +469,17 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
             String::new()
         };
 
+        // Self-reported activity, so a glance at the roster shows what each
+        // agent is working on and not merely whether it is awake.
+        let doing_text = match doing_map.get(&data.name) {
+            Some(doing) if !doing.is_empty() => format!(" - {}", truncate_display(doing, 50)),
+            _ => String::new(),
+        };
+
         let name_part = format!("{name}{headless_badge}{remote_badge}{unread_str}");
-        let status_text =
-            format!("{age_display}{desc_sep}{description}{listening_since}{timeout_marker}");
+        let status_text = format!(
+            "{age_display}{desc_sep}{description}{listening_since}{timeout_marker}{doing_text}"
+        );
 
         println!(
             "{tool_prefix}{icon} {name_part:<width$}{status_text}",
@@ -531,16 +556,14 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
             println!("    transcript:   {transcript}");
 
             if !data.status_detail.is_empty() {
-                let detail = if data.status_detail.len() > 60 {
-                    let end = (0..=60)
-                        .rev()
-                        .find(|&i| data.status_detail.is_char_boundary(i))
-                        .unwrap_or(0);
-                    format!("{}...", &data.status_detail[..end])
-                } else {
-                    data.status_detail.clone()
-                };
-                println!("    detail:       {detail}");
+                println!(
+                    "    detail:       {}",
+                    truncate_display(&data.status_detail, 60)
+                );
+            }
+            // Untruncated here: -v is where you go for the full text.
+            if let Some(doing) = doing_map.get(&data.name).filter(|d| !d.is_empty()) {
+                println!("    doing:        {doing}");
             }
             println!();
         }
@@ -605,6 +628,13 @@ fn print_instance_details(db: &HcomDb, data: &InstanceRow, display_name: &str) {
     };
 
     println!("{display_name}:");
+
+    // What the agent says it is working on, ahead of the mechanical fields:
+    // it is the first thing a peer inspecting this agent wants.
+    let doing = db.get_doing(&data.name);
+    if !doing.is_empty() {
+        println!("  Doing:       {doing}");
+    }
 
     // Core Identity
     let headless_str = if data.background != 0 {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod stop;
 
 // Diagnostics
 pub mod bundle;
+pub mod doing;
 pub mod events;
 pub mod list;
 pub mod status;

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -465,6 +465,14 @@ fn start_rebind(
         Some(&cwd_override),
     );
 
+    // A reclaim recreates the identity fresh (new instances row, cursor treated
+    // as a delivery boundary above), so the prior occupant's self-reported
+    // `doing` must not carry over — doing derivation is latest-event-wins per
+    // name with no lifetime scoping, so append an empty doing to reset it blank.
+    if let Err(e) = db.log_doing_event(&target_name, "") {
+        eprintln!("[hcom] warn: reset doing failed for {target_name}: {e}");
+    }
+
     if let Some(ref sid) = session_id {
         let old_root = if current_name.is_empty() {
             target_name.as_str()
@@ -1174,6 +1182,39 @@ mod tests {
             db.get_session_binding("sess-rebind").unwrap().as_deref(),
             Some("nova"),
             "a start after the rebind returns the reclaimed identity"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_rebind_reclaim_clears_prior_doing() {
+        let (_dir, hcom_dir, _home, _guard) = crate::hooks::test_helpers::isolated_test_env();
+        let db = HcomDb::open().unwrap();
+        assert!(crate::hooks::claude::setup_claude_hooks(false));
+
+        // The prior occupant of the name advertised what it was working on.
+        db.log_doing_event("nova", "refactoring auth").unwrap();
+        assert_eq!(db.get_doing("nova"), "refactoring auth");
+
+        // A different session reclaims the name via `start --as nova`.
+        let ctx = make_claude_ctx(
+            Some(("CLAUDE_CODE_SESSION_ID", "sess-reclaim")),
+            "/tmp/project",
+        );
+        assert_eq!(start_bare(&db, &hcom_dir, &ctx, None).unwrap(), 0);
+        assert_eq!(start_rebind(&db, "nova", &ctx, None).unwrap(), 0);
+
+        // The reclaimed identity must start blank, not inherit stale doing text
+        // this session never wrote.
+        assert_eq!(
+            db.get_doing("nova"),
+            "",
+            "a reclaimed name must not inherit the prior occupant's doing text"
+        );
+        assert_eq!(
+            db.get_doing_map().get("nova").map(String::as_str),
+            Some(""),
+            "the reclaimed name's doing resolves empty, which the roster renders as no activity"
         );
     }
 

--- a/src/core/filters.rs
+++ b/src/core/filters.rs
@@ -454,7 +454,7 @@ fn parse_timestamp(s: &str) -> Result<String, String> {
 pub struct EventFilterArgs {
     #[arg(long)]
     pub agent: Vec<String>,
-    #[arg(long = "type", value_parser = clap::builder::PossibleValuesParser::new(["message", "status", "life"]))]
+    #[arg(long = "type", value_parser = clap::builder::PossibleValuesParser::new(["message", "status", "life", "doing"]))]
     pub event_type: Vec<String>,
     #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(["active", "listening", "blocked", "inactive", "launching", "error"]))]
     pub status: Vec<String>,

--- a/src/core/filters.rs
+++ b/src/core/filters.rs
@@ -454,7 +454,7 @@ fn parse_timestamp(s: &str) -> Result<String, String> {
 pub struct EventFilterArgs {
     #[arg(long)]
     pub agent: Vec<String>,
-    #[arg(long = "type", value_parser = clap::builder::PossibleValuesParser::new(["message", "status", "life", "doing"]))]
+    #[arg(long = "type", value_parser = clap::builder::PossibleValuesParser::new(["message", "status", "life", crate::db::DOING_EVENT_TYPE]))]
     pub event_type: Vec<String>,
     #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(["active", "listening", "blocked", "inactive", "launching", "error"]))]
     pub status: Vec<String>,

--- a/src/db/events.rs
+++ b/src/db/events.rs
@@ -21,12 +21,19 @@ pub fn doing_map_from_conn(
            ON e.id = m.id",
     ) {
         Ok(stmt) => stmt,
-        Err(_) => return std::collections::HashMap::new(),
+        Err(e) => {
+            crate::log::log_error("db", "doing_map_from_conn.prepare", &format!("{e}"));
+            return std::collections::HashMap::new();
+        }
     };
-    let Ok(rows) = stmt.query_map(params![DOING_EVENT_TYPE], |row| {
+    let rows = match stmt.query_map(params![DOING_EVENT_TYPE], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-    }) else {
-        return std::collections::HashMap::new();
+    }) {
+        Ok(rows) => rows,
+        Err(e) => {
+            crate::log::log_error("db", "doing_map_from_conn.query", &format!("{e}"));
+            return std::collections::HashMap::new();
+        }
     };
     rows.filter_map(|row| row.ok())
         .filter_map(|(instance, data)| doing_text_from_data(&data).map(|text| (instance, text)))

--- a/src/db/events.rs
+++ b/src/db/events.rs
@@ -5,6 +5,43 @@ use rusqlite::params;
 
 use super::{HcomDb, chrono_now_iso, subscriptions};
 
+/// Event type carrying an agent's self-reported current activity (`hcom doing`).
+pub const DOING_EVENT_TYPE: &str = "doing";
+
+/// Latest self-reported activity for every instance that has set one.
+///
+/// Takes a raw connection so `HcomDb::get_doing_map` and the TUI's snapshot
+/// loader (which only has a `Connection`) share one definition of this query.
+pub fn doing_map_from_conn(
+    conn: &rusqlite::Connection,
+) -> std::collections::HashMap<String, String> {
+    let mut stmt = match conn.prepare(
+        "SELECT e.instance, e.data FROM events e
+         JOIN (SELECT instance, MAX(id) AS id FROM events WHERE type = ? GROUP BY instance) m
+           ON e.id = m.id",
+    ) {
+        Ok(stmt) => stmt,
+        Err(_) => return std::collections::HashMap::new(),
+    };
+    let Ok(rows) = stmt.query_map(params![DOING_EVENT_TYPE], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    }) else {
+        return std::collections::HashMap::new();
+    };
+    rows.filter_map(|row| row.ok())
+        .filter_map(|(instance, data)| doing_text_from_data(&data).map(|text| (instance, text)))
+        .collect()
+}
+
+/// Pull the activity text out of a `doing` event's stored JSON payload.
+fn doing_text_from_data(data: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(data)
+        .ok()?
+        .get("text")
+        .and_then(|value| value.as_str())
+        .map(String::from)
+}
+
 /// Message from the events table
 #[derive(Debug, Clone)]
 pub struct Message {
@@ -559,6 +596,41 @@ impl HcomDb {
         Ok(rows)
     }
 
+    /// Record what an instance says it is currently working on.
+    ///
+    /// Stored as an event rather than an `instances` column so it survives the
+    /// hook lifecycle: `status_context`/`status_detail` are rewritten on every
+    /// tool-use tick, which would erase agent-authored text. Being an event also
+    /// makes it subscribable through the ordinary `events` filters.
+    pub fn log_doing_event(&self, instance: &str, text: &str) -> Result<i64> {
+        self.log_event(
+            DOING_EVENT_TYPE,
+            instance,
+            &serde_json::json!({ "text": text }),
+        )
+    }
+
+    /// What one instance last said it was working on. Empty when never set.
+    pub fn get_doing(&self, instance: &str) -> String {
+        self.conn
+            .query_row(
+                "SELECT data FROM events WHERE type = ? AND instance = ? ORDER BY id DESC LIMIT 1",
+                params![DOING_EVENT_TYPE, instance],
+                |row| row.get::<_, String>(0),
+            )
+            .ok()
+            .and_then(|data| doing_text_from_data(&data))
+            .unwrap_or_default()
+    }
+
+    /// Latest self-reported activity for every instance that has set one.
+    ///
+    /// One query for the whole listing rather than a per-instance lookup, so
+    /// `hcom list` does not issue N queries for N agents.
+    pub fn get_doing_map(&self) -> std::collections::HashMap<String, String> {
+        doing_map_from_conn(&self.conn)
+    }
+
     /// Get current maximum event ID, or 0 if no events.
     pub fn get_last_event_id(&self) -> i64 {
         self.conn
@@ -602,6 +674,52 @@ impl HcomDb {
 #[cfg(test)]
 mod tests {
     use super::super::tests::{cleanup_test_db, setup_full_test_db};
+
+    #[test]
+    fn test_doing_round_trip() {
+        let (db, db_path) = setup_full_test_db();
+
+        assert_eq!(db.get_doing("luna"), "");
+        db.log_doing_event("luna", "refactoring the auth layer")
+            .unwrap();
+        assert_eq!(db.get_doing("luna"), "refactoring the auth layer");
+
+        cleanup_test_db(db_path);
+    }
+
+    #[test]
+    fn test_doing_latest_wins() {
+        let (db, db_path) = setup_full_test_db();
+
+        db.log_doing_event("luna", "first").unwrap();
+        db.log_doing_event("luna", "second").unwrap();
+        assert_eq!(db.get_doing("luna"), "second");
+
+        // Empty text is how an agent clears it — not a no-op write.
+        db.log_doing_event("luna", "").unwrap();
+        assert_eq!(db.get_doing("luna"), "");
+
+        cleanup_test_db(db_path);
+    }
+
+    #[test]
+    fn test_doing_map_is_per_instance_latest() {
+        let (db, db_path) = setup_full_test_db();
+
+        db.log_doing_event("luna", "luna-old").unwrap();
+        db.log_doing_event("nova", "nova-only").unwrap();
+        db.log_doing_event("luna", "luna-new").unwrap();
+        // An unrelated event type must not leak into the map.
+        db.log_event("status", "zeta", &serde_json::json!({"status": "active"}))
+            .unwrap();
+
+        let map = db.get_doing_map();
+        assert_eq!(map.get("luna").map(String::as_str), Some("luna-new"));
+        assert_eq!(map.get("nova").map(String::as_str), Some("nova-only"));
+        assert!(!map.contains_key("zeta"));
+
+        cleanup_test_db(db_path);
+    }
 
     #[test]
     fn test_log_event_returns_id() {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -32,6 +32,7 @@ mod sessions;
 pub(crate) mod subscriptions;
 
 pub use events::Message;
+pub use events::doing_map_from_conn;
 pub use instances::InstanceRow;
 #[allow(unused_imports)]
 pub use instances::InstanceStatus;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -32,7 +32,7 @@ mod sessions;
 pub(crate) mod subscriptions;
 
 pub use events::Message;
-pub use events::doing_map_from_conn;
+pub use events::{DOING_EVENT_TYPE, doing_map_from_conn};
 pub use instances::InstanceRow;
 #[allow(unused_imports)]
 pub use instances::InstanceStatus;

--- a/src/hooks/common.rs
+++ b/src/hooks/common.rs
@@ -53,6 +53,7 @@ pub(crate) fn dispatch_with_panic_guard<R>(
 pub(crate) const SAFE_HCOM_COMMANDS: &[&str] = &[
     "send",
     "start",
+    "doing",
     "help",
     "--help",
     "-h",

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -123,31 +123,50 @@ impl InstanceInfo {
 // validate_scope and validate_intent live in core::helpers — re-export for consumers.
 pub use crate::core::helpers::{validate_intent, validate_scope};
 
+/// Validate agent-authored free text before it is stored as an event and later
+/// rendered raw onto peer terminals.
+///
+/// This is the single write-boundary guard for the "unvalidated free text into
+/// events" class: it rejects C0/C1 control characters (including ESC 0x1B, which
+/// enables terminal-escape injection) and caps size at [`MAX_MESSAGE_SIZE`], so
+/// every downstream sink — inline roster, `-v`, `list <name>`, TUI, relay
+/// replication — is safe by construction regardless of how it prints the text.
+///
+/// `allow_line_whitespace` distinguishes multi-line fields (message bodies) from
+/// single-line fields (`doing`, rendered on one roster row): when `false`, tab,
+/// newline and carriage return are rejected too, so the value cannot break out
+/// of its display line.
+///
+/// Empty input is accepted here; callers that require content (e.g. `send`)
+/// enforce that separately, while callers that treat empty as a clear (`doing`)
+/// rely on it being allowed.
+pub fn validate_text_field(text: &str, allow_line_whitespace: bool) -> Result<(), String> {
+    for ch in text.chars() {
+        if ch == '\t' || ch == '\n' || ch == '\r' {
+            if allow_line_whitespace {
+                continue;
+            }
+            return Err("Text must be a single line (no tabs or newlines)".to_string());
+        }
+        if ('\x00'..='\x1F').contains(&ch) || ('\u{0080}'..='\u{009F}').contains(&ch) {
+            return Err("Text contains control characters".to_string());
+        }
+    }
+
+    if text.len() > MAX_MESSAGE_SIZE {
+        return Err(format!("Text too large (max {} chars)", MAX_MESSAGE_SIZE));
+    }
+
+    Ok(())
+}
+
 /// Validate message content and size.
 pub fn validate_message(message: &str) -> Result<(), String> {
     if message.is_empty() || message.trim().is_empty() {
         return Err("Message required".to_string());
     }
 
-    // Reject control characters (except \n, \r, \t)
-    for ch in message.chars() {
-        if ('\x00'..='\x08').contains(&ch)
-            || ('\x0B'..='\x0C').contains(&ch)
-            || ('\x0E'..='\x1F').contains(&ch)
-            || ('\u{0080}'..='\u{009F}').contains(&ch)
-        {
-            return Err("Message contains control characters".to_string());
-        }
-    }
-
-    if message.len() > MAX_MESSAGE_SIZE {
-        return Err(format!(
-            "Message too large (max {} chars)",
-            MAX_MESSAGE_SIZE
-        ));
-    }
-
-    Ok(())
+    validate_text_field(message, true)
 }
 
 /// Format recipients list for display.
@@ -951,6 +970,36 @@ mod tests {
     fn test_validate_message_too_large() {
         let big = "x".repeat(MAX_MESSAGE_SIZE + 1);
         assert!(validate_message(&big).is_err());
+    }
+
+    // ---- validate_text_field ----
+
+    #[test]
+    fn test_validate_text_field_rejects_esc_and_c1() {
+        // ESC (0x1B) is the terminal-escape-injection vector; rejected in both modes.
+        assert!(validate_text_field("a\x1b[2Jb", true).is_err());
+        assert!(validate_text_field("a\x1b[2Jb", false).is_err());
+        // C1 control range is rejected too.
+        assert!(validate_text_field("a\u{0085}b", true).is_err());
+    }
+
+    #[test]
+    fn test_validate_text_field_single_line_rejects_line_whitespace() {
+        // Single-line fields (doing) reject tabs/newlines/CR that would break the row...
+        assert!(validate_text_field("line1\nline2", false).is_err());
+        assert!(validate_text_field("a\tb", false).is_err());
+        assert!(validate_text_field("a\rb", false).is_err());
+        // ...while multi-line fields (message bodies) accept them.
+        assert!(validate_text_field("line1\nline2\ttab", true).is_ok());
+    }
+
+    #[test]
+    fn test_validate_text_field_allows_empty_and_caps_size() {
+        // Empty is allowed (the `doing` clear); size is capped in both modes.
+        assert!(validate_text_field("", false).is_ok());
+        let big = "x".repeat(MAX_MESSAGE_SIZE + 1);
+        assert!(validate_text_field(&big, false).is_err());
+        assert!(validate_text_field(&big, true).is_err());
     }
 
     // ---- format_recipients ----

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -127,10 +127,14 @@ pub use crate::core::helpers::{validate_intent, validate_scope};
 /// rendered raw onto peer terminals.
 ///
 /// This is the single write-boundary guard for the "unvalidated free text into
-/// events" class: it rejects C0/C1 control characters (including ESC 0x1B, which
-/// enables terminal-escape injection) and caps size at [`MAX_MESSAGE_SIZE`], so
-/// every downstream sink — inline roster, `-v`, `list <name>`, TUI, relay
-/// replication — is safe by construction regardless of how it prints the text.
+/// events" class: it rejects the Cc control characters — C0 (0x00-0x1F, including
+/// ESC 0x1B, which enables terminal-escape injection), DEL (0x7F), and C1
+/// (U+0080-U+009F) — plus the bidirectional formatting controls (U+202A-202E,
+/// U+2066-2069) that enable Trojan-Source-style visual reordering, and caps size
+/// at [`MAX_MESSAGE_SIZE`], so every downstream sink — inline roster, `-v`,
+/// `list <name>`, TUI, relay replication — is safe by construction regardless of
+/// how it prints the text. Other `Cf` format chars (e.g. ZWJ U+200D used in
+/// legitimate emoji sequences) are deliberately left allowed.
 ///
 /// `allow_line_whitespace` distinguishes multi-line fields (message bodies) from
 /// single-line fields (`doing`, rendered on one roster row): when `false`, tab,
@@ -148,13 +152,21 @@ pub fn validate_text_field(text: &str, allow_line_whitespace: bool) -> Result<()
             }
             return Err("Text must be a single line (no tabs or newlines)".to_string());
         }
-        if ('\x00'..='\x1F').contains(&ch) || ('\u{0080}'..='\u{009F}').contains(&ch) {
+        if ('\x00'..='\x1F').contains(&ch)
+            || ch == '\x7f'
+            || ('\u{0080}'..='\u{009F}').contains(&ch)
+        {
             return Err("Text contains control characters".to_string());
+        }
+        // Bidirectional overrides/embeddings/isolates let a single line render
+        // visually reordered on peer terminals (Trojan-Source-style spoofing).
+        if ('\u{202A}'..='\u{202E}').contains(&ch) || ('\u{2066}'..='\u{2069}').contains(&ch) {
+            return Err("Text contains bidirectional control characters".to_string());
         }
     }
 
     if text.len() > MAX_MESSAGE_SIZE {
-        return Err(format!("Text too large (max {} chars)", MAX_MESSAGE_SIZE));
+        return Err(format!("Text too large (max {} bytes)", MAX_MESSAGE_SIZE));
     }
 
     Ok(())
@@ -981,6 +993,26 @@ mod tests {
         assert!(validate_text_field("a\x1b[2Jb", false).is_err());
         // C1 control range is rejected too.
         assert!(validate_text_field("a\u{0085}b", true).is_err());
+    }
+
+    #[test]
+    fn test_validate_text_field_rejects_del_and_bidi_controls() {
+        // DEL (0x7F) is a Cc control the guard's contract covers; rejected in both modes.
+        assert!(validate_text_field("a\x7fb", true).is_err());
+        assert!(validate_text_field("a\x7fb", false).is_err());
+        // Bidi override/embedding/isolate controls enable Trojan-Source visual
+        // reordering on a single roster line; rejected in both modes.
+        for c in ['\u{202A}', '\u{202B}', '\u{202C}', '\u{202D}', '\u{202E}'] {
+            assert!(validate_text_field(&format!("a{c}b"), false).is_err());
+            assert!(validate_text_field(&format!("a{c}b"), true).is_err());
+        }
+        for c in ['\u{2066}', '\u{2067}', '\u{2068}', '\u{2069}'] {
+            assert!(validate_text_field(&format!("a{c}b"), false).is_err());
+            assert!(validate_text_field(&format!("a{c}b"), true).is_err());
+        }
+        // Other Cf format chars stay allowed: ZWJ in a legitimate emoji sequence.
+        assert!(validate_text_field("\u{1F469}\u{200D}\u{1F4BB}", false).is_ok());
+        assert!(validate_text_field("\u{1F469}\u{200D}\u{1F4BB}", true).is_ok());
     }
 
     #[test]

--- a/src/router.rs
+++ b/src/router.rs
@@ -23,6 +23,7 @@ fn is_hook(name: &str) -> bool {
 const COMMANDS: &[&str] = &[
     "send",
     "list",
+    "doing",
     "events",
     "stop",
     "start",
@@ -594,6 +595,7 @@ pub fn dispatch() -> anyhow::Result<()> {
                 cmd.as_str(),
                 "send"
                     | "list"
+                    | "doing"
                     | "stop"
                     | "listen"
                     | "events"
@@ -814,6 +816,9 @@ fn dispatch_native_command(cmd: &str, args: &[String]) -> i32 {
         },
         "list" => clap_dispatch!(crate::commands::list::ListArgs, cmd, &cmd_argv, |args| {
             crate::commands::list::cmd_list(&db, &args, Some(&ctx))
+        }),
+        "doing" => clap_dispatch!(crate::commands::doing::DoingArgs, cmd, &cmd_argv, |args| {
+            crate::commands::doing::cmd_doing(&db, &args, Some(&ctx))
         }),
         "stop" => clap_dispatch!(crate::commands::stop::StopArgs, cmd, &cmd_argv, |args| {
             crate::commands::stop::cmd_stop(&db, &args, Some(&ctx))

--- a/src/tui/db.rs
+++ b/src/tui/db.rs
@@ -233,6 +233,7 @@ fn load_all(conn: &Connection, default_limit: usize) -> DataState {
         relay_enabled,
         relay_health,
         search_results: None,
+        doing: crate::db::doing_map_from_conn(conn),
     }
 }
 

--- a/src/tui/render/agents.rs
+++ b/src/tui/render/agents.rs
@@ -1060,6 +1060,18 @@ fn build_agent_detail(agent: &Agent, app: &App, lines: &mut Vec<Line<'static>>, 
     finalize_detail_spans(&mut info, w);
     lines.push(Line::from(info));
 
+    // Line 3 (when set): what the agent says it is working on. Its own line
+    // because it is free text an agent wrote, not a fixed-width status field.
+    if let Some(doing) = app.data.doing.get(&agent.name).filter(|d| !d.is_empty()) {
+        let mut activity: Vec<Span<'static>> = vec![
+            Span::raw("  "),
+            Span::styled("doing: ", Theme::separator()),
+            Span::styled(doing.clone(), Theme::agent_context()),
+        ];
+        finalize_detail_spans(&mut activity, w);
+        lines.push(Line::from(activity));
+    }
+
     // Separator line
     let dashes = "\u{254c}".repeat(w.saturating_sub(4) as usize);
     lines.push(Line::from(vec![

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -23,6 +23,11 @@ pub struct DataState {
     pub relay_health: crate::relay::RelayHealth,
     /// FTS search results. `Some` when a text search query is active (both inline and vertical modes).
     pub search_results: Option<(Vec<Message>, Vec<Event>)>,
+    /// Self-reported activity per agent name (`hcom doing`), latest wins.
+    ///
+    /// Held beside the agents rather than on `Agent` because it comes from the
+    /// event log, not the `instances` row the agent list is built from.
+    pub doing: std::collections::HashMap<String, String>,
 }
 
 impl DataState {
@@ -37,6 +42,7 @@ impl DataState {
             relay_enabled: false,
             relay_health: crate::relay::RelayHealth::NotConfigured,
             search_results: None,
+            doing: std::collections::HashMap::new(),
         }
     }
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1236,3 +1236,29 @@ fn doing_rejects_an_unregistered_agent() {
     let (code, stdout, stderr) = h.run(["doing", "--name", "ghost", "something"]);
     assert_ne!(code, 0, "expected failure; stdout={stdout} stderr={stderr}");
 }
+
+#[test]
+fn doing_rejects_terminal_escape_and_newline_injection() {
+    let h = Hcom::new();
+    let me = h.start();
+
+    // Terminal-escape injection: an ESC (0x1B) sequence would clear/recolor a
+    // peer's screen and fake a roster row when rendered raw via println!. It
+    // must be rejected at the write boundary and never stored.
+    let (code, _stdout, stderr) =
+        h.run(["doing", "--name", &me, "\x1b[2J\x1b[31mSYSTEM ALERT"]);
+    assert_ne!(code, 0, "escape sequence must be rejected; stderr={stderr}");
+
+    // Newline injection: `doing` renders on one roster line, so a value that
+    // spans lines (fabricating extra rows) must also be rejected.
+    let (code, _stdout, stderr) =
+        h.run(["doing", "--name", &me, "active - now\n  o admin - active"]);
+    assert_ne!(code, 0, "newline must be rejected; stderr={stderr}");
+
+    // Neither rejected write leaked into the roster: `doing` is still unset.
+    let (_, stdout, _) = h.run(["doing", "--name", &me]);
+    assert!(
+        stdout.contains("nothing set"),
+        "rejected writes must not be stored; stdout={stdout}"
+    );
+}

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1165,3 +1165,74 @@ fn pi_e2e_hook_dispatch() {
         .unwrap_or_else(|| panic!("stopped event missing: {stdout}"));
     assert_eq!(stopped["data"]["action"].as_str(), Some("stopped"));
 }
+
+#[test]
+fn doing_is_set_read_and_seen_by_peers() {
+    let h = Hcom::new();
+    let me = h.start();
+
+    // Nothing set yet: say so, and say how to set it.
+    let (code, stdout, stderr) = h.run(["doing", "--name", &me]);
+    assert_eq!(code, 0, "doing (empty) stderr={stderr}");
+    assert!(stdout.contains("nothing set"), "stdout={stdout}");
+    assert!(stdout.contains("hcom doing"), "stdout={stdout}");
+
+    let (code, stdout, stderr) = h.run(["doing", "--name", &me, "refactoring the auth layer"]);
+    assert_eq!(code, 0, "doing (set) stderr={stderr}");
+    assert!(
+        stdout.contains("refactoring the auth layer"),
+        "stdout={stdout}"
+    );
+
+    // Readable back by the setter.
+    let (_, stdout, _) = h.run(["doing", "--name", &me]);
+    assert!(
+        stdout.contains("refactoring the auth layer"),
+        "stdout={stdout}"
+    );
+
+    // And visible to anyone reading the roster — the point of the feature.
+    let (code, stdout, stderr) = h.run(["list", "--json"]);
+    assert_eq!(code, 0, "list --json stderr={stderr}");
+    let agents: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("list json: {e}\n{stdout}"));
+    let mine = agents
+        .as_array()
+        .and_then(|a| a.iter().find(|v| v["base_name"] == me.as_str()))
+        .unwrap_or_else(|| panic!("{me} missing from list: {stdout}"));
+    assert_eq!(
+        mine["doing"].as_str(),
+        Some("refactoring the auth layer"),
+        "list json={stdout}"
+    );
+
+    let (_, stdout, _) = h.run(["list", "--format", "{name} {doing}"]);
+    assert!(
+        stdout.contains("refactoring the auth layer"),
+        "stdout={stdout}"
+    );
+
+    // Latest write wins.
+    let (code, _, stderr) = h.run(["doing", "--name", &me, "now writing tests"]);
+    assert_eq!(code, 0, "doing (update) stderr={stderr}");
+    let (_, stdout, _) = h.run(["list", "--format", "{doing}"]);
+    assert!(stdout.contains("now writing tests"), "stdout={stdout}");
+    assert!(
+        !stdout.contains("refactoring"),
+        "stale value retained: {stdout}"
+    );
+
+    // Empty string clears it.
+    let (code, _, stderr) = h.run(["doing", "--name", &me, ""]);
+    assert_eq!(code, 0, "doing (clear) stderr={stderr}");
+    let (_, stdout, _) = h.run(["doing", "--name", &me]);
+    assert!(stdout.contains("nothing set"), "stdout={stdout}");
+}
+
+#[test]
+fn doing_rejects_an_unregistered_agent() {
+    let h = Hcom::new();
+    // Recording activity for a name nobody can look up would be a silent no-op.
+    let (code, stdout, stderr) = h.run(["doing", "--name", "ghost", "something"]);
+    assert_ne!(code, 0, "expected failure; stdout={stdout} stderr={stderr}");
+}


### PR DESCRIPTION
## Why

hcom tells you whether an agent is awake, not what it is doing. `status` is a fixed lifecycle enum (`active`/`listening`/`blocked`/`inactive`/`launching`/`error`), and there is no field an agent can deliberately set to describe its current task. A peer deciding whether to interrupt, hand off, or wait has to open a transcript to find out.

This adds one verb so an agent can say it, and shows it everywhere the roster is already displayed.

```
hcom doing "refactoring the auth layer"   # set
hcom doing                                # show
hcom doing ""                             # clear
```

Peers read it in `hcom list` (inline, truncated to 50 chars), `hcom list -v`, `hcom list <name>`, `--json`, `--format '{doing}'`, the TUI agent detail pane, and `hcom events --type doing`.

## Why an event and not an instances column

- `status_context` / `status_detail` are rewritten by hooks on every tool-use tick, and `set_gate_status` explicitly overwrites `status_detail` unless it equals the one `"cmd:listen"` sentinel - so agent-authored text there does not survive. `hints` is reinjected into the owning agent's own message feedback and never appears in `list` output. `notes` is baked into the launch prompt once and is not a live field.
- No schema change: no `SCHEMA_VERSION` bump, no `MIGRATIONS` entry, nothing for existing databases to migrate.
- `hcom list --stopped` already derives current state from `life` events, so latest-event-wins is an established pattern here rather than a new one.
- Being an event makes it filterable and subscribable through the machinery that already exists.

A column would also have meant touching the positional-index `instance_row_to_json`, roughly 20 `InstanceRow`/`Agent` struct literals in test fixtures, and the TUI's separate hand-written query - about 30 sites for the same user-visible behavior.

The second commit is part of that reasoning rather than an afterthought: `--type` is a closed clap enum, so `hcom events --type doing` was rejected with `invalid value 'doing'` even though the rows were in the table. Adding the type to `EventFilterArgs` makes the filter, `listen`, and `events sub` all reach it, and there is a parse test so the event type and the filter enum cannot drift apart again. I found that by running the real bus, not by reading the diff.

## Naming

`doing`, not `intent`: `hcom send --intent request|inform|ack` already means something different, and two unrelated senses of "intent" one space apart on the CLI would be a trap.

## Notes

- An unregistered `--name` is rejected rather than recorded. Activity filed under a name no listing can resolve would be a silent no-op.
- The listing uses one grouped query for the whole roster rather than a lookup per agent. `doing_map_from_conn` takes a raw `Connection` so the CLI and the TUI snapshot loader share one definition of that query instead of two copies of the SQL.
- Both bootstrap primers (`UNIVERSAL` and `SUBAGENT_BOOTSTRAP`) mention the verb, and it is added to `SAFE_HCOM_COMMANDS` so agents are not prompted for approval on first use.

## Testing

Unit tests in `src/db/events.rs`: round-trip, latest-wins including the empty-string clear, and that the per-instance map ignores other event types. Parse test in `src/commands/events.rs` for `--type doing`.

CLI smoke test in `tests/cli_smoke.rs` covering the full path: nothing-set message, set, read back, visible in `list --json` and `--format`, latest write wins, clear, and a second test asserting an unregistered name fails.

```
cargo test --test cli_smoke
test result: ok. 25 passed; 0 failed
```

### End to end on a real two-harness bus

Not a CLI-only check: I launched a real headless Claude Code agent and a real headless Codex agent onto one bus at the same time, and had them talk.

```
$ hcom list
[CLAUDE]  * e2e-nene [headless]  now: listening - done - read peer transcript
[CODEX]   * e2e-kobe [headless]  now: listening

$ hcom list --format '{name} [{tool}] doing={doing}'
e2e-nene [claude] doing=done - read peer transcript
e2e-kobe [codex] doing=codex side - set via absolute path

$ hcom events --type doing --last 10
  nene -> claude side of cross-harness test
  nene -> done - read peer transcript
  kobe -> codex side - set via absolute path
```

Both agents set their own `doing` through the CLI, and each read the other's conversation via `hcom transcript`. The messages went both ways (`intent=request` from the claude agent, `intent=ack` back from the codex agent). Against the released 0.7.25 binary the same `events --type doing` query fails with `invalid value 'doing'`, which is the before-state for the second commit.

Also verified in the TUI rather than by inspection - the agent detail pane renders:

```
  o hera - adhoc - 4s - doing                                    created 5m
  ~/code/mew
  doing: verifying the TUI renders this
```

`cargo fmt --check` and `cargo clippy -D warnings` are clean via `just ci`.

## Note on the local suite

`cargo test` on my machine has 17 pre-existing failures in `hooks::gemini::tests` (all asserting `setup_gemini_hooks(false)`). They fail identically on unmodified `main` at 79ebde1 - I diffed the failing node-id sets in both directions and they are the same set, so they are unrelated to this change. They look environment-specific, and CI here is green. Everything else passes: 2161 passed, and the full `cli_smoke` suite is green.
