### PR TITLE
fix: report paused PTY delivery accurately

### DIFF
--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -1629,6 +1629,24 @@ mod tests {
 
     #[test]
     #[serial]
+    fn recipient_feedback_warns_for_hook_approval_block() {
+        let (db, path, _env) = setup_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances (name, status, status_context, created_at)
+                 VALUES ('hook-approval', 'blocked', 'approval', 1000.0)",
+                [],
+            )
+            .unwrap();
+
+        let feedback = get_recipient_feedback(&db, &["hook-approval".to_string()]);
+
+        assert_eq!(feedback, "Queued; delivery paused: ■ hook-approval");
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
     fn recipient_feedback_lists_healthy_before_paused_recipients() {
         let (db, path, _env) = setup_test_db();
         insert_feedback_recipient(&db, "paused", "tui:user-active");

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -1,5 +1,6 @@
 //! `hcom send` command — send messages to hcom instances.
 
+use std::collections::HashSet;
 use std::io::{IsTerminal, Read as IoRead};
 use std::time::{Duration, Instant};
 
@@ -239,9 +240,15 @@ fn get_recipient_feedback(db: &HcomDb, delivered_to: &[String]) -> String {
         }
         std::thread::sleep(RECIPIENT_FEEDBACK_POLL_INTERVAL.min(deadline - now));
     }
+    let unresolved: HashSet<&str> = sync_candidates
+        .iter()
+        .filter(|name| db.has_pending(name))
+        .map(String::as_str)
+        .collect();
 
     let mut healthy = Vec::new();
     let mut paused = Vec::new();
+    let mut pending = Vec::new();
     for name in delivered_to {
         if let Ok(Some(data)) = db.get_instance_full(name) {
             let icon = status_icon(&data.status);
@@ -249,6 +256,8 @@ fn get_recipient_feedback(db: &HcomDb, delivered_to: &[String]) -> String {
             let recipient = format!("{icon} {display}");
             if is_delivery_paused_status_context(&data.status_context) {
                 paused.push(recipient);
+            } else if unresolved.contains(name.as_str()) {
+                pending.push(recipient);
             } else {
                 healthy.push(recipient);
             }
@@ -265,6 +274,9 @@ fn get_recipient_feedback(db: &HcomDb, delivered_to: &[String]) -> String {
     }
     if !paused.is_empty() {
         lines.push(format!("Queued; delivery paused: {}", paused.join(", ")));
+    }
+    if !pending.is_empty() {
+        lines.push(format!("Queued; delivery pending: {}", pending.join(", ")));
     }
     lines.join("\n")
 }

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -1,6 +1,7 @@
 //! `hcom send` command — send messages to hcom instances.
 
 use std::io::{IsTerminal, Read as IoRead};
+use std::time::{Duration, Instant};
 
 use crate::db::HcomDb;
 use crate::db::subscriptions::create_request_watches;
@@ -11,8 +12,13 @@ use crate::messages::{
     validate_intent, validate_message,
 };
 use crate::shared::{
-    CommandContext, SENDER, SenderIdentity, SenderKind, is_inside_ai_tool, status_icon,
+    CommandContext, SENDER, SenderIdentity, SenderKind, is_delivery_paused_status_context,
+    is_inside_ai_tool, status_icon,
 };
+
+// Leave 25 ms of the 100 ms CLI contract for scheduler wake-up and formatting.
+pub(crate) const RECIPIENT_FEEDBACK_SYNC_TIMEOUT: Duration = Duration::from_millis(75);
+const RECIPIENT_FEEDBACK_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 const SEND_AFTER_HELP: &str = "\
 Target matching:
@@ -219,21 +225,77 @@ fn get_recipient_feedback(db: &HcomDb, delivered_to: &[String]) -> String {
     if delivered_to.is_empty() {
         return format!("Sent to: {SENDER}");
     }
-    if delivered_to.len() > 10 {
-        return format!("Sent to {} agents", delivered_to.len());
+
+    // `send_message` wakes PTY delivery loops over one-way TCP. Give a local
+    // loop a short, shared deadline to publish its first gate disposition (or
+    // consume the message) before describing the result. The deadline is
+    // collective, so fan-out cannot multiply CLI latency.
+    let deadline = Instant::now() + RECIPIENT_FEEDBACK_SYNC_TIMEOUT;
+    let sync_candidates = recipient_feedback_sync_candidates(db, delivered_to);
+    while recipient_feedback_needs_delivery_sync(db, &sync_candidates) {
+        let now = Instant::now();
+        if now >= deadline {
+            break;
+        }
+        std::thread::sleep(RECIPIENT_FEEDBACK_POLL_INTERVAL.min(deadline - now));
     }
 
-    let mut parts = Vec::new();
+    let mut healthy = Vec::new();
+    let mut paused = Vec::new();
     for name in delivered_to {
         if let Ok(Some(data)) = db.get_instance_full(name) {
             let icon = status_icon(&data.status);
             let display = identity::get_display_name(db, name);
-            parts.push(format!("{icon} {display}"));
+            let recipient = format!("{icon} {display}");
+            if is_delivery_paused_status_context(&data.status_context) {
+                paused.push(recipient);
+            } else {
+                healthy.push(recipient);
+            }
         } else {
-            parts.push(format!("◌ {name}"));
+            healthy.push(format!("◌ {name}"));
         }
     }
-    format!("Sent to: {}", parts.join(", "))
+
+    let mut lines = Vec::new();
+    if healthy.len() > 10 {
+        lines.push(format!("Sent to {} agents", healthy.len()));
+    } else if !healthy.is_empty() {
+        lines.push(format!("Sent to: {}", healthy.join(", ")));
+    }
+    if !paused.is_empty() {
+        lines.push(format!("Queued; delivery paused: {}", paused.join(", ")));
+    }
+    lines.join("\n")
+}
+
+/// Snapshot recipients whose static transport/origin can require PTY feedback sync.
+/// Dynamic pending/status state is the only data re-read during the poll loop.
+fn recipient_feedback_sync_candidates(db: &HcomDb, delivered_to: &[String]) -> Vec<String> {
+    delivered_to
+        .iter()
+        .filter_map(|name| {
+            let data = db.get_instance_full(name).ok().flatten()?;
+            let is_local = data
+                .origin_device_id
+                .as_deref()
+                .is_none_or(|device| device.is_empty());
+            (data.tcp_mode != 0 && is_local).then(|| name.clone())
+        })
+        .collect()
+}
+
+fn recipient_feedback_needs_delivery_sync(db: &HcomDb, candidates: &[String]) -> bool {
+    candidates.iter().any(|name| {
+        if !db.has_pending(name) {
+            return false;
+        }
+
+        let Ok(Some((_, status_context))) = db.get_status(name) else {
+            return false;
+        };
+        !is_delivery_paused_status_context(&status_context)
+    })
 }
 
 struct ResolvedDelivery {
@@ -1456,6 +1518,251 @@ mod tests {
         let shm = PathBuf::from(format!("{}-shm", path.display()));
         let _ = std::fs::remove_file(wal);
         let _ = std::fs::remove_file(shm);
+    }
+
+    fn insert_feedback_recipient(db: &HcomDb, name: &str, status_context: &str) {
+        db.conn()
+            .execute(
+                "INSERT INTO instances (name, status, status_context, created_at)
+                 VALUES (?1, 'listening', ?2, 1000.0)",
+                rusqlite::params![name, status_context],
+            )
+            .unwrap();
+    }
+
+    fn insert_pty_feedback_recipient(db: &HcomDb, name: &str) {
+        db.conn()
+            .execute(
+                "INSERT INTO instances
+                 (name, status, status_context, created_at, tcp_mode)
+                 VALUES (?1, 'listening', '', 1000.0, 1)",
+                rusqlite::params![name],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn recipient_feedback_preserves_healthy_success_wording() {
+        let (db, path, _env) = setup_test_db();
+        let recipients = [
+            ("idle", ""),
+            ("using-tool", "tool:Bash"),
+            ("receiving", "deliver:rune"),
+            ("stopped-hook", "stop"),
+        ];
+        for (name, status_context) in recipients {
+            insert_feedback_recipient(&db, name, status_context);
+        }
+
+        let delivered_to = recipients
+            .iter()
+            .map(|(name, _)| (*name).to_string())
+            .collect::<Vec<_>>();
+        let feedback = get_recipient_feedback(&db, &delivered_to);
+
+        assert_eq!(
+            feedback,
+            "Sent to: ◉ idle, ◉ using-tool, ◉ receiving, ◉ stopped-hook"
+        );
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn recipient_feedback_preserves_large_healthy_recipient_count() {
+        let (db, path, _env) = setup_test_db();
+        let recipients: Vec<String> = (0..11).map(|index| format!("agent{index}")).collect();
+        for recipient in &recipients {
+            insert_feedback_recipient(&db, recipient, "");
+        }
+
+        let feedback = get_recipient_feedback(&db, &recipients);
+
+        assert_eq!(feedback, "Sent to 11 agents");
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn recipient_feedback_warns_for_delivery_paused_status_family() {
+        let (db, path, _env) = setup_test_db();
+        let recipients = [
+            ("not-ready", "tui:not-ready"),
+            ("draft", "tui:prompt-has-text"),
+            ("wake", "tui:wake-unacknowledged"),
+        ];
+        for (name, status_context) in recipients {
+            insert_feedback_recipient(&db, name, status_context);
+        }
+
+        let delivered_to = recipients
+            .iter()
+            .map(|(name, _)| (*name).to_string())
+            .collect::<Vec<_>>();
+        let feedback = get_recipient_feedback(&db, &delivered_to);
+
+        assert_eq!(
+            feedback,
+            "Queued; delivery paused: ◉ not-ready, ◉ draft, ◉ wake"
+        );
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn recipient_feedback_lists_healthy_before_paused_recipients() {
+        let (db, path, _env) = setup_test_db();
+        insert_feedback_recipient(&db, "paused", "tui:user-active");
+        insert_feedback_recipient(&db, "healthy", "");
+
+        let feedback = get_recipient_feedback(&db, &["paused".to_string(), "healthy".to_string()]);
+
+        assert_eq!(
+            feedback,
+            "Sent to: ◉ healthy\nQueued; delivery paused: ◉ paused"
+        );
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn recipient_feedback_send_message_persists_paused_recipient_once() {
+        let (db, path, _env) = setup_test_db();
+        insert_feedback_recipient(&db, "paused", "tui:not-ready");
+        let sender = SenderIdentity {
+            kind: SenderKind::External,
+            name: "bigboss".into(),
+            instance_data: None,
+            session_id: None,
+        };
+
+        let delivered =
+            send_message(&db, &sender, "ping", None, Some(&["paused".to_string()])).unwrap();
+
+        assert_eq!(delivered, vec!["paused".to_string()]);
+        let message_count: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE type = 'message'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(message_count, 1);
+        let delivered_to: String = db
+            .conn()
+            .query_row(
+                "SELECT json_extract(data, '$.delivered_to')
+                 FROM events
+                 WHERE type = 'message'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(delivered_to, "[\"paused\"]");
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn recipient_feedback_observes_gate_status_published_after_wake() {
+        let (db, path, _env) = setup_test_db();
+        insert_pty_feedback_recipient(&db, "rozo");
+        db.log_event(
+            "message",
+            "ext_bigboss",
+            &serde_json::json!({
+                "from": "bigboss",
+                "sender_kind": "external",
+                "scope": "mentions",
+                "text": "probe",
+                "mentions": ["rozo"],
+                "delivered_to": ["rozo"],
+            }),
+        )
+        .unwrap();
+
+        let updater_path = path.clone();
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        let updater = std::thread::spawn(move || {
+            let updater_db = HcomDb::open_raw(&updater_path).unwrap();
+            ready_tx.send(()).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(30));
+            updater_db
+                .set_gate_status("rozo", "tui:not-ready", "prompt not visible")
+                .unwrap();
+        });
+        ready_rx.recv().unwrap();
+
+        let feedback = get_recipient_feedback(&db, &["rozo".to_string()]);
+
+        updater.join().unwrap();
+        assert_eq!(feedback, "Queued; delivery paused: ◉ rozo");
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn unresolved_pty_feedback_wait_is_bounded() {
+        let (db, path, _env) = setup_test_db();
+        insert_pty_feedback_recipient(&db, "slow");
+        db.log_event(
+            "message",
+            "ext_bigboss",
+            &serde_json::json!({
+                "from": "bigboss",
+                "sender_kind": "external",
+                "scope": "mentions",
+                "text": "probe",
+                "mentions": ["slow"],
+                "delivered_to": ["slow"],
+            }),
+        )
+        .unwrap();
+
+        let started = std::time::Instant::now();
+        let feedback = get_recipient_feedback(&db, &["slow".to_string()]);
+
+        assert_eq!(
+            RECIPIENT_FEEDBACK_SYNC_TIMEOUT,
+            std::time::Duration::from_millis(75),
+            "delivery-loop and feedback tests share the 75 ms synchronization contract"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(500),
+            "recipient feedback synchronization must remain collectively bounded"
+        );
+        assert_eq!(feedback, "Sent to: ◉ slow");
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn feedback_sync_candidates_include_only_local_pty_recipients() {
+        let (db, path, _env) = setup_test_db();
+        insert_pty_feedback_recipient(&db, "local-pty");
+        insert_feedback_recipient(&db, "local-hook", "");
+        db.conn()
+            .execute(
+                "INSERT INTO instances
+                 (name, status, status_context, created_at, tcp_mode, origin_device_id)
+                 VALUES ('remote-pty', 'listening', '', 1000.0, 1, 'peer-device')",
+                [],
+            )
+            .unwrap();
+
+        let candidates = recipient_feedback_sync_candidates(
+            &db,
+            &[
+                "local-pty".to_string(),
+                "local-hook".to_string(),
+                "remote-pty".to_string(),
+            ],
+        );
+
+        assert_eq!(candidates, vec!["local-pty".to_string()]);
+        cleanup_test_db(path);
     }
 
     #[test]

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -1769,7 +1769,7 @@ mod tests {
             started.elapsed() < std::time::Duration::from_millis(500),
             "recipient feedback synchronization must remain collectively bounded"
         );
-        assert_eq!(feedback, "Sent to: ◉ slow");
+        assert_eq!(feedback, "Queued; delivery pending: ◉ slow");
         cleanup_test_db(path);
     }
 

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -1611,6 +1611,24 @@ mod tests {
 
     #[test]
     #[serial]
+    fn recipient_feedback_warns_for_approval_block() {
+        let (db, path, _env) = setup_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances (name, status, status_context, created_at)
+                 VALUES ('approval', 'blocked', 'pty:approval', 1000.0)",
+                [],
+            )
+            .unwrap();
+
+        let feedback = get_recipient_feedback(&db, &["approval".to_string()]);
+
+        assert_eq!(feedback, "Queued; delivery paused: ■ approval");
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
     fn recipient_feedback_lists_healthy_before_paused_recipients() {
         let (db, path, _env) = setup_test_db();
         insert_feedback_recipient(&db, "paused", "tui:user-active");

--- a/src/db/instances.rs
+++ b/src/db/instances.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use rusqlite::{OptionalExtension, params};
 
 use super::{HcomDb, chrono_now_iso, subscriptions};
-use crate::shared::constants::ST_LISTENING;
+use crate::shared::constants::{ST_LISTENING, is_delivery_paused_status_context};
 use crate::shared::time::now_epoch_i64;
 
 /// Instance status info
@@ -204,6 +204,44 @@ impl HcomDb {
             params![context, detail, name],
         )?;
         Ok(())
+    }
+
+    /// Publish a PTY gate context only while the instance is still listening.
+    /// The status check and write are one statement so a concurrent hook/tool
+    /// transition cannot be overwritten between a read and update.
+    pub(crate) fn set_gate_status_if_listening(
+        &self,
+        name: &str,
+        context: &str,
+        detail: &str,
+    ) -> Result<bool> {
+        let changed = self.conn.execute(
+            "UPDATE instances SET status_context = ?,
+                status_detail = CASE WHEN status_detail = 'cmd:listen' THEN status_detail ELSE ? END
+             WHERE name = ? AND status = ?",
+            params![context, detail, name, ST_LISTENING],
+        )?;
+        Ok(changed > 0)
+    }
+
+    /// Clear a PTY gate context only if the instance row still contains the
+    /// exact context published by the caller.
+    pub(crate) fn clear_gate_status_if_context(
+        &self,
+        name: &str,
+        expected_context: &str,
+    ) -> Result<bool> {
+        if !is_delivery_paused_status_context(expected_context) {
+            return Ok(false);
+        }
+
+        let changed = self.conn.execute(
+            "UPDATE instances SET status_context = '',
+                status_detail = CASE WHEN status_detail = 'cmd:listen' THEN status_detail ELSE '' END
+             WHERE name = ? AND status_context = ?",
+            params![name, expected_context],
+        )?;
+        Ok(changed > 0)
     }
 
     /// Update instance PID after spawn

--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -713,6 +713,198 @@ pub(crate) fn gate_block_detail(reason: &str) -> &'static str {
     }
 }
 
+const TRANSIENT_GATE_STATUS_DEBOUNCE: Duration = Duration::from_secs(2);
+
+/// Delay before the daemon publishes a PTY gate reason to shared instance state.
+///
+/// Operator-held gates are durable dispositions that status/TUI consumers and
+/// synchronous send feedback must see immediately. Runtime transition gates
+/// are expected to clear on their own, so retain the historical debounce to
+/// avoid exposing normal prompt and output churn as a delivery pause.
+fn gate_status_publication_delay(reason: &str) -> Duration {
+    if matches!(
+        reason,
+        "not_ready"
+            | "prompt_has_text"
+            | "user_active"
+            | "approval"
+            | "nav_overlay"
+            | "wake_unacknowledged"
+    ) {
+        Duration::ZERO
+    } else {
+        TRANSIENT_GATE_STATUS_DEBOUNCE
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum GateStatusUpdate {
+    None,
+    Publish {
+        context: String,
+        reason: &'static str,
+    },
+    Clear,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct OwnedGateStatus {
+    instance_name: String,
+    context: String,
+}
+
+#[derive(Default)]
+struct GateStatusTracker {
+    blocked_instance: Option<String>,
+    blocked_reason: Option<&'static str>,
+    blocked_since: Option<Instant>,
+    owned_status: Option<OwnedGateStatus>,
+    clear_pending: bool,
+}
+
+impl GateStatusTracker {
+    fn observe_blocked_for(
+        &mut self,
+        instance_name: &str,
+        reason: &'static str,
+        now: Instant,
+    ) -> GateStatusUpdate {
+        let gate_changed = self.blocked_instance.as_deref() != Some(instance_name)
+            || self.blocked_reason != Some(reason);
+        if gate_changed {
+            self.blocked_instance = Some(instance_name.to_owned());
+            self.blocked_reason = Some(reason);
+            self.blocked_since = Some(now);
+        }
+
+        let blocked_for = now.saturating_duration_since(self.blocked_since.unwrap_or(now));
+        if blocked_for >= gate_status_publication_delay(reason) {
+            let context = format!("tui:{}", reason.replace('_', "-"));
+            if self
+                .owned_status
+                .as_ref()
+                .is_some_and(|owned| owned.instance_name != instance_name)
+            {
+                self.clear_pending = true;
+                return GateStatusUpdate::Clear;
+            }
+            if !self.owned_status.as_ref().is_some_and(|owned| {
+                owned.instance_name == instance_name && owned.context == context
+            }) {
+                return GateStatusUpdate::Publish { context, reason };
+            }
+        } else if self.owned_status.is_some() {
+            self.clear_pending = true;
+            return GateStatusUpdate::Clear;
+        }
+
+        GateStatusUpdate::None
+    }
+
+    fn reset(&mut self) -> GateStatusUpdate {
+        self.blocked_instance = None;
+        self.blocked_reason = None;
+        self.blocked_since = None;
+        if self.owned_status.is_some() {
+            self.clear_pending = true;
+            GateStatusUpdate::Clear
+        } else {
+            GateStatusUpdate::None
+        }
+    }
+
+    fn record_published_for(&mut self, instance_name: &str, context: String) {
+        self.owned_status = Some(OwnedGateStatus {
+            instance_name: instance_name.to_owned(),
+            context,
+        });
+        self.clear_pending = false;
+    }
+
+    fn record_cleared(&mut self) {
+        self.owned_status = None;
+        self.clear_pending = false;
+    }
+
+    fn owned_status(&self) -> Option<(&str, &str)> {
+        self.owned_status
+            .as_ref()
+            .map(|owned| (owned.instance_name.as_str(), owned.context.as_str()))
+    }
+
+    fn clear_owned_status(&mut self, db: &HcomDb) {
+        let Some((instance_name, context)) = self
+            .owned_status()
+            .map(|(name, context)| (name.to_owned(), context.to_owned()))
+        else {
+            self.clear_pending = false;
+            return;
+        };
+
+        match db.clear_gate_status_if_context(&instance_name, &context) {
+            Ok(_) => self.record_cleared(),
+            Err(e) => log_warn("native", "delivery.gate_clear_fail", &format!("{}", e)),
+        }
+    }
+
+    fn reconcile_instance(&mut self, db: &HcomDb, current_name: &str) {
+        if self
+            .blocked_instance
+            .as_deref()
+            .is_some_and(|name| name != current_name)
+        {
+            self.blocked_instance = None;
+            self.blocked_reason = None;
+            self.blocked_since = None;
+        }
+        if self
+            .owned_status
+            .as_ref()
+            .is_some_and(|owned| owned.instance_name != current_name)
+        {
+            self.clear_pending = true;
+        }
+        if self.clear_pending {
+            self.clear_owned_status(db);
+        }
+    }
+
+    fn apply_update(&mut self, db: &HcomDb, name: &str, update: GateStatusUpdate) {
+        self.reconcile_instance(db, name);
+        if self.clear_pending {
+            return;
+        }
+
+        match update {
+            GateStatusUpdate::None => {}
+            GateStatusUpdate::Clear => {
+                self.clear_pending = true;
+                self.clear_owned_status(db);
+            }
+            GateStatusUpdate::Publish { context, reason } => {
+                if self
+                    .owned_status
+                    .as_ref()
+                    .is_some_and(|owned| owned.instance_name != name)
+                {
+                    self.clear_pending = true;
+                    self.clear_owned_status(db);
+                    if self.clear_pending {
+                        return;
+                    }
+                }
+
+                let detail = gate_block_detail(reason);
+                match db.set_gate_status_if_listening(name, &context, detail) {
+                    Ok(true) => self.record_published_for(name, context),
+                    Ok(false) => {}
+                    Err(e) => log_warn("native", "delivery.gate_status_fail", &format!("{}", e)),
+                }
+            }
+        }
+    }
+}
+
 /// Build PTY wake text for tools whose delivery path is not human-visible.
 ///
 /// Claude and Codex inject the plain `<hcom>` trigger because their hooks already
@@ -1750,9 +1942,7 @@ pub fn run_delivery_loop(
         let mut injected_text = String::new();
         let mut phase_started_at = Instant::now();
         let mut cursor_before: i64 = 0;
-        // Gate block tracking for TUI status updates
-        let mut block_since: Option<Instant> = None;
-        let mut last_block_context: String = String::new();
+        let mut gate_status_tracker = GateStatusTracker::default();
 
         // Status tracking for terminal title updates
         let mut current_status = ST_LISTENING.to_string();
@@ -1769,6 +1959,7 @@ pub fn run_delivery_loop(
                 tool: &config.tool,
                 host_label: &mut host_label,
             });
+            gate_status_tracker.reconcile_instance(db, &current_name);
             drive_launch_outcome(
                 db,
                 state,
@@ -1873,6 +2064,8 @@ pub fn run_delivery_loop(
                         );
                         delivery_state = State::Idle;
                         attempt = 0;
+                        let update = gate_status_tracker.reset();
+                        gate_status_tracker.apply_update(db, &current_name, update);
                         continue;
                     }
 
@@ -1886,6 +2079,8 @@ pub fn run_delivery_loop(
                     let gate = evaluate_gate(config, state, is_idle);
 
                     if gate.safe {
+                        let update = gate_status_tracker.reset();
+                        gate_status_tracker.apply_update(db, &current_name, update);
                         log_info(
                             "native",
                             "delivery.gate_pass",
@@ -1940,6 +2135,13 @@ pub fn run_delivery_loop(
                             attempt += 1;
                         }
                     } else {
+                        let update = gate_status_tracker.observe_blocked_for(
+                            &current_name,
+                            gate.reason,
+                            Instant::now(),
+                        );
+                        gate_status_tracker.apply_update(db, &current_name, update);
+
                         // Gate blocked - refresh heartbeat so we don't go stale while waiting
                         // (DB status is still "listening" until message is delivered and hooks fire)
                         if let Err(e) = db.update_heartbeat(&current_name) {
@@ -1961,11 +2163,6 @@ pub fn run_delivery_loop(
                                     state.is_user_active()
                                 ),
                             );
-                        }
-
-                        // Track when blocking started
-                        if block_since.is_none() {
-                            block_since = Some(Instant::now());
                         }
 
                         let approval_showing = {
@@ -2017,70 +2214,6 @@ pub fn run_delivery_loop(
                                         "delivery.recovery_check",
                                         &format!("DB error checking status: {}", e),
                                     );
-                                }
-                            }
-                            // Fall through to TUI status update
-                            if let Some(since) = block_since
-                                && since.elapsed().as_secs_f64() >= 2.0
-                            {
-                                match db.get_status(&current_name) {
-                                    Ok(Some((status, _))) if status == ST_LISTENING => {
-                                        let context = "tui:not-idle".to_string();
-                                        if context != last_block_context {
-                                            if let Err(e) = db.set_gate_status(
-                                                &current_name,
-                                                &context,
-                                                "waiting for idle status",
-                                            ) {
-                                                log_warn(
-                                                    "native",
-                                                    "delivery.gate_status_fail",
-                                                    &format!("{}", e),
-                                                );
-                                            }
-                                            last_block_context = context;
-                                        }
-                                    }
-                                    Ok(Some(_)) | Ok(None) => {
-                                        // Status not "listening" or not found - skip
-                                    }
-                                    Err(e) => {
-                                        log_error(
-                                            "native",
-                                            "delivery.tui_status_update",
-                                            &format!("DB error checking status: {}", e),
-                                        );
-                                    }
-                                }
-                            }
-                        } else if let Some(since) = block_since {
-                            // After 2 seconds of blocking, update TUI status context
-                            if since.elapsed().as_secs_f64() >= 2.0 {
-                                // Only update if status is "listening" (don't overwrite active/blocked)
-                                match db.get_status(&current_name) {
-                                    Ok(Some((status, _))) if status == ST_LISTENING => {
-                                        // Format context: tui:not-ready, tui:user-active, etc.
-                                        let reason_formatted = gate.reason.replace("_", "-");
-                                        let context = format!("tui:{}", reason_formatted);
-
-                                        // Only update if context changed
-                                        if context != last_block_context {
-                                            let detail = gate_block_detail(gate.reason);
-                                            let _ =
-                                                db.set_gate_status(&current_name, &context, detail);
-                                            last_block_context = context;
-                                        }
-                                    }
-                                    Ok(Some(_)) | Ok(None) => {
-                                        // Status not "listening" or not found - skip
-                                    }
-                                    Err(e) => {
-                                        log_error(
-                                            "native",
-                                            "delivery.gate_status_update",
-                                            &format!("DB error checking status: {}", e),
-                                        );
-                                    }
                                 }
                             }
                         }
@@ -2303,14 +2436,8 @@ pub fn run_delivery_loop(
                     let current_cursor = db.get_cursor(&current_name);
                     if current_cursor > cursor_before {
                         // Success! Clear gate block status
-                        if !last_block_context.is_empty() {
-                            if let Err(e) = db.set_gate_status(&current_name, "", "") {
-                                log_warn("native", "delivery.gate_clear_fail", &format!("{}", e));
-                            }
-                            last_block_context.clear();
-                        }
-                        block_since = None;
-
+                        let update = gate_status_tracker.reset();
+                        gate_status_tracker.apply_update(db, &current_name, update);
                         log_info(
                             "native",
                             "delivery.success",
@@ -2360,17 +2487,8 @@ pub fn run_delivery_loop(
                                 // pending rows" is also sufficient — avoids
                                 // wedging when hook delivery succeeded but
                                 // cursor bookkeeping did not advance.
-                                if !last_block_context.is_empty() {
-                                    if let Err(e) = db.set_gate_status(&current_name, "", "") {
-                                        log_warn(
-                                            "native",
-                                            "delivery.gate_clear_fail",
-                                            &format!("{}", e),
-                                        );
-                                    }
-                                    last_block_context.clear();
-                                }
-                                block_since = None;
+                                let update = gate_status_tracker.reset();
+                                gate_status_tracker.apply_update(db, &current_name, update);
                                 log_info(
                                     "native",
                                     "delivery.success_no_cursor",
@@ -2397,16 +2515,20 @@ pub fn run_delivery_loop(
                             VerifyTimeoutDecision::FastFail => {
                                 let context = "tui:wake-unacknowledged".to_string();
                                 let detail = "delivery paused; kill and resume this agent to retry";
-                                if let Err(e) = db.set_gate_status(&current_name, &context, detail)
-                                {
-                                    log_warn(
+                                match db.set_gate_status_if_listening(
+                                    &current_name,
+                                    &context,
+                                    detail,
+                                ) {
+                                    Ok(true) => gate_status_tracker
+                                        .record_published_for(&current_name, context),
+                                    Ok(false) => {}
+                                    Err(e) => log_warn(
                                         "native",
                                         "delivery.gate_status_fail",
                                         &format!("{}", e),
-                                    );
+                                    ),
                                 }
-                                last_block_context = context;
-                                block_since = Some(Instant::now());
                                 log_warn(
                                     "native",
                                     "delivery.wake_unacknowledged",
@@ -2465,11 +2587,8 @@ pub fn run_delivery_loop(
                     let current_cursor = db.get_cursor(&current_name);
                     let has_pending = db.has_pending(&current_name);
                     if current_cursor > cursor_before || !has_pending {
-                        if let Err(e) = db.set_gate_status(&current_name, "", "") {
-                            log_warn("native", "delivery.gate_clear_fail", &format!("{}", e));
-                        }
-                        last_block_context.clear();
-                        block_since = None;
+                        let update = gate_status_tracker.reset();
+                        gate_status_tracker.apply_update(db, &current_name, update);
                         attempt = 0;
                         inject_attempt = 0;
                         delivery_state = if has_pending {
@@ -2658,6 +2777,105 @@ mod tests {
             approval_scrape_latched: false,
             nav_overlay: false,
         }
+    }
+
+    fn observe_gate_status_within_feedback_deadline(
+        config: ToolConfig,
+        screen: ScreenState,
+    ) -> (String, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let mut db = HcomDb::open_raw(&db_path).unwrap();
+        db.init_db().unwrap();
+        db.conn()
+            .execute(
+                "INSERT INTO instances
+                 (name, tool, status, status_context, created_at, tcp_mode)
+                 VALUES ('rozo', 'antigravity', 'listening', '', 0, 1)",
+                [],
+            )
+            .unwrap();
+        db.log_event(
+            "message",
+            "ext_bigboss",
+            &serde_json::json!({
+                "from": "bigboss",
+                "sender_kind": "external",
+                "scope": "mentions",
+                "text": "probe",
+                "mentions": ["rozo"],
+                "delivered_to": ["rozo"],
+            }),
+        )
+        .unwrap();
+
+        let notify = NotifyServer::new().unwrap();
+        let notify_port = notify.port();
+        let running = Arc::new(AtomicBool::new(true));
+        let running_for_loop = running.clone();
+        let state = make_state(screen, 500);
+
+        let delivery = std::thread::spawn(move || {
+            run_delivery_loop(
+                running_for_loop,
+                &mut db,
+                &notify,
+                &state,
+                "rozo",
+                &config,
+                None,
+                None,
+                None,
+            );
+        });
+
+        let observer = HcomDb::open_raw(&db_path).unwrap();
+        let deadline = Instant::now() + crate::commands::send::RECIPIENT_FEEDBACK_SYNC_TIMEOUT;
+        let mut observed_status = String::new();
+        let mut observed_context = String::new();
+        while Instant::now() < deadline {
+            if let Some(row) = observer.get_instance_full("rozo").unwrap() {
+                observed_status = row.status;
+                observed_context = row.status_context;
+            }
+            if observed_context.starts_with("tui:") {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        running.store(false, Ordering::Release);
+        let _ = TcpStream::connect(("127.0.0.1", notify_port));
+        delivery.join().unwrap();
+
+        (observed_status, observed_context)
+    }
+
+    #[test]
+    fn operator_blocking_gate_status_is_published_before_feedback_deadline() {
+        let mut screen = safe_screen();
+        screen.ready = false;
+        screen.prompt_empty = false;
+        screen.input_text = Some("UNSUBMITTED-20260831-R1".to_string());
+
+        let observed =
+            observe_gate_status_within_feedback_deadline(ToolConfig::antigravity(), screen);
+
+        assert_eq!(observed, ("listening".into(), "tui:not-ready".into()));
+    }
+
+    #[test]
+    fn transient_gate_status_is_debounced_past_feedback_deadline() {
+        let mut screen = safe_screen();
+        screen.last_prompt_submit = Some(Instant::now());
+
+        let observed = observe_gate_status_within_feedback_deadline(ToolConfig::codex(), screen);
+
+        assert_eq!(observed.0, "listening");
+        assert!(
+            !crate::shared::is_delivery_paused_status_context(&observed.1),
+            "transient gate must not publish a shared TUI pause before debounce: {observed:?}"
+        );
     }
 
     #[test]
@@ -3193,6 +3411,334 @@ mod tests {
             "waiting for subagent nav / session switcher to close"
         );
         assert_eq!(gate_block_detail("unknown"), "blocked");
+    }
+
+    #[test]
+    fn operator_blocking_gate_statuses_publish_without_debounce() {
+        for reason in [
+            "not_ready",
+            "prompt_has_text",
+            "user_active",
+            "approval",
+            "nav_overlay",
+            "wake_unacknowledged",
+        ] {
+            assert_eq!(gate_status_publication_delay(reason), Duration::ZERO);
+        }
+    }
+
+    #[test]
+    fn transient_gate_statuses_retain_historical_debounce() {
+        for reason in ["submit_settle", "output_unstable", "not_idle", "unknown"] {
+            assert_eq!(
+                gate_status_publication_delay(reason),
+                TRANSIENT_GATE_STATUS_DEBOUNCE
+            );
+        }
+    }
+
+    #[test]
+    fn transient_gate_status_publishes_only_after_two_seconds() {
+        let started_at = Instant::now();
+        let mut tracker = GateStatusTracker::default();
+
+        assert_eq!(
+            tracker.observe_blocked_for("rozo", "submit_settle", started_at),
+            GateStatusUpdate::None
+        );
+        assert_eq!(
+            tracker.observe_blocked_for(
+                "rozo",
+                "submit_settle",
+                started_at + TRANSIENT_GATE_STATUS_DEBOUNCE - Duration::from_millis(1),
+            ),
+            GateStatusUpdate::None
+        );
+        assert_eq!(
+            tracker.observe_blocked_for(
+                "rozo",
+                "submit_settle",
+                started_at + TRANSIENT_GATE_STATUS_DEBOUNCE,
+            ),
+            GateStatusUpdate::Publish {
+                context: "tui:submit-settle".into(),
+                reason: "submit_settle",
+            }
+        );
+    }
+
+    #[test]
+    fn durable_to_transient_clears_owned_context_and_restarts_debounce() {
+        let started_at = Instant::now();
+        let transition_at = started_at + Duration::from_millis(20);
+        let mut tracker = GateStatusTracker::default();
+
+        assert_eq!(
+            tracker.observe_blocked_for("rozo", "not_ready", started_at),
+            GateStatusUpdate::Publish {
+                context: "tui:not-ready".into(),
+                reason: "not_ready",
+            }
+        );
+        tracker.record_published_for("rozo", "tui:not-ready".into());
+        assert_eq!(
+            tracker.observe_blocked_for("rozo", "submit_settle", transition_at),
+            GateStatusUpdate::Clear
+        );
+        assert_eq!(
+            tracker.observe_blocked_for(
+                "rozo",
+                "submit_settle",
+                transition_at + Duration::from_millis(1),
+            ),
+            GateStatusUpdate::Clear,
+            "failed conditional clears must be retried while the transient gate is debounced"
+        );
+        tracker.record_cleared();
+        assert_eq!(
+            tracker.observe_blocked_for(
+                "rozo",
+                "submit_settle",
+                transition_at + TRANSIENT_GATE_STATUS_DEBOUNCE - Duration::from_millis(1),
+            ),
+            GateStatusUpdate::None
+        );
+        assert_eq!(
+            tracker.observe_blocked_for(
+                "rozo",
+                "submit_settle",
+                transition_at + TRANSIENT_GATE_STATUS_DEBOUNCE,
+            ),
+            GateStatusUpdate::Publish {
+                context: "tui:submit-settle".into(),
+                reason: "submit_settle",
+            }
+        );
+    }
+
+    #[test]
+    fn transient_reason_change_restarts_debounce() {
+        let started_at = Instant::now();
+        let changed_at = started_at + Duration::from_secs(1);
+        let mut tracker = GateStatusTracker::default();
+
+        assert_eq!(
+            tracker.observe_blocked_for("rozo", "submit_settle", started_at),
+            GateStatusUpdate::None
+        );
+        assert_eq!(
+            tracker.observe_blocked_for("rozo", "output_unstable", changed_at),
+            GateStatusUpdate::None
+        );
+        assert_eq!(
+            tracker.observe_blocked_for(
+                "rozo",
+                "output_unstable",
+                changed_at + TRANSIENT_GATE_STATUS_DEBOUNCE - Duration::from_millis(1),
+            ),
+            GateStatusUpdate::None
+        );
+        assert_eq!(
+            tracker.observe_blocked_for(
+                "rozo",
+                "output_unstable",
+                changed_at + TRANSIENT_GATE_STATUS_DEBOUNCE,
+            ),
+            GateStatusUpdate::Publish {
+                context: "tui:output-unstable".into(),
+                reason: "output_unstable",
+            }
+        );
+    }
+
+    #[test]
+    fn safe_no_pending_and_message_transitions_reset_owned_context() {
+        for transition in ["safe", "no-pending", "message-delivered"] {
+            let mut tracker = GateStatusTracker::default();
+            tracker.record_published_for("rozo", "tui:not-ready".into());
+
+            assert_eq!(
+                tracker.reset(),
+                GateStatusUpdate::Clear,
+                "{transition} transition must clear loop-owned gate status"
+            );
+            tracker.record_cleared();
+            assert_eq!(tracker.reset(), GateStatusUpdate::None);
+        }
+    }
+
+    #[test]
+    fn clearing_loop_owned_status_preserves_other_writer() {
+        let (_dir, db) = open_ready_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances
+                 (name, status, status_context, status_detail, created_at)
+                 VALUES ('rozo', 'listening', 'tool:Bash', 'running', 1000.0)",
+                [],
+            )
+            .unwrap();
+        let mut tracker = GateStatusTracker::default();
+        tracker.record_published_for("rozo", "tui:not-ready".into());
+
+        tracker.clear_owned_status(&db);
+
+        let row = db.get_instance_full("rozo").unwrap().unwrap();
+        assert_eq!(row.status_context, "tool:Bash");
+        assert_eq!(row.status_detail, "running");
+        assert_eq!(tracker.owned_status(), None);
+    }
+
+    #[test]
+    fn clearing_loop_owned_status_clears_matching_shared_context() {
+        let (_dir, db) = open_ready_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances
+                 (name, status, status_context, status_detail, created_at)
+                 VALUES ('rozo', 'listening', 'tui:not-ready', 'prompt not visible', 1000.0)",
+                [],
+            )
+            .unwrap();
+        let mut tracker = GateStatusTracker::default();
+        tracker.record_published_for("rozo", "tui:not-ready".into());
+
+        tracker.clear_owned_status(&db);
+
+        let row = db.get_instance_full("rozo").unwrap().unwrap();
+        assert_eq!(row.status_context, "");
+        assert_eq!(row.status_detail, "");
+        assert_eq!(tracker.owned_status(), None);
+    }
+
+    #[test]
+    fn clearing_loop_owned_status_preserves_cmd_listen_detail() {
+        let (_dir, db) = open_ready_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances
+                 (name, status, status_context, status_detail, created_at)
+                 VALUES ('rozo', 'listening', 'tui:not-ready', 'cmd:listen', 1000.0)",
+                [],
+            )
+            .unwrap();
+        let mut tracker = GateStatusTracker::default();
+        tracker.record_published_for("rozo", "tui:not-ready".into());
+
+        tracker.clear_owned_status(&db);
+
+        let row = db.get_instance_full("rozo").unwrap().unwrap();
+        assert_eq!(row.status_context, "");
+        assert_eq!(row.status_detail, "cmd:listen");
+        assert_eq!(tracker.owned_status(), None);
+    }
+
+    #[test]
+    fn publication_cas_preserves_concurrent_non_listening_writer() {
+        let (_dir, db) = open_ready_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances
+                 (name, status, status_context, status_detail, created_at)
+                 VALUES ('rozo', 'listening', '', '', 1000.0)",
+                [],
+            )
+            .unwrap();
+
+        // Deterministically model the interleaving that used to occur between
+        // delivery's status read and status write: the tool writer wins first.
+        db.set_status("rozo", "active", "tool:Bash").unwrap();
+        db.conn()
+            .execute(
+                "UPDATE instances SET status_detail = 'running' WHERE name = 'rozo'",
+                [],
+            )
+            .unwrap();
+
+        let published = db
+            .set_gate_status_if_listening("rozo", "tui:not-ready", "prompt not visible")
+            .unwrap();
+
+        assert!(!published);
+        let row = db.get_instance_full("rozo").unwrap().unwrap();
+        assert_eq!(row.status, "active");
+        assert_eq!(row.status_context, "tool:Bash");
+        assert_eq!(row.status_detail, "running");
+    }
+
+    #[test]
+    fn binding_transition_clears_owned_old_instance_and_resets_debounce() {
+        let (_dir, db) = open_ready_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances
+                 (name, status, status_context, status_detail, created_at)
+                 VALUES
+                 ('old', 'listening', 'tui:not-ready', 'prompt not visible', 1000.0),
+                 ('new', 'listening', '', '', 1000.0)",
+                [],
+            )
+            .unwrap();
+        let started_at = Instant::now();
+        let mut tracker = GateStatusTracker::default();
+        tracker.record_published_for("old", "tui:not-ready".into());
+
+        tracker.reconcile_instance(&db, "new");
+
+        assert_eq!(
+            db.get_instance_full("old").unwrap().unwrap().status_context,
+            ""
+        );
+        assert_eq!(tracker.owned_status(), None);
+        assert_eq!(
+            tracker.observe_blocked_for("new", "submit_settle", started_at),
+            GateStatusUpdate::None
+        );
+        assert_eq!(
+            tracker.observe_blocked_for(
+                "new",
+                "submit_settle",
+                started_at + TRANSIENT_GATE_STATUS_DEBOUNCE - Duration::from_millis(1),
+            ),
+            GateStatusUpdate::None
+        );
+    }
+
+    #[test]
+    fn failed_idle_clear_is_retried_without_clobbering_replacement_writer() {
+        let (_dir, db) = open_ready_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances
+                 (name, status, status_context, status_detail, created_at)
+                 VALUES ('rozo', 'listening', 'tui:not-ready', 'prompt not visible', 1000.0)",
+                [],
+            )
+            .unwrap();
+        let mut tracker = GateStatusTracker::default();
+        tracker.record_published_for("rozo", "tui:not-ready".into());
+        let update = tracker.reset();
+        assert_eq!(update, GateStatusUpdate::Clear);
+
+        db.conn()
+            .execute("ALTER TABLE instances RENAME TO instances_unavailable", [])
+            .unwrap();
+        tracker.apply_update(&db, "rozo", update);
+        assert_eq!(
+            tracker.owned_status(),
+            Some(("rozo", "tui:not-ready")),
+            "failed clear must retain ownership for retry"
+        );
+        db.conn()
+            .execute("ALTER TABLE instances_unavailable RENAME TO instances", [])
+            .unwrap();
+        db.set_status("rozo", "active", "tool:Bash").unwrap();
+
+        tracker.reconcile_instance(&db, "rozo");
+
+        let row = db.get_instance_full("rozo").unwrap().unwrap();
+        assert_eq!(row.status_context, "tool:Bash");
+        assert_eq!(tracker.owned_status(), None);
     }
 
     // ---- ToolConfig ----

--- a/src/pty/screen.rs
+++ b/src/pty/screen.rs
@@ -14,6 +14,16 @@ use std::time::Instant;
 
 use crate::config::Config;
 
+/// Is `text` Antigravity's accept-edits banner rather than a user draft?
+///
+/// Callers must also require the ready footer; this predicate alone is not
+/// sufficient. The two-way prefix test accepts the banner whole or truncated by
+/// a narrow terminal, and rejects anything continuing past its end.
+fn is_antigravity_accept_edits_banner(text: &str) -> bool {
+    text.starts_with(ANTIGRAVITY_ACCEPT_EDITS_MARKER)
+        && ANTIGRAVITY_ACCEPT_EDITS_BANNER.starts_with(text)
+}
+
 /// Escape a string as a JSON string literal (with quotes).
 fn json_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
@@ -36,6 +46,16 @@ fn json_escape(s: &str) -> String {
 const OSC_TITLE_0: &[u8] = b"\x1b]0;";
 const OSC_TITLE_2: &[u8] = b"\x1b]2;";
 const CODEX_ACTION_REQUIRED: &str = "Action Required";
+
+/// Antigravity's accept-edits banner, rendered on the prompt row in normal
+/// intensity — visually identical to a user draft (`Antigravity 1.1.17`).
+const ANTIGRAVITY_ACCEPT_EDITS_BANNER: &str =
+    "Accept-edits mode: file edits auto-approved (shift+tab to cycle)";
+
+/// The stable leading portion of the banner. A narrow terminal truncates the
+/// tail, so recognition keys on this marker plus a prefix relation rather than
+/// on the full string.
+const ANTIGRAVITY_ACCEPT_EDITS_MARKER: &str = "Accept-edits mode:";
 
 /// Return the last complete OSC 0/2 terminal title in a raw output buffer.
 ///
@@ -918,6 +938,10 @@ impl ScreenTracker {
             Some((row_idx, trim_with_nbsp(after)))
         }) {
             if text.is_empty() {
+                return Some(String::new());
+            }
+
+            if self.is_ready() && is_antigravity_accept_edits_banner(text) {
                 return Some(String::new());
             }
 
@@ -1862,6 +1886,82 @@ mod tests {
         t.process("some agent output\r\n".as_bytes());
         t.process("> \r\n? for shortcuts\r\n".as_bytes());
         assert_eq!(t.get_antigravity_input_text(), Some(String::new()));
+    }
+
+    // ---- Antigravity accept-edits banner ----
+
+    #[test]
+    fn antigravity_accept_edits_banner_with_ready_is_empty() {
+        let mut t = make_tracker(24, 192, "? for shortcuts");
+        t.process(
+            "> Accept-edits mode: file edits auto-approved (shift+tab to cycle)\r\n             ? for shortcuts\r\n"
+                .as_bytes(),
+        );
+        assert_eq!(t.get_antigravity_input_text(), Some(String::new()));
+        assert!(t.is_prompt_empty("antigravity"));
+    }
+
+    #[test]
+    fn antigravity_accept_edits_banner_wrapped_is_empty() {
+        let mut t = make_tracker(24, 40, "? for shortcuts");
+        t.process(
+            "> Accept-edits mode: file edits auto-approved (shift+tab to cycle)\r\n             ? for shortcuts\r\n"
+                .as_bytes(),
+        );
+        assert_eq!(t.get_antigravity_input_text(), Some(String::new()));
+    }
+
+    #[test]
+    fn antigravity_banner_in_scrollback_then_real_draft_blocks() {
+        let mut t = make_tracker(24, 80, "? for shortcuts");
+        t.process(
+            "> Accept-edits mode: file edits auto-approved (shift+tab to cycle)\r\n".as_bytes(),
+        );
+        t.process("some agent output\r\n".as_bytes());
+        t.process("> deploy to prod\r\n? for shortcuts\r\n".as_bytes());
+        assert_eq!(
+            t.get_antigravity_input_text(),
+            Some("deploy to prod".to_string())
+        );
+        assert!(!t.is_prompt_empty("antigravity"));
+    }
+
+    // Ready footer absent: the banner must still block, or hcom would deliver
+    // into a session that cannot act.
+    #[test]
+    fn antigravity_banner_without_ready_footer_is_not_empty() {
+        let mut t = make_tracker(24, 192, "? for shortcuts");
+        t.process(
+            "> Accept-edits mode: file edits auto-approved (shift+tab to cycle)\r\n             AI: Out of credits\r\n"
+                .as_bytes(),
+        );
+        assert_eq!(
+            t.get_antigravity_input_text(),
+            Some("Accept-edits mode: file edits auto-approved (shift+tab to cycle)".to_string())
+        );
+    }
+
+    #[test]
+    fn antigravity_banner_text_with_trailing_draft_is_not_empty() {
+        let mut t = make_tracker(24, 192, "? for shortcuts");
+        t.process(
+            "> Accept-edits mode: file edits auto-approved (shift+tab to cycle) and also ship it\r\n             ? for shortcuts\r\n"
+                .as_bytes(),
+        );
+        assert_ne!(t.get_antigravity_input_text(), Some(String::new()));
+    }
+
+    #[test]
+    fn antigravity_accept_edits_banner_cut_inside_marker_still_blocks() {
+        let mut t = make_tracker(24, 12, "? for shortcuts");
+        t.process(
+            "> Accept-edits mode: file edits auto-approved (shift+tab to cycle)\r\n? for shortcuts\r\n"
+                .as_bytes(),
+        );
+        assert_eq!(
+            t.get_antigravity_input_text(),
+            Some("Accept-edi".to_string())
+        );
     }
 
     // ---- Claude input extraction ----

--- a/src/shared/constants.rs
+++ b/src/shared/constants.rs
@@ -75,6 +75,7 @@ const TUI_DELIVERY_PAUSED_STATUS_PREFIX: &str = "tui:";
 /// Whether queued messages cannot currently be submitted through the target's PTY.
 pub fn is_delivery_paused_status_context(status_context: &str) -> bool {
     status_context.starts_with(TUI_DELIVERY_PAUSED_STATUS_PREFIX)
+        || status_context == "pty:approval"
 }
 
 /// Valid status values (ordered for display priority).

--- a/src/shared/constants.rs
+++ b/src/shared/constants.rs
@@ -69,6 +69,14 @@ pub const ST_INACTIVE: &str = "inactive";
 pub const ST_LAUNCHING: &str = "launching";
 pub const ST_ERROR: &str = "error";
 
+/// Status-context prefix used while PTY delivery is held at a TUI safety gate.
+const TUI_DELIVERY_PAUSED_STATUS_PREFIX: &str = "tui:";
+
+/// Whether queued messages cannot currently be submitted through the target's PTY.
+pub fn is_delivery_paused_status_context(status_context: &str) -> bool {
+    status_context.starts_with(TUI_DELIVERY_PAUSED_STATUS_PREFIX)
+}
+
 /// Valid status values (ordered for display priority).
 pub const STATUS_ORDER: &[&str] = &[
     ST_ACTIVE,

--- a/src/shared/constants.rs
+++ b/src/shared/constants.rs
@@ -76,6 +76,7 @@ const TUI_DELIVERY_PAUSED_STATUS_PREFIX: &str = "tui:";
 pub fn is_delivery_paused_status_context(status_context: &str) -> bool {
     status_context.starts_with(TUI_DELIVERY_PAUSED_STATUS_PREFIX)
         || status_context == "pty:approval"
+        || status_context == "approval"
 }
 
 /// Valid status values (ordered for display priority).

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -34,6 +34,7 @@ pub use constants::{
     extract_mentions,
     format_pane_title,
     format_pane_title_combined,
+    is_delivery_paused_status_context,
     status_bg,
     status_fg,
     status_icon,

--- a/src/tui/model.rs
+++ b/src/tui/model.rs
@@ -273,7 +273,7 @@ impl Agent {
 
     /// True when PTY delivery is gate-blocked (daemon wrote a `tui:*` context).
     pub fn is_pty_blocked(&self) -> bool {
-        self.status_context.starts_with("tui:")
+        crate::shared::is_delivery_paused_status_context(&self.status_context)
     }
 }
 

--- a/src/tui/model.rs
+++ b/src/tui/model.rs
@@ -1251,6 +1251,13 @@ mod tests {
     }
 
     #[test]
+    fn pty_blocked_with_hook_approval_context() {
+        let mut a = test_agent("nova");
+        a.status_context = "approval".into();
+        assert!(a.is_pty_blocked());
+    }
+
+    #[test]
     fn pty_not_blocked_without_tui_prefix() {
         let mut a = test_agent("nova");
         a.status_context = "tool:Bash".into();

--- a/tests/real_tool_claude.rs
+++ b/tests/real_tool_claude.rs
@@ -223,6 +223,10 @@ fn real_claude_approval_gate_blocks_pending_message_then_clears_on_approval() {
         send_code, 0,
         "held-message send failed: stdout={send_stdout} stderr={send_stderr}"
     );
+    assert!(
+        send_stdout.contains("Queued; delivery paused:") && !send_stdout.contains("Sent to:"),
+        "approval-blocked recipient must be reported as queued: {send_stdout}"
+    );
 
     h.eventually(
         "blocked(approval) to latch from Claude's PermissionRequest hook",

--- a/tests/real_tool_claude.rs
+++ b/tests/real_tool_claude.rs
@@ -224,8 +224,8 @@ fn real_claude_approval_gate_blocks_pending_message_then_clears_on_approval() {
         "held-message send failed: stdout={send_stdout} stderr={send_stderr}"
     );
     assert!(
-        send_stdout.contains("Queued; delivery paused:") && !send_stdout.contains("Sent to:"),
-        "approval-blocked recipient must be reported as queued: {send_stdout}"
+        send_stdout.contains("Queued; delivery") && !send_stdout.contains("Sent to:"),
+        "approval-blocked or unresolved recipient must be reported as queued: {send_stdout}"
     );
 
     h.eventually(


### PR DESCRIPTION
## Summary

- recognize Antigravity's accept-edits banner as an empty prompt
- report blocked local PTY delivery as queued instead of sent
- classify PTY and hook approval contexts as paused delivery
- report unresolved local PTY delivery as pending instead of sent
- preserve debounce for transient gates and publish durable blockers promptly
- make shared gate-status ownership atomic and instance-bound
- keep feedback synchronization collective and bounded

## Verification

- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features -- --test-threads=1`
- 2,241 passed; 16 ignored
- live approval gate reports `Queued; delivery paused`
- live Claude, Codex, Droid, and Antigravity matrix: 4/4 received and answered
