### PR TITLE
feat(list): expose receipt-backed Droid attestation

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -148,6 +148,9 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
 
         match db.get_instance_full(&lookup_name) {
             Ok(Some(data)) => {
+                let adapter_attestation = db
+                    .has_adapter_attestation(&data.name, data.created_at)
+                    .then_some("droid");
                 let mut payload = serde_json::json!({
                     "name": lookup_name,
                     "session_id": data.session_id,
@@ -157,6 +160,7 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
                     "parent_name": data.parent_name,
                     "agent_id": data.agent_id,
                     "tool": data.tool,
+                    "adapter_attestation": adapter_attestation,
                 });
 
                 if is_self
@@ -231,6 +235,9 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
             // Get binding status
             let hooks_bound = db.has_session_binding(&data.name);
             let process_bound = db.has_process_binding_for_instance(&data.name);
+            let adapter_attestation = db
+                .has_adapter_attestation(&data.name, data.created_at)
+                .then_some("droid");
 
             // Parse launch_context JSON
             let launch_context: serde_json::Value = data
@@ -262,6 +269,7 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
                 "hooks_bound": hooks_bound,
                 "process_bound": process_bound,
                 "launch_context": launch_context,
+                "adapter_attestation": adapter_attestation,
             });
             result_list.push(payload);
         }
@@ -352,6 +360,9 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
     let mut max_name_len = 0;
     for data in &sorted_instances {
         let mut n = get_full_name(data).len();
+        if db.has_adapter_attestation(&data.name, data.created_at) {
+            n += " [adapter-attested]".len();
+        }
         if data.background != 0 {
             n += 11; // " [headless]"
         }
@@ -405,6 +416,14 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
         };
 
         // Badges
+        let adapter_attestation = db
+            .has_adapter_attestation(&data.name, data.created_at)
+            .then_some("droid");
+        let attestation_badge = if adapter_attestation.is_some() {
+            " [adapter-attested]"
+        } else {
+            ""
+        };
         let headless_badge = if data.background != 0 {
             " [headless]"
         } else {
@@ -452,7 +471,8 @@ pub fn cmd_list(db: &HcomDb, args: &ListArgs, ctx: Option<&CommandContext>) -> i
             String::new()
         };
 
-        let name_part = format!("{name}{headless_badge}{remote_badge}{unread_str}");
+        let name_part =
+            format!("{name}{attestation_badge}{headless_badge}{remote_badge}{unread_str}");
         let status_text =
             format!("{age_display}{desc_sep}{description}{listening_since}{timeout_marker}");
 
@@ -635,6 +655,10 @@ fn print_instance_details(db: &HcomDb, data: &InstanceRow, display_name: &str) {
         && !tag.is_empty()
     {
         println!("  Tag:         {tag}");
+    }
+
+    if db.has_adapter_attestation(&data.name, data.created_at) {
+        println!("  Attestation: droid (adapter_hook receipt)");
     }
 
     // Status & Connection

--- a/src/db/events.rs
+++ b/src/db/events.rs
@@ -98,6 +98,63 @@ impl HcomDb {
         false
     }
 
+    /// Return whether the current instance generation has a valid Droid adapter receipt.
+    pub fn has_adapter_attestation(&self, name: &str, created_at: f64) -> bool {
+        let Ok(mut stmt) = self.conn().prepare(
+            "SELECT id, data FROM events \
+             WHERE type = 'receipt' AND instance = ?1 ORDER BY id DESC",
+        ) else {
+            return false;
+        };
+        let Ok(rows) = stmt.query_map([name], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        }) else {
+            return false;
+        };
+
+        for row in rows.flatten() {
+            let (receipt_id, raw_receipt) = row;
+            let Ok(receipt) = serde_json::from_str::<serde_json::Value>(&raw_receipt) else {
+                continue;
+            };
+            let Some(request_id) = receipt.get("request_id").and_then(|v| v.as_i64()) else {
+                continue;
+            };
+            let valid_envelope = receipt.get("channel").and_then(|v| v.as_str())
+                == Some("adapter_hook")
+                && matches!(
+                    receipt.get("hook").and_then(|v| v.as_str()),
+                    Some("UserPromptSubmit" | "Stop")
+                )
+                && receipt.get("instance_created_at").and_then(|v| v.as_f64()) == Some(created_at)
+                && request_id < receipt_id;
+            if !valid_envelope {
+                continue;
+            }
+            let request_data = self.conn().query_row(
+                "SELECT data FROM events WHERE id = ?1 AND type = 'message'",
+                [request_id],
+                |row| row.get::<_, String>(0),
+            );
+            let Ok(raw_request) = request_data else {
+                continue;
+            };
+            let Ok(request) = serde_json::from_str::<serde_json::Value>(&raw_request) else {
+                continue;
+            };
+            let addressed = ["delivered_to", "mentions"].iter().any(|field| {
+                request
+                    .get(field)
+                    .and_then(|v| v.as_array())
+                    .is_some_and(|values| values.iter().any(|v| v.as_str() == Some(name)))
+            });
+            if addressed {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Get unread messages for an instance
     ///
     /// Returns messages where:

--- a/src/db/events.rs
+++ b/src/db/events.rs
@@ -764,4 +764,205 @@ mod tests {
 
         cleanup_test_db(db_path);
     }
+
+    #[test]
+    fn test_adapter_attestation_accepts_generation_bound_addressed_receipt() {
+        let (db, db_path) = setup_full_test_db();
+        db.conn
+            .execute(
+                "INSERT INTO instances (name, created_at) VALUES ('pita', 100.0)",
+                [],
+            )
+            .unwrap();
+
+        let request_id = db
+            .log_event(
+                "message",
+                "suki",
+                &serde_json::json!({
+                    "from": "suki",
+                    "mentions": ["pita"],
+                    "delivered_to": ["pita"],
+                    "text": "review"
+                }),
+            )
+            .unwrap();
+        db.log_event(
+            "receipt",
+            "pita",
+            &serde_json::json!({
+                "request_id": request_id,
+                "channel": "adapter_hook",
+                "hook": "Stop",
+                "instance_created_at": 100.0
+            }),
+        )
+        .unwrap();
+
+        assert!(db.has_adapter_attestation("pita", 100.0));
+
+        cleanup_test_db(db_path);
+    }
+
+    #[test]
+    fn test_adapter_attestation_rejects_untrusted_evidence() {
+        let (db, db_path) = setup_full_test_db();
+        db.conn
+            .execute(
+                "INSERT INTO instances (name, created_at) VALUES ('pita', 100.0)",
+                [],
+            )
+            .unwrap();
+
+        let addressed_request_id = db
+            .log_event(
+                "message",
+                "suki",
+                &serde_json::json!({
+                    "from": "suki",
+                    "mentions": ["pita"],
+                    "delivered_to": ["pita"],
+                    "text": "review"
+                }),
+            )
+            .unwrap();
+
+        db.log_event(
+            "receipt",
+            "pita",
+            &serde_json::json!({
+                "request_id": addressed_request_id,
+                "channel": "adapter_hook",
+                "hook": "Stop"
+            }),
+        )
+        .unwrap();
+        assert!(!db.has_adapter_attestation("pita", 100.0));
+
+        db.log_event(
+            "receipt",
+            "pita",
+            &serde_json::json!({
+                "request_id": addressed_request_id,
+                "channel": "adapter_hook",
+                "hook": "Stop",
+                "instance_created_at": 200.0
+            }),
+        )
+        .unwrap();
+        assert!(!db.has_adapter_attestation("pita", 100.0));
+
+        db.log_event(
+            "receipt",
+            "pita",
+            &serde_json::json!({
+                "request_id": addressed_request_id,
+                "channel": "adapter_hook",
+                "hook": "Keepalive",
+                "instance_created_at": 100.0
+            }),
+        )
+        .unwrap();
+        assert!(!db.has_adapter_attestation("pita", 100.0));
+
+        db.log_event(
+            "receipt",
+            "other",
+            &serde_json::json!({
+                "request_id": addressed_request_id,
+                "channel": "adapter_hook",
+                "hook": "Stop",
+                "instance_created_at": 100.0
+            }),
+        )
+        .unwrap();
+        assert!(!db.has_adapter_attestation("pita", 100.0));
+
+        let unaddressed_request_id = db
+            .log_event(
+                "message",
+                "suki",
+                &serde_json::json!({
+                    "from": "suki",
+                    "mentions": ["other"],
+                    "delivered_to": ["other"],
+                    "text": "review"
+                }),
+            )
+            .unwrap();
+        db.log_event(
+            "receipt",
+            "pita",
+            &serde_json::json!({
+                "request_id": unaddressed_request_id,
+                "channel": "adapter_hook",
+                "hook": "Stop",
+                "instance_created_at": 100.0
+            }),
+        )
+        .unwrap();
+        assert!(!db.has_adapter_attestation("pita", 100.0));
+
+        db.conn
+            .execute("DROP TRIGGER events_fts_insert", [])
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO events (timestamp, type, instance, data) \
+                 VALUES ('2026-09-01T00:00:00Z', 'receipt', 'pita', '{malformed')",
+                [],
+            )
+            .unwrap();
+        assert!(!db.has_adapter_attestation("pita", 100.0));
+
+        db.conn
+            .execute(
+                "INSERT INTO events (timestamp, type, instance, data) \
+                 VALUES ('2026-09-01T00:00:00Z', 'message', 'suki', '{malformed')",
+                [],
+            )
+            .unwrap();
+        let malformed_request_id = db.conn.last_insert_rowid();
+        db.log_event(
+            "receipt",
+            "pita",
+            &serde_json::json!({
+                "request_id": malformed_request_id,
+                "channel": "adapter_hook",
+                "hook": "Stop",
+                "instance_created_at": 100.0
+            }),
+        )
+        .unwrap();
+        assert!(!db.has_adapter_attestation("pita", 100.0));
+
+        let future_request_id = db.get_last_event_id() + 2;
+        db.log_event(
+            "receipt",
+            "pita",
+            &serde_json::json!({
+                "request_id": future_request_id,
+                "channel": "adapter_hook",
+                "hook": "UserPromptSubmit",
+                "instance_created_at": 100.0
+            }),
+        )
+        .unwrap();
+        let actual_request_id = db
+            .log_event(
+                "message",
+                "suki",
+                &serde_json::json!({
+                    "from": "suki",
+                    "mentions": ["pita"],
+                    "delivered_to": ["pita"],
+                    "text": "late request"
+                }),
+            )
+            .unwrap();
+        assert_eq!(actual_request_id, future_request_id);
+        assert!(!db.has_adapter_attestation("pita", 100.0));
+
+        cleanup_test_db(db_path);
+    }
 }

--- a/src/db/events.rs
+++ b/src/db/events.rs
@@ -5,6 +5,14 @@ use rusqlite::params;
 
 use super::{HcomDb, chrono_now_iso, subscriptions};
 
+fn adapter_generation_matches(receipt: f64, current: f64) -> bool {
+    receipt.is_finite()
+        && current.is_finite()
+        && receipt >= 0.0
+        && current >= 0.0
+        && receipt.to_bits().abs_diff(current.to_bits()) <= 1
+}
+
 /// Message from the events table
 #[derive(Debug, Clone)]
 pub struct Message {
@@ -126,7 +134,10 @@ impl HcomDb {
                     receipt.get("hook").and_then(|v| v.as_str()),
                     Some("UserPromptSubmit" | "Stop")
                 )
-                && receipt.get("instance_created_at").and_then(|v| v.as_f64()) == Some(created_at)
+                && receipt
+                    .get("instance_created_at")
+                    .and_then(|v| v.as_f64())
+                    .is_some_and(|token| adapter_generation_matches(token, created_at))
                 && request_id < receipt_id;
             if !valid_envelope {
                 continue;

--- a/src/db/events.rs
+++ b/src/db/events.rs
@@ -862,6 +862,48 @@ mod tests {
     }
 
     #[test]
+    fn test_adapter_attestation_accepts_one_ulp_generation_variance_only() {
+        let (db, db_path) = setup_full_test_db();
+        let receipt_generation = 1_788_315_180.618_200_3_f64;
+        let one_ulp_higher = f64::from_bits(receipt_generation.to_bits() + 1);
+        let two_ulps_higher = f64::from_bits(receipt_generation.to_bits() + 2);
+        db.conn
+            .execute(
+                "INSERT INTO instances (name, created_at) VALUES ('pita', ?1)",
+                [one_ulp_higher],
+            )
+            .unwrap();
+
+        let request_id = db
+            .log_event(
+                "message",
+                "suki",
+                &serde_json::json!({
+                    "from": "suki",
+                    "mentions": ["pita"],
+                    "delivered_to": ["pita"],
+                    "text": "review"
+                }),
+            )
+            .unwrap();
+        db.log_event(
+            "receipt",
+            "pita",
+            &serde_json::json!({
+                "request_id": request_id,
+                "channel": "adapter_hook",
+                "hook": "Stop",
+                "instance_created_at": receipt_generation
+            }),
+        )
+        .unwrap();
+        assert!(!db.has_adapter_attestation("pita", two_ulps_higher));
+        assert!(db.has_adapter_attestation("pita", one_ulp_higher));
+
+        cleanup_test_db(db_path);
+    }
+
+    #[test]
     fn test_adapter_attestation_rejects_untrusted_evidence() {
         let (db, db_path) = setup_full_test_db();
         db.conn

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -83,6 +83,93 @@ fn list_json_empty() {
 }
 
 #[test]
+fn droid_attestation_requires_current_generation_adapter_receipt() {
+    let h = Hcom::new();
+    let (code, _, stderr) = h.run(["list", "--json"]);
+    assert_eq!(code, 0, "{stderr}");
+
+    let created_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock after Unix epoch")
+        .as_secs_f64();
+    let conn = rusqlite::Connection::open(h.path().join("hcom.db")).expect("open hcom db");
+    conn.execute(
+        "INSERT INTO instances \
+         (name, tag, tool, created_at, status, status_time, last_seen) \
+         VALUES ('pita', 'droid', 'adhoc', ?1, 'active', CAST(?1 AS INTEGER), CAST(?1 AS INTEGER))",
+        [created_at],
+    )
+    .expect("seed Droid adapter instance");
+    conn.execute("DROP TRIGGER events_fts_insert", [])
+        .expect("allow malformed ledger fixture");
+    conn.execute(
+        "INSERT INTO events (timestamp, type, instance, data) \
+         VALUES ('2026-09-01T00:00:00Z', 'receipt', 'pita', '{malformed')",
+        [],
+    )
+    .expect("seed malformed receipt");
+    let request = serde_json::json!({
+        "from": "suki",
+        "mentions": ["pita"],
+        "delivered_to": ["pita"],
+        "text": "review"
+    });
+    conn.execute(
+        "INSERT INTO events (timestamp, type, instance, data) \
+         VALUES ('2026-09-01T00:00:01Z', 'message', 'suki', ?1)",
+        [request.to_string()],
+    )
+    .expect("seed addressed request");
+    let request_id = conn.last_insert_rowid();
+
+    let (code, stdout, stderr) = h.run(["list", "--json"]);
+    assert_eq!(code, 0, "{stderr}");
+    let list: serde_json::Value = serde_json::from_str(&stdout).expect("list json");
+    let instance = &list.as_array().expect("list array")[0];
+    assert_eq!(instance["name"], "droid-pita");
+    assert!(instance["adapter_attestation"].is_null());
+
+    let receipt = serde_json::json!({
+        "request_id": request_id,
+        "channel": "adapter_hook",
+        "hook": "Stop",
+        "instance_created_at": created_at
+    });
+    conn.execute(
+        "INSERT INTO events (timestamp, type, instance, data) \
+         VALUES ('2026-09-01T00:00:02Z', 'receipt', 'pita', ?1)",
+        [receipt.to_string()],
+    )
+    .expect("seed current-generation adapter receipt");
+
+    let (code, stdout, stderr) = h.run(["list", "--json"]);
+    assert_eq!(code, 0, "{stderr}");
+    let list: serde_json::Value = serde_json::from_str(&stdout).expect("list json");
+    let instance = &list.as_array().expect("list array")[0];
+    assert_eq!(instance["adapter_attestation"], "droid");
+
+    let (code, stdout, stderr) = h.run(["list"]);
+    assert_eq!(code, 0, "{stderr}");
+    assert!(stdout.contains("droid-pita [adapter-attested]"), "{stdout}");
+
+    let (code, stdout, stderr) = h.run(["list", "--names"]);
+    assert_eq!(code, 0, "{stderr}");
+    assert_eq!(stdout.trim(), "droid-pita");
+
+    let (code, stdout, stderr) = h.run(["list", "droid-pita", "--json"]);
+    assert_eq!(code, 0, "{stderr}");
+    let instance: serde_json::Value = serde_json::from_str(&stdout).expect("instance json");
+    assert_eq!(instance["adapter_attestation"], "droid");
+
+    let (code, stdout, stderr) = h.run(["list", "droid-pita"]);
+    assert_eq!(code, 0, "{stderr}");
+    assert!(
+        stdout.contains("Attestation: droid (adapter_hook receipt)"),
+        "{stdout}"
+    );
+}
+
+#[test]
 fn events_empty_in_fresh_dir() {
     let h = Hcom::new();
     let (code, stdout, _stderr) = h.run(["events", "--last", "5"]);


### PR DESCRIPTION
## Summary

- expose receipt-backed Droid adapter attestation in `hcom list`
- require an addressed request followed by a current-generation `UserPromptSubmit` or `Stop` adapter receipt
- keep display tags out of the attestation decision
- accept only exact or adjacent IEEE-754 generation values to tolerate empirically bounded default-parser drift

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-targets --locked` — 2,214 passed; 16 ignored

This is forgeable same-user local receipt evidence, not authentication. nurmterm owns adapter receipt-schema churn. Human `list` currently performs two receipt-history lookups per instance; that tradeoff is called out for maintainer review.
