### PR TITLE
fix(transcript): report unavailable model history honestly

### DIFF
--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -31,6 +31,10 @@ const FILTER_HELP: &[HelpEntry] = &[
     ),
     ("  --collision", "Two agents edit same file within 30s"),
     ("  --from NAME", "Sender"),
+    (
+        "  --participant NAME",
+        "Message sender or delivery recipient",
+    ),
     ("  --mention NAME", "@mention target"),
     ("  --intent VAL", "request | inform | ack"),
     ("  --thread NAME", "Thread name"),

--- a/src/commands/transcript.rs
+++ b/src/commands/transcript.rs
@@ -255,8 +255,8 @@ fn get_transcript_path(db: &HcomDb, name: &str) -> Option<String> {
 fn no_transcript_error(db: &HcomDb, name: &str) -> String {
     if let Some(resolved) = crate::identity::resolve_display_name_or_stopped(db, name) {
         format!(
-            "Agent '{}' has no transcript yet — no messages have been exchanged",
-            resolved
+            "No model transcript is registered for {resolved}.\n\
+View transport messages with: hcom events --agent {resolved} --type message"
         )
     } else {
         format!("Agent '{name}' not found")

--- a/src/commands/transcript.rs
+++ b/src/commands/transcript.rs
@@ -1436,6 +1436,26 @@ mod tests {
     }
 
     #[test]
+    fn known_agent_without_transcript_points_to_transport_history() {
+        let db = test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances (name, created_at, transcript_path, tool) \
+             VALUES ('pita', 100.0, '', 'adhoc')",
+                [],
+            )
+            .unwrap();
+
+        let error = no_transcript_error(&db, "pita");
+        assert_eq!(
+            error,
+            "No model transcript is registered for pita.\n\
+View transport messages with: hcom events --agent pita --type message"
+        );
+        assert!(!error.contains("no messages have been exchanged"));
+    }
+
+    #[test]
     fn test_parse_range() {
         assert_eq!(parse_range("5"), (Some(5), Some(5)));
         assert_eq!(parse_range("3-10"), (Some(3), Some(10)));

--- a/src/commands/transcript.rs
+++ b/src/commands/transcript.rs
@@ -252,14 +252,29 @@ fn get_transcript_path(db: &HcomDb, name: &str) -> Option<String> {
 /// Build an appropriate error message when transcript resolution fails.
 /// Uses resolve_display_name_or_stopped (which handles exact base and tag-name
 /// resolution) to check if the instance exists without a transcript.
-fn no_transcript_error(db: &HcomDb, name: &str) -> String {
+fn no_transcript_error(
+    db: &HcomDb,
+    name: &str,
+    display_name: &str,
+    device: Option<&str>,
+) -> String {
     if let Some(resolved) = crate::identity::resolve_display_name_or_stopped(db, name) {
+        let display_name = if display_name.is_empty() {
+            &resolved
+        } else {
+            display_name
+        };
+        let command = match device {
+            Some(device) => format!(
+                "hcom events --remote-fetch --device {device} --participant {resolved} --type message"
+            ),
+            None => format!("hcom events --participant {resolved} --type message"),
+        };
         format!(
-            "No model transcript is registered for {resolved}.\n\
-View transport messages with: hcom events --agent {resolved} --type message"
+            "No model transcript is registered for {display_name}.\nView transport messages with: {command}"
         )
     } else {
-        format!("Agent '{name}' not found")
+        format!("Agent '{display_name}' not found")
     }
 }
 
@@ -1006,6 +1021,8 @@ pub fn cmd_transcript(db: &HcomDb, args: &TranscriptArgs, ctx: Option<&CommandCo
                 crate::relay::control::rpc_action::TRANSCRIPT,
                 &json!({
                     "target": base_name,
+                    "display_target": resolved,
+                    "origin_device": device,
                     "last": last_n,
                     "range": args.range_flag.as_ref().or(args.range_positional.as_ref()),
                     "json": json_mode,
@@ -1050,7 +1067,7 @@ pub fn cmd_transcript(db: &HcomDb, args: &TranscriptArgs, ctx: Option<&CommandCo
         match resolved {
             Some(r) => r,
             None => {
-                eprintln!("Error: {}", no_transcript_error(db, name));
+                eprintln!("Error: {}", no_transcript_error(db, name, name, None));
                 return 1;
             }
         }
@@ -1210,6 +1227,8 @@ pub fn render_instance_transcript(
             last_n,
             ..Default::default()
         },
+        name,
+        None,
     )
 }
 
@@ -1233,6 +1252,37 @@ pub fn render_instance_transcript_with_options_no_retry(
             detailed,
             retry_codex: false,
         },
+        name,
+        None,
+    )
+}
+
+/// Render a remote transcript while retaining the caller's device-qualified
+/// name in diagnostics.
+pub fn render_remote_instance_transcript_with_options_no_retry(
+    db: &HcomDb,
+    name: &str,
+    display_name: &str,
+    device: &str,
+    range: Option<&str>,
+    last_n: usize,
+    json_mode: bool,
+    full_mode: bool,
+    detailed: bool,
+) -> Result<String, String> {
+    render_instance_transcript_impl(
+        db,
+        name,
+        &TranscriptRenderOpts {
+            range,
+            last_n,
+            json_mode,
+            full_mode,
+            detailed,
+            retry_codex: false,
+        },
+        display_name,
+        Some(device),
     )
 }
 
@@ -1256,6 +1306,8 @@ pub fn render_instance_transcript_with_options(
             detailed,
             retry_codex: true,
         },
+        name,
+        None,
     )
 }
 
@@ -1263,9 +1315,12 @@ fn render_instance_transcript_impl(
     db: &HcomDb,
     name: &str,
     opts: &TranscriptRenderOpts<'_>,
+    display_name: &str,
+    device: Option<&str>,
 ) -> Result<String, String> {
     let (instance_name, transcript_path, agent_type, session_id) =
-        resolve_instance_transcript(db, name).ok_or_else(|| no_transcript_error(db, name))?;
+        resolve_instance_transcript(db, name)
+            .ok_or_else(|| no_transcript_error(db, name, display_name, device))?;
     let (range_start, range_end) = if let Some(r) = opts.range {
         parse_range(r)
     } else {
@@ -1446,13 +1501,32 @@ mod tests {
             )
             .unwrap();
 
-        let error = no_transcript_error(&db, "pita");
+        let error = no_transcript_error(&db, "pita", "pita", None);
         assert_eq!(
             error,
             "No model transcript is registered for pita.\n\
-View transport messages with: hcom events --agent pita --type message"
+View transport messages with: hcom events --participant pita --type message"
         );
         assert!(!error.contains("no messages have been exchanged"));
+    }
+
+    #[test]
+    fn remote_agent_without_transcript_queries_its_origin_device() {
+        let db = test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances (name, created_at, transcript_path, tool) \
+                 VALUES ('pita', 100.0, '', 'adhoc')",
+                [],
+            )
+            .unwrap();
+
+        let error = no_transcript_error(&db, "pita", "pita:ABCD", Some("ABCD"));
+        assert_eq!(
+            error,
+            "No model transcript is registered for pita:ABCD.\n\
+View transport messages with: hcom events --remote-fetch --device ABCD --participant pita --type message"
+        );
     }
 
     #[test]

--- a/src/commands/transcript.rs
+++ b/src/commands/transcript.rs
@@ -1264,26 +1264,9 @@ pub fn render_remote_instance_transcript_with_options_no_retry(
     name: &str,
     display_name: &str,
     device: &str,
-    range: Option<&str>,
-    last_n: usize,
-    json_mode: bool,
-    full_mode: bool,
-    detailed: bool,
+    opts: &TranscriptRenderOpts<'_>,
 ) -> Result<String, String> {
-    render_instance_transcript_impl(
-        db,
-        name,
-        &TranscriptRenderOpts {
-            range,
-            last_n,
-            json_mode,
-            full_mode,
-            detailed,
-            retry_codex: false,
-        },
-        display_name,
-        Some(device),
-    )
+    render_instance_transcript_impl(db, name, opts, display_name, Some(device))
 }
 
 pub fn render_instance_transcript_with_options(

--- a/src/core/filters.rs
+++ b/src/core/filters.rs
@@ -20,6 +20,7 @@ const FLAG_MAP: &[(&str, &str)] = &[
     ("--file", "file"),
     ("--cmd", "cmd"),
     ("--from", "from"),
+    ("--participant", "participant"),
     ("--mention", "mention"),
     ("--action", "action"),
     ("--after", "after"),
@@ -33,7 +34,14 @@ const FLAG_MAP: &[(&str, &str)] = &[
 /// Flags that require type='status'.
 const STATUS_FLAGS: &[&str] = &["status", "context", "file", "cmd"];
 /// Flags that require type='message'.
-const MESSAGE_FLAGS: &[&str] = &["from", "mention", "intent", "thread", "reply_to"];
+const MESSAGE_FLAGS: &[&str] = &[
+    "from",
+    "participant",
+    "mention",
+    "intent",
+    "thread",
+    "reply_to",
+];
 /// Flags that require type='life'.
 const LIFE_FLAGS: &[&str] = &["action"];
 
@@ -155,7 +163,7 @@ pub fn parse_event_flags(argv: &[String]) -> Result<(FilterMap, Vec<String>), St
 ///
 ///
 pub fn resolve_filter_names(filters: &mut FilterMap, db: &crate::db::HcomDb) {
-    for key in ["instance", "mention"] {
+    for key in ["instance", "participant", "mention"] {
         let Some(names) = filters.get_mut(key) else {
             continue;
         };
@@ -279,6 +287,22 @@ pub fn build_sql_from_flags(filters: &FilterMap) -> Result<String, String> {
         clauses.push("type = 'message'".into());
     } else if LIFE_FLAGS.iter().any(|f| filters.contains_key(*f)) {
         clauses.push("type = 'life'".into());
+    }
+
+    // A participant is either the message's routing instance (the sender) or
+    // one of its delivery recipients. Unlike --agent, this reconstructs both
+    // sides of an hcom transport exchange.
+    if let Some(values) = filters.get("participant") {
+        let participant_clauses: Vec<String> = values
+            .iter()
+            .map(|value| {
+                let value = escape_sql(value);
+                format!(
+                    "(instance = '{value}' OR EXISTS (SELECT 1 FROM json_each(msg_delivered_to) WHERE value = '{value}'))"
+                )
+            })
+            .collect();
+        clauses.push(or_wrap(participant_clauses));
     }
 
     // Status filter
@@ -466,6 +490,9 @@ pub struct EventFilterArgs {
     pub cmd: Vec<String>,
     #[arg(long)]
     pub from: Vec<String>,
+    /// Include messages sent by or delivered to this participant.
+    #[arg(long)]
+    pub participant: Vec<String>,
     #[arg(long)]
     pub mention: Vec<String>,
     #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(["created", "started", "ready", "stopped", "batch_launched", "launch_failed", "launch_blocked"]))]
@@ -522,6 +549,7 @@ impl EventFilterArgs {
         insert_if_nonempty!("file", self.file.clone());
         insert_if_nonempty!("cmd", self.cmd.clone());
         insert_if_nonempty!("from", self.from.clone());
+        insert_if_nonempty!("participant", self.participant.clone());
         insert_if_nonempty!("mention", self.mention.clone());
         insert_if_nonempty!("action", self.action.clone());
         insert_if_nonempty!("after", self.after.clone());
@@ -546,6 +574,7 @@ impl EventFilterArgs {
             || !self.file.is_empty()
             || !self.cmd.is_empty()
             || !self.from.is_empty()
+            || !self.participant.is_empty()
             || !self.mention.is_empty()
             || !self.action.is_empty()
             || !self.after.is_empty()
@@ -659,6 +688,16 @@ mod tests {
         filters.insert("instance".into(), vec!["peso".into(), "luna".into()]);
         let sql = build_sql_from_flags(&filters).unwrap();
         assert!(sql.contains("instance IN ('peso', 'luna')"));
+    }
+
+    #[test]
+    fn test_build_participant_matches_sender_and_recipient() {
+        let mut filters = FilterMap::new();
+        filters.insert("participant".into(), vec!["pita".into()]);
+        let sql = build_sql_from_flags(&filters).unwrap();
+        assert!(sql.contains("type = 'message'"));
+        assert!(sql.contains("instance = 'pita'"));
+        assert!(sql.contains("json_each(msg_delivered_to) WHERE value = 'pita'"));
     }
 
     #[test]

--- a/src/relay/control.rs
+++ b/src/relay/control.rs
@@ -987,9 +987,25 @@ fn handle_remote_transcript(
     let json_mode = bool_param(params, "json", false);
     let full_mode = bool_param(params, "full", false);
     let detailed = bool_param(params, "detailed", false);
-    let content = crate::commands::transcript::render_instance_transcript_with_options_no_retry(
-        db, target, range, last_n, json_mode, full_mode, detailed,
-    )?;
+    let display_target = optional_param(params, "display_target").unwrap_or(target);
+    let content = match optional_param(params, "origin_device") {
+        Some(device) => {
+            crate::commands::transcript::render_remote_instance_transcript_with_options_no_retry(
+                db,
+                target,
+                display_target,
+                device,
+                range,
+                last_n,
+                json_mode,
+                full_mode,
+                detailed,
+            )?
+        }
+        None => crate::commands::transcript::render_instance_transcript_with_options_no_retry(
+            db, target, range, last_n, json_mode, full_mode, detailed,
+        )?,
+    };
     Ok(json!({"target": target, "content": content}))
 }
 

--- a/src/relay/control.rs
+++ b/src/relay/control.rs
@@ -995,11 +995,14 @@ fn handle_remote_transcript(
                 target,
                 display_target,
                 device,
-                range,
-                last_n,
-                json_mode,
-                full_mode,
-                detailed,
+                &crate::commands::transcript::TranscriptRenderOpts {
+                    range,
+                    last_n,
+                    json_mode,
+                    full_mode,
+                    detailed,
+                    retry_codex: false,
+                },
             )?
         }
         None => crate::commands::transcript::render_instance_transcript_with_options_no_retry(


### PR DESCRIPTION
## Summary

- stop reporting transport history as empty when model transcript history is unavailable
- direct operators to `hcom events` for transport-level evidence

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-targets --locked` — 2,211 passed; 16 ignored
