### PR TITLE
fix(send): resolve remote reply origin from relay metadata

### DIFF
--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -476,23 +476,53 @@ pub fn send_message(
     Ok(delivery.delivered_to)
 }
 
-/// Resolve reply_to to local event ID. Returns None if not found.
+/// Resolve reply_to to local event ID. Returns None if not found or ambiguous.
 fn resolve_reply_to_local(db: &HcomDb, reply_to: &str) -> Option<i64> {
-    // reply_to can be "42" or "42:BOXE" (remote)
-    let local_part = reply_to.split(':').next()?;
-    let id: i64 = local_part.parse().ok()?;
+    let reply_to = reply_to.trim();
+    if reply_to.is_empty() {
+        return None;
+    }
 
-    // Verify event exists and is a message
-    let exists: bool = db
-        .conn()
-        .query_row(
-            "SELECT 1 FROM events WHERE id = ? AND type = 'message'",
-            rusqlite::params![id],
-            |_| Ok(true),
-        )
-        .unwrap_or(false);
+    if let Some((origin_str, device_short)) = reply_to.split_once(':') {
+        if origin_str.is_empty() || device_short.is_empty() || device_short.contains(':') {
+            return None;
+        }
+        let origin_id: i64 = origin_str.parse().ok()?;
 
-    if exists { Some(id) } else { None }
+        let mut stmt = db
+            .conn()
+            .prepare(
+                "SELECT id FROM events WHERE type = 'message' \
+                 AND CAST(json_extract(data, '$._relay.id') AS INTEGER) = ? \
+                 AND json_extract(data, '$._relay.short') = ? \
+                 LIMIT 2",
+            )
+            .ok()?;
+
+        let matching_ids: Vec<i64> = stmt
+            .query_map(rusqlite::params![origin_id, device_short], |row| row.get(0))
+            .ok()?
+            .flatten()
+            .collect();
+
+        if matching_ids.len() == 1 {
+            Some(matching_ids[0])
+        } else {
+            None
+        }
+    } else {
+        let local_id: i64 = reply_to.parse().ok()?;
+        let exists: bool = db
+            .conn()
+            .query_row(
+                "SELECT 1 FROM events WHERE id = ? AND type = 'message'",
+                rusqlite::params![local_id],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+
+        if exists { Some(local_id) } else { None }
+    }
 }
 
 /// Get thread from an event (for --reply-to thread inheritance).
@@ -1732,5 +1762,229 @@ mod tests {
         let (targets, msg) = process_positionals(&["@luna".to_string(), "hello".to_string()]);
         assert_eq!(targets, vec!["luna"]);
         assert_eq!(msg.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_reply_to_remote_different_local_id() {
+        let (db, path, _env) = setup_test_db();
+        let data = serde_json::json!({
+            "text": "remote message",
+            "_relay": {
+                "id": 42,
+                "short": "BOXE",
+                "device": "dev-uuid-boxe"
+            }
+        });
+        db.conn()
+            .execute(
+                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-inst', '2026-09-04T00:00:00Z', ?)",
+                [data.to_string()],
+            )
+            .unwrap();
+        db.kv_set("relay_short_BOXE", Some("dev-uuid-boxe"))
+            .unwrap();
+
+        let resolved = resolve_reply_to_local(&db, "42:BOXE");
+        assert_eq!(resolved, Some(100));
+
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_reply_to_remote_colliding_local_id() {
+        let (db, path, _env) = setup_test_db();
+        let local_data = serde_json::json!({ "text": "unrelated local message" });
+        db.conn()
+            .execute(
+                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (42, 'message', 'local-inst', '2026-09-04T00:00:00Z', ?)",
+                [local_data.to_string()],
+            )
+            .unwrap();
+
+        let remote_data = serde_json::json!({
+            "text": "remote message",
+            "_relay": {
+                "id": 42,
+                "short": "BOXE",
+                "device": "dev-uuid-boxe"
+            }
+        });
+        db.conn()
+            .execute(
+                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-inst', '2026-09-04T00:00:00Z', ?)",
+                [remote_data.to_string()],
+            )
+            .unwrap();
+        db.kv_set("relay_short_BOXE", Some("dev-uuid-boxe"))
+            .unwrap();
+
+        // 42:BOXE must resolve to the remote event (100), never the colliding local event (42)
+        assert_eq!(resolve_reply_to_local(&db, "42:BOXE"), Some(100));
+        // local 42 without suffix must resolve to the local event (42)
+        assert_eq!(resolve_reply_to_local(&db, "42"), Some(42));
+
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_reply_to_two_devices_same_origin_id() {
+        let (db, path, _env) = setup_test_db();
+        let remote_data_1 = serde_json::json!({
+            "text": "remote message 1",
+            "_relay": {
+                "id": 42,
+                "short": "BOXE",
+                "device": "dev-uuid-boxe"
+            }
+        });
+        db.conn()
+            .execute(
+                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-1', '2026-09-04T00:00:00Z', ?)",
+                [remote_data_1.to_string()],
+            )
+            .unwrap();
+        db.kv_set("relay_short_BOXE", Some("dev-uuid-boxe"))
+            .unwrap();
+
+        let remote_data_2 = serde_json::json!({
+            "text": "remote message 2",
+            "_relay": {
+                "id": 42,
+                "short": "WAVE",
+                "device": "dev-uuid-wave"
+            }
+        });
+        db.conn()
+            .execute(
+                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (200, 'message', 'remote-2', '2026-09-04T00:00:00Z', ?)",
+                [remote_data_2.to_string()],
+            )
+            .unwrap();
+        db.kv_set("relay_short_WAVE", Some("dev-uuid-wave"))
+            .unwrap();
+
+        assert_eq!(resolve_reply_to_local(&db, "42:BOXE"), Some(100));
+        assert_eq!(resolve_reply_to_local(&db, "42:WAVE"), Some(200));
+
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_reply_to_unknown_device_fails_closed() {
+        let (db, path, _env) = setup_test_db();
+        let remote_data = serde_json::json!({
+            "text": "remote message",
+            "_relay": {
+                "id": 42,
+                "short": "BOXE",
+                "device": "dev-uuid-boxe"
+            }
+        });
+        db.conn()
+            .execute(
+                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-inst', '2026-09-04T00:00:00Z', ?)",
+                [remote_data.to_string()],
+            )
+            .unwrap();
+        db.kv_set("relay_short_BOXE", Some("dev-uuid-boxe"))
+            .unwrap();
+
+        assert_eq!(resolve_reply_to_local(&db, "42:NOPE"), None);
+
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_reply_to_duplicate_same_short_origin_fails_closed() {
+        let (db, path, _env) = setup_test_db();
+        let remote_data_1 = serde_json::json!({
+            "text": "remote message 1",
+            "_relay": {
+                "id": 42,
+                "short": "BOXE",
+                "device": "dev-uuid-boxe-1"
+            }
+        });
+        db.conn()
+            .execute(
+                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-1', '2026-09-04T00:00:00Z', ?)",
+                [remote_data_1.to_string()],
+            )
+            .unwrap();
+
+        // Duplicate imported event with same origin ID 42 and same device short BOXE
+        let remote_data_2 = serde_json::json!({
+            "text": "remote message 2",
+            "_relay": {
+                "id": 42,
+                "short": "BOXE",
+                "device": "dev-uuid-boxe-2"
+            }
+        });
+        db.conn()
+            .execute(
+                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (101, 'message', 'remote-2', '2026-09-04T00:00:00Z', ?)",
+                [remote_data_2.to_string()],
+            )
+            .unwrap();
+
+        // When multiple rows match (origin=42, short=BOXE), resolution must fail closed
+        assert_eq!(resolve_reply_to_local(&db, "42:BOXE"), None);
+
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_reply_to_malformed_tokens_fail_closed() {
+        let (db, path, _env) = setup_test_db();
+        let remote_data = serde_json::json!({
+            "text": "remote message",
+            "_relay": {
+                "id": 42,
+                "short": "BOXE",
+                "device": "dev-uuid-boxe"
+            }
+        });
+        db.conn()
+            .execute(
+                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-inst', '2026-09-04T00:00:00Z', ?)",
+                [remote_data.to_string()],
+            )
+            .unwrap();
+
+        assert_eq!(resolve_reply_to_local(&db, ""), None);
+        assert_eq!(resolve_reply_to_local(&db, "   "), None);
+        assert_eq!(resolve_reply_to_local(&db, "42:"), None);
+        assert_eq!(resolve_reply_to_local(&db, ":BOXE"), None);
+        assert_eq!(resolve_reply_to_local(&db, "42:BOXE:EXTRA"), None);
+        assert_eq!(resolve_reply_to_local(&db, "abc:BOXE"), None);
+        assert_eq!(resolve_reply_to_local(&db, "42:BO"), None); // Non-matching prefix fails closed
+
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_reply_to_local_only_unchanged() {
+        let (db, path, _env) = setup_test_db();
+        let local_data = serde_json::json!({ "text": "local message" });
+        db.conn()
+            .execute(
+                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (42, 'message', 'local-inst', '2026-09-04T00:00:00Z', ?)",
+                [local_data.to_string()],
+            )
+            .unwrap();
+
+        assert_eq!(resolve_reply_to_local(&db, "42"), Some(42));
+        assert_eq!(resolve_reply_to_local(&db, "999"), None);
+        assert_eq!(resolve_reply_to_local(&db, "notanumber"), None);
+
+        cleanup_test_db(path);
     }
 }

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -483,17 +483,15 @@ fn resolve_reply_to_local(db: &HcomDb, reply_to: &str) -> Option<i64> {
         return None;
     }
 
-    if let Some((origin_str, device_short)) = reply_to.split_once(':') {
-        if origin_str.is_empty() || device_short.is_empty() || device_short.contains(':') {
-            return None;
-        }
+    if let Some((origin_str, device_short)) = crate::relay::control::split_device_suffix(reply_to) {
         let origin_id: i64 = origin_str.parse().ok()?;
 
         let mut stmt = db
             .conn()
             .prepare(
                 "SELECT id FROM events WHERE type = 'message' \
-                 AND CAST(json_extract(data, '$._relay.id') AS INTEGER) = ? \
+                 AND json_type(data, '$._relay.id') = 'integer' \
+                 AND json_extract(data, '$._relay.id') = ? \
                  AND json_extract(data, '$._relay.short') = ? \
                  LIMIT 2",
             )
@@ -1764,26 +1762,52 @@ mod tests {
         assert_eq!(msg.as_deref(), Some("hello"));
     }
 
+    fn insert_imported_remote_message(
+        db: &HcomDb,
+        local_id: i64,
+        origin_id: serde_json::Value,
+        short: &str,
+        text: &str,
+        thread: Option<&str>,
+        intent: Option<&str>,
+    ) {
+        let relay_obj = serde_json::json!({
+            "id": origin_id,
+            "short": short,
+            "device": format!("dev-uuid-{short}"),
+        });
+        let mut data = serde_json::json!({
+            "from": format!("remote:{short}"),
+            "text": text,
+            "_relay": relay_obj,
+        });
+        if let Some(t) = thread {
+            data["thread"] = serde_json::json!(t);
+        }
+        if let Some(i) = intent {
+            data["intent"] = serde_json::json!(i);
+        }
+        db.conn()
+            .execute(
+                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (?, 'message', 'remote-inst', '2026-09-04T00:00:00Z', ?)",
+                rusqlite::params![local_id, data.to_string()],
+            )
+            .unwrap();
+    }
+
     #[test]
     #[serial]
     fn test_resolve_reply_to_remote_different_local_id() {
         let (db, path, _env) = setup_test_db();
-        let data = serde_json::json!({
-            "text": "remote message",
-            "_relay": {
-                "id": 42,
-                "short": "BOXE",
-                "device": "dev-uuid-boxe"
-            }
-        });
-        db.conn()
-            .execute(
-                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-inst', '2026-09-04T00:00:00Z', ?)",
-                [data.to_string()],
-            )
-            .unwrap();
-        db.kv_set("relay_short_BOXE", Some("dev-uuid-boxe"))
-            .unwrap();
+        insert_imported_remote_message(
+            &db,
+            100,
+            serde_json::json!(42),
+            "BOXE",
+            "remote msg",
+            None,
+            None,
+        );
 
         let resolved = resolve_reply_to_local(&db, "42:BOXE");
         assert_eq!(resolved, Some(100));
@@ -1803,22 +1827,15 @@ mod tests {
             )
             .unwrap();
 
-        let remote_data = serde_json::json!({
-            "text": "remote message",
-            "_relay": {
-                "id": 42,
-                "short": "BOXE",
-                "device": "dev-uuid-boxe"
-            }
-        });
-        db.conn()
-            .execute(
-                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-inst', '2026-09-04T00:00:00Z', ?)",
-                [remote_data.to_string()],
-            )
-            .unwrap();
-        db.kv_set("relay_short_BOXE", Some("dev-uuid-boxe"))
-            .unwrap();
+        insert_imported_remote_message(
+            &db,
+            100,
+            serde_json::json!(42),
+            "BOXE",
+            "remote msg",
+            None,
+            None,
+        );
 
         // 42:BOXE must resolve to the remote event (100), never the colliding local event (42)
         assert_eq!(resolve_reply_to_local(&db, "42:BOXE"), Some(100));
@@ -1832,39 +1849,24 @@ mod tests {
     #[serial]
     fn test_resolve_reply_to_two_devices_same_origin_id() {
         let (db, path, _env) = setup_test_db();
-        let remote_data_1 = serde_json::json!({
-            "text": "remote message 1",
-            "_relay": {
-                "id": 42,
-                "short": "BOXE",
-                "device": "dev-uuid-boxe"
-            }
-        });
-        db.conn()
-            .execute(
-                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-1', '2026-09-04T00:00:00Z', ?)",
-                [remote_data_1.to_string()],
-            )
-            .unwrap();
-        db.kv_set("relay_short_BOXE", Some("dev-uuid-boxe"))
-            .unwrap();
-
-        let remote_data_2 = serde_json::json!({
-            "text": "remote message 2",
-            "_relay": {
-                "id": 42,
-                "short": "WAVE",
-                "device": "dev-uuid-wave"
-            }
-        });
-        db.conn()
-            .execute(
-                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (200, 'message', 'remote-2', '2026-09-04T00:00:00Z', ?)",
-                [remote_data_2.to_string()],
-            )
-            .unwrap();
-        db.kv_set("relay_short_WAVE", Some("dev-uuid-wave"))
-            .unwrap();
+        insert_imported_remote_message(
+            &db,
+            100,
+            serde_json::json!(42),
+            "BOXE",
+            "msg 1",
+            None,
+            None,
+        );
+        insert_imported_remote_message(
+            &db,
+            200,
+            serde_json::json!(42),
+            "WAVE",
+            "msg 2",
+            None,
+            None,
+        );
 
         assert_eq!(resolve_reply_to_local(&db, "42:BOXE"), Some(100));
         assert_eq!(resolve_reply_to_local(&db, "42:WAVE"), Some(200));
@@ -1874,26 +1876,49 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_resolve_reply_to_unknown_device_fails_closed() {
+    fn test_resolve_reply_to_canonical_device_suffix_grammar() {
         let (db, path, _env) = setup_test_db();
-        let remote_data = serde_json::json!({
-            "text": "remote message",
-            "_relay": {
-                "id": 42,
-                "short": "BOXE",
-                "device": "dev-uuid-boxe"
-            }
-        });
-        db.conn()
-            .execute(
-                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-inst', '2026-09-04T00:00:00Z', ?)",
-                [remote_data.to_string()],
-            )
-            .unwrap();
-        db.kv_set("relay_short_BOXE", Some("dev-uuid-boxe"))
-            .unwrap();
+        insert_imported_remote_message(
+            &db,
+            100,
+            serde_json::json!(42),
+            "BOXE",
+            "remote msg",
+            None,
+            None,
+        );
 
+        // Exact 4-char uppercase ASCII succeeds
+        assert_eq!(resolve_reply_to_local(&db, "42:BOXE"), Some(100));
+
+        // Lowercase, mixed-case, prefixes, or non-4-char suffixes must fail closed
+        assert_eq!(resolve_reply_to_local(&db, "42:boxe"), None);
+        assert_eq!(resolve_reply_to_local(&db, "42:Boxe"), None);
+        assert_eq!(resolve_reply_to_local(&db, "42:BO"), None);
+        assert_eq!(resolve_reply_to_local(&db, "42:BOX"), None);
+        assert_eq!(resolve_reply_to_local(&db, "42:BOXES"), None);
         assert_eq!(resolve_reply_to_local(&db, "42:NOPE"), None);
+
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_reply_to_rejects_non_integer_json_id() {
+        let (db, path, _env) = setup_test_db();
+        // Origin ID stored as JSON string instead of JSON integer
+        insert_imported_remote_message(
+            &db,
+            100,
+            serde_json::json!("42"),
+            "BOXE",
+            "malformed",
+            None,
+            None,
+        );
+
+        // Must fail closed because json_type is not 'integer'
+        assert_eq!(resolve_reply_to_local(&db, "42:BOXE"), None);
 
         cleanup_test_db(path);
     }
@@ -1902,39 +1927,276 @@ mod tests {
     #[serial]
     fn test_resolve_reply_to_duplicate_same_short_origin_fails_closed() {
         let (db, path, _env) = setup_test_db();
-        let remote_data_1 = serde_json::json!({
-            "text": "remote message 1",
-            "_relay": {
-                "id": 42,
-                "short": "BOXE",
-                "device": "dev-uuid-boxe-1"
-            }
-        });
-        db.conn()
-            .execute(
-                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-1', '2026-09-04T00:00:00Z', ?)",
-                [remote_data_1.to_string()],
-            )
-            .unwrap();
+        insert_imported_remote_message(
+            &db,
+            100,
+            serde_json::json!(42),
+            "BOXE",
+            "msg 1",
+            None,
+            None,
+        );
+        insert_imported_remote_message(
+            &db,
+            101,
+            serde_json::json!(42),
+            "BOXE",
+            "msg 2",
+            None,
+            None,
+        );
 
-        // Duplicate imported event with same origin ID 42 and same device short BOXE
-        let remote_data_2 = serde_json::json!({
-            "text": "remote message 2",
-            "_relay": {
-                "id": 42,
-                "short": "BOXE",
-                "device": "dev-uuid-boxe-2"
-            }
-        });
-        db.conn()
-            .execute(
-                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (101, 'message', 'remote-2', '2026-09-04T00:00:00Z', ?)",
-                [remote_data_2.to_string()],
-            )
-            .unwrap();
-
-        // When multiple rows match (origin=42, short=BOXE), resolution must fail closed
+        // Multiple rows with origin=42 and short=BOXE must fail closed
         assert_eq!(resolve_reply_to_local(&db, "42:BOXE"), None);
+
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_cmd_send_remote_reply_inherits_thread_at_command_boundary() {
+        let (db, path, _env) = setup_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances (name, created_at) VALUES ('sender', 1000.0), ('target', 1000.0)",
+                [],
+            )
+            .unwrap();
+
+        // Remote request at local row 100 with origin 42 and thread "thread-remote-99"
+        insert_imported_remote_message(
+            &db,
+            100,
+            serde_json::json!(42),
+            "BOXE",
+            "remote req",
+            Some("thread-remote-99"),
+            Some("request"),
+        );
+
+        // Execute send through the full cmd_send entrypoint without specifying --thread
+        let mut args = SendArgs::try_parse_from([
+            "send",
+            "@target",
+            "--from",
+            "sender",
+            "--intent",
+            "ack",
+            "--reply-to",
+            "42:BOXE",
+            "--",
+            "pong message",
+        ])
+        .unwrap();
+        args.had_separator = true;
+
+        let exit_code = cmd_send(&db, &args, None);
+        assert_eq!(exit_code, 0, "cmd_send should succeed");
+
+        // Verify sent event data at command boundary
+        let (reply_to, reply_to_local, thread): (Option<String>, Option<i64>, Option<String>) = db
+            .conn()
+            .query_row(
+                "SELECT json_extract(data, '$.reply_to'), json_extract(data, '$.reply_to_local'), json_extract(data, '$.thread')
+                 FROM events WHERE type = 'message' AND id != 100 ORDER BY id DESC LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+
+        assert_eq!(reply_to.as_deref(), Some("42:BOXE"));
+        assert_eq!(reply_to_local, Some(100));
+        assert_eq!(thread.as_deref(), Some("thread-remote-99"));
+
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_cmd_send_unresolved_remote_reply_exits_one() {
+        let (db, path, _env) = setup_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances (name, created_at) VALUES ('sender', 1000.0), ('target', 1000.0)",
+                [],
+            )
+            .unwrap();
+
+        insert_imported_remote_message(
+            &db,
+            100,
+            serde_json::json!(42),
+            "BOXE",
+            "remote req",
+            None,
+            None,
+        );
+
+        // Unknown device
+        let mut args_unknown = SendArgs::try_parse_from([
+            "send",
+            "@target",
+            "--from",
+            "sender",
+            "--reply-to",
+            "42:NOPE",
+            "--",
+            "hi",
+        ])
+        .unwrap();
+        args_unknown.had_separator = true;
+        assert_eq!(cmd_send(&db, &args_unknown, None), 1);
+
+        // Non-canonical lowercase device
+        let mut args_lower = SendArgs::try_parse_from([
+            "send",
+            "@target",
+            "--from",
+            "sender",
+            "--reply-to",
+            "42:boxe",
+            "--",
+            "hi",
+        ])
+        .unwrap();
+        args_lower.had_separator = true;
+        assert_eq!(cmd_send(&db, &args_lower, None), 1);
+
+        // Non-existent origin ID
+        let mut args_nonexistent = SendArgs::try_parse_from([
+            "send",
+            "@target",
+            "--from",
+            "sender",
+            "--reply-to",
+            "999:BOXE",
+            "--",
+            "hi",
+        ])
+        .unwrap();
+        args_nonexistent.had_separator = true;
+        assert_eq!(cmd_send(&db, &args_nonexistent, None), 1);
+
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_cmd_send_ambiguous_remote_reply_exits_one_and_emits_no_message() {
+        let (db, path, _env) = setup_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances (name, created_at) VALUES ('sender', 1000.0), ('target', 1000.0)",
+                [],
+            )
+            .unwrap();
+
+        // Two distinct local rows with identical origin ID (42) and short device ("BOXE")
+        insert_imported_remote_message(
+            &db,
+            101,
+            serde_json::json!(42),
+            "BOXE",
+            "remote msg 1",
+            None,
+            None,
+        );
+        insert_imported_remote_message(
+            &db,
+            102,
+            serde_json::json!(42),
+            "BOXE",
+            "remote msg 2",
+            None,
+            None,
+        );
+
+        let count_before: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))
+            .unwrap();
+
+        let mut args_ambiguous = SendArgs::try_parse_from([
+            "send",
+            "@target",
+            "--from",
+            "sender",
+            "--reply-to",
+            "42:BOXE",
+            "--",
+            "hi",
+        ])
+        .unwrap();
+        args_ambiguous.had_separator = true;
+
+        assert_eq!(cmd_send(&db, &args_ambiguous, None), 1);
+
+        let count_after: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count_before, count_after);
+
+        cleanup_test_db(path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_send_message_remote_ack_loop_prevention_with_differing_ids() {
+        let (db, path, _env) = setup_test_db();
+        db.conn()
+            .execute(
+                "INSERT INTO instances (name, created_at) VALUES ('luna', 1000.0)",
+                [],
+            )
+            .unwrap();
+
+        // 1. Remote inform: local id = 110, origin id = 10 (distinct IDs)
+        insert_imported_remote_message(
+            &db,
+            110,
+            serde_json::json!(10),
+            "BOXE",
+            "remote info",
+            None,
+            Some("inform"),
+        );
+
+        let sender = SenderIdentity {
+            kind: SenderKind::Instance,
+            name: "luna".into(),
+            instance_data: None,
+            session_id: None,
+        };
+
+        let ack_to_inform = MessageEnvelope {
+            intent: Some(crate::messages::MessageIntent::Ack),
+            reply_to: Some("10:BOXE".into()),
+            ..Default::default()
+        };
+
+        let err = send_message(&db, &sender, "ack", Some(&ack_to_inform), None).unwrap_err();
+        assert!(err.contains("Cannot ack an inform"));
+
+        // 2. Remote ack: local id = 120, origin id = 20 (distinct IDs)
+        insert_imported_remote_message(
+            &db,
+            120,
+            serde_json::json!(20),
+            "BOXE",
+            "remote ack",
+            None,
+            Some("ack"),
+        );
+
+        let ack_to_ack = MessageEnvelope {
+            intent: Some(crate::messages::MessageIntent::Ack),
+            reply_to: Some("20:BOXE".into()),
+            ..Default::default()
+        };
+
+        let err = send_message(&db, &sender, "ack", Some(&ack_to_ack), None).unwrap_err();
+        assert!(err.contains("Ack-on-ack loop detected"));
 
         cleanup_test_db(path);
     }
@@ -1943,20 +2205,15 @@ mod tests {
     #[serial]
     fn test_resolve_reply_to_malformed_tokens_fail_closed() {
         let (db, path, _env) = setup_test_db();
-        let remote_data = serde_json::json!({
-            "text": "remote message",
-            "_relay": {
-                "id": 42,
-                "short": "BOXE",
-                "device": "dev-uuid-boxe"
-            }
-        });
-        db.conn()
-            .execute(
-                "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote-inst', '2026-09-04T00:00:00Z', ?)",
-                [remote_data.to_string()],
-            )
-            .unwrap();
+        insert_imported_remote_message(
+            &db,
+            100,
+            serde_json::json!(42),
+            "BOXE",
+            "remote msg",
+            None,
+            None,
+        );
 
         assert_eq!(resolve_reply_to_local(&db, ""), None);
         assert_eq!(resolve_reply_to_local(&db, "   "), None);
@@ -1964,7 +2221,6 @@ mod tests {
         assert_eq!(resolve_reply_to_local(&db, ":BOXE"), None);
         assert_eq!(resolve_reply_to_local(&db, "42:BOXE:EXTRA"), None);
         assert_eq!(resolve_reply_to_local(&db, "abc:BOXE"), None);
-        assert_eq!(resolve_reply_to_local(&db, "42:BO"), None); // Non-matching prefix fails closed
 
         cleanup_test_db(path);
     }

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -2032,6 +2032,11 @@ mod tests {
             None,
         );
 
+        let count_before: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))
+            .unwrap();
+
         // Unknown device
         let mut args_unknown = SendArgs::try_parse_from([
             "send",
@@ -2076,6 +2081,12 @@ mod tests {
         .unwrap();
         args_nonexistent.had_separator = true;
         assert_eq!(cmd_send(&db, &args_nonexistent, None), 1);
+
+        let count_after: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count_before, count_after);
 
         cleanup_test_db(path);
     }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -361,6 +361,74 @@ fn intent_and_reply_to_roundtrip() {
 }
 
 #[test]
+fn remote_reply_to_origin_resolves_imported_event_row() {
+    let h = Hcom::new();
+    let a = h.start();
+    let b = h.start();
+
+    // Direct SQLite access to seed colliding local event and imported remote event
+    let conn = rusqlite::Connection::open(h.hcom_dir.join("hcom.db")).expect("open hcom db");
+
+    // Colliding local message at id = 42
+    let local_data = serde_json::json!({
+        "from": a,
+        "text": "colliding local message",
+        "intent": "request"
+    });
+    conn.execute(
+        "INSERT INTO events (id, type, instance, timestamp, data) VALUES (42, 'message', ?1, '2026-09-04T00:00:00Z', ?2)",
+        rusqlite::params![a, local_data.to_string()],
+    )
+    .expect("insert colliding local event");
+
+    // Imported relay message at id = 100 with origin 42 and device short BOXE
+    let remote_data = serde_json::json!({
+        "from": "remote:BOXE",
+        "text": "remote request",
+        "intent": "request",
+        "_relay": {
+            "id": 42,
+            "short": "BOXE",
+            "device": "dev-uuid-boxe"
+        }
+    });
+    conn.execute(
+        "INSERT INTO events (id, type, instance, timestamp, data) VALUES (100, 'message', 'remote:BOXE', '2026-09-04T00:00:01Z', ?1)",
+        rusqlite::params![remote_data.to_string()],
+    )
+    .expect("insert remote imported event");
+
+    // Reply using remote token 42:BOXE
+    let (c, _, e) = h.run([
+        "send",
+        &format!("@{a}"),
+        "--name",
+        &b,
+        "--intent",
+        "ack",
+        "--reply-to",
+        "42:BOXE",
+        "--",
+        "pong",
+    ]);
+    assert_eq!(c, 0, "ack send with remote reply-to failed: stderr={e}");
+
+    let (_, ack_out, _) = h.run(["events", "--intent", "ack", "--last", "5", "--full"]);
+    let ack: serde_json::Value = ack_out
+        .lines()
+        .find_map(|l| serde_json::from_str(l).ok())
+        .expect("ack event present");
+
+    assert_eq!(ack["data"]["intent"], "ack");
+    assert_eq!(ack["data"]["reply_to"], "42:BOXE");
+    assert_eq!(
+        ack["data"]["reply_to_local"].as_i64(),
+        Some(100),
+        "reply_to_local must resolve to imported event id 100, not colliding local id 42; ack={ack}"
+    );
+}
+
+#[test]
 fn lifecycle_events_emitted_for_start_and_stop() {
     // Wiki contract (agent-lifecycle.md + event-model.md): start emits
     // life.started, stop emits life.stopped — filterable via --action.


### PR DESCRIPTION
## Summary

- resolve remote `--reply-to <origin>:<SHORT>` tokens against imported relay metadata instead of unrelated local event IDs
- enforce the canonical four-character uppercase device suffix and strict integer origin metadata, failing closed on missing or ambiguous matches
- cover local-ID collisions, device ambiguity, command effects, thread inheritance, ack-loop protection, and the end-to-end CLI path

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (2184 passed, 1 ignored; CLI smoke 24 passed)
- focused final-SHA proof: unresolved command effect 1/1, resolver 8/8, remote CLI smoke 1/1
- independent Codex Terra/Medium adversarial rereview: PASS, no P0-P3 findings

Fixes #124
