### PR TITLE
fix(windows): handle live database connection during reset archive

### DIFF
--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -23,12 +23,12 @@ pub struct ResetArgs {
     pub target: Option<ResetTarget>,
 }
 
-pub fn cmd_reset(db: &HcomDb, args: &ResetArgs, ctx: Option<&CommandContext>) -> i32 {
+pub fn cmd_reset(db: HcomDb, args: &ResetArgs, ctx: Option<&CommandContext>) -> i32 {
     let target = args.target;
 
     // Confirmation gate: inside AI tools, require --go
     if is_inside_ai_tool() && !ctx.map(|c| c.go).unwrap_or(false) {
-        super::reset_preview::print_reset_preview(target, db);
+        super::reset_preview::print_reset_preview(target, &db);
         return 0;
     }
 
@@ -43,7 +43,7 @@ pub fn cmd_reset(db: &HcomDb, args: &ResetArgs, ctx: Option<&CommandContext>) ->
     let stop_args = crate::commands::stop::StopArgs {
         targets: vec!["all".into()],
     };
-    exit_codes.push(crate::commands::stop::cmd_stop(db, &stop_args, ctx));
+    exit_codes.push(crate::commands::stop::cmd_stop(&db, &stop_args, ctx));
 
     // Stop relay daemon if running before clear
     let _ = crate::commands::daemon::daemon_stop();
@@ -51,11 +51,15 @@ pub fn cmd_reset(db: &HcomDb, args: &ResetArgs, ctx: Option<&CommandContext>) ->
     // Clean temp files
     super::reset_ops::clean_temp_files();
 
+    // Explicitly release command-owned database connection before archive/clear.
+    // On Windows, SQLite's open file handle prevents deleting hcom.db, hcom.db-wal, and hcom.db-shm.
+    drop(db);
+
     // Archive and clear database
     let archive_exit =
         super::reset_ops::print_archive_result(super::reset_ops::archive_and_clear_db());
     if archive_exit != 0 {
-        exit_codes.push(archive_exit);
+        return archive_exit;
     }
 
     // For reset all: clear pidtrack before recovery can trigger

--- a/src/commands/reset_ops.rs
+++ b/src/commands/reset_ops.rs
@@ -246,4 +246,64 @@ mod tests {
         assert!(err.contains("could not remove"));
         assert!(err.contains("Stop other hcom processes"));
     }
+
+    #[cfg(windows)]
+    #[test]
+    #[serial_test::serial]
+    fn test_windows_reset_archive_handles_command_owned_live_connection() {
+        let (_tmp, hcom_dir, _home, _guard) = crate::hooks::test_helpers::isolated_test_env();
+
+        let db = HcomDb::open().expect("failed to open test database");
+        db.conn()
+            .execute(
+                "INSERT INTO events (timestamp, type, instance, data) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![
+                    "2026-09-04T00:00:00Z",
+                    "message",
+                    "test_instance",
+                    "{\"content\":\"test\"}"
+                ],
+            )
+            .expect("failed to insert test event");
+
+        let wal_path = hcom_dir.join("hcom.db-wal");
+        assert!(
+            wal_path.exists(),
+            "expected non-empty WAL database with active WAL sidecar"
+        );
+
+        // While the command-owned/live connection `db` remains open, attempt archive and clear.
+        // On Windows, SQLite holds an open handle preventing deletion.
+        let archive_result = archive_and_clear_db();
+
+        // When deletion fails due to the open handle, verify that the original
+        // database is not left in a partially deleted or corrupted state, and remains queryable.
+        if archive_result.is_err() {
+            let db_path = hcom_dir.join("hcom.db");
+            assert!(
+                db_path.exists(),
+                "original database file must remain present when deletion fails"
+            );
+            let fresh_conn = rusqlite::Connection::open(&db_path).expect(
+                "on-disk database must remain openable via fresh connection when deletion fails",
+            );
+            let event_count: i64 = fresh_conn
+                .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+                .expect("original on-disk database must remain readable when deletion fails");
+            assert_eq!(
+                event_count, 1,
+                "original database content must remain intact when deletion fails"
+            );
+        }
+
+        // Live connection must not prevent safe reset/archive.
+        // On Windows prior to fix, this fails (RED) because remove_database_files cannot
+        // remove the active database and WAL files while the connection handle is open.
+        let archive_path = archive_result
+            .expect("live command-owned database handle must not prevent safe reset/archive");
+        assert!(
+            archive_path.is_some(),
+            "expected non-empty database to be archived"
+        );
+    }
 }

--- a/src/commands/reset_ops.rs
+++ b/src/commands/reset_ops.rs
@@ -343,14 +343,39 @@ mod tests {
         let reset_event_count: i64 = fresh_db
             .conn()
             .query_row(
-                "SELECT COUNT(*) FROM events WHERE type = 'reset'",
+                "SELECT COUNT(*) FROM events WHERE type = 'life' AND instance = '_device'",
                 [],
                 |r| r.get(0),
             )
-            .expect("must query reset event");
+            .expect("must query life/_device reset event");
         assert_eq!(
             reset_event_count, 1,
-            "fresh database must contain initial reset event"
+            "fresh database must contain initial life/_device reset event"
+        );
+
+        let reset_data_raw: String = fresh_db
+            .conn()
+            .query_row(
+                "SELECT data FROM events WHERE type = 'life' AND instance = '_device' ORDER BY id DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .expect("must query reset event data");
+        let reset_data: serde_json::Value =
+            serde_json::from_str(&reset_data_raw).expect("reset event data must be valid JSON");
+        assert_eq!(
+            reset_data.get("action").and_then(|v| v.as_str()),
+            Some("reset"),
+            "life/_device event action must be 'reset'"
+        );
+
+        let relay_reset_ts = fresh_db
+            .kv_get("relay_local_reset_ts")
+            .expect("must query relay_local_reset_ts")
+            .expect("relay_local_reset_ts must be present after reset");
+        assert!(
+            !relay_reset_ts.trim().is_empty(),
+            "relay_local_reset_ts must not be empty"
         );
     }
 

--- a/src/commands/reset_ops.rs
+++ b/src/commands/reset_ops.rs
@@ -272,38 +272,209 @@ mod tests {
             "expected non-empty WAL database with active WAL sidecar"
         );
 
-        // While the command-owned/live connection `db` remains open, attempt archive and clear.
-        // On Windows, SQLite holds an open handle preventing deletion.
-        let archive_result = archive_and_clear_db();
-
-        // When deletion fails due to the open handle, verify that the original
-        // database is not left in a partially deleted or corrupted state, and remains queryable.
-        if archive_result.is_err() {
-            let db_path = hcom_dir.join("hcom.db");
-            assert!(
-                db_path.exists(),
-                "original database file must remain present when deletion fails"
-            );
-            let fresh_conn = rusqlite::Connection::open(&db_path).expect(
-                "on-disk database must remain openable via fresh connection when deletion fails",
-            );
-            let event_count: i64 = fresh_conn
-                .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
-                .expect("original on-disk database must remain readable when deletion fails");
-            assert_eq!(
-                event_count, 1,
-                "original database content must remain intact when deletion fails"
-            );
-        }
-
-        // Live connection must not prevent safe reset/archive.
-        // On Windows prior to fix, this fails (RED) because remove_database_files cannot
-        // remove the active database and WAL files while the connection handle is open.
-        let archive_path = archive_result
-            .expect("live command-owned database handle must not prevent safe reset/archive");
-        assert!(
-            archive_path.is_some(),
-            "expected non-empty database to be archived"
+        // Command-owned handle flow: cmd_reset takes ownership of `db`, releases it,
+        // archives and clears the database, and bootstraps a fresh database.
+        let ctx = crate::shared::CommandContext {
+            explicit_name: None,
+            identity: None,
+            go: true,
+        };
+        let reset_args = crate::commands::reset::ResetArgs { target: None };
+        let exit_code = crate::commands::reset::cmd_reset(db, &reset_args, Some(&ctx));
+        assert_eq!(
+            exit_code, 0,
+            "cmd_reset must succeed when command-owned handle is released"
         );
+
+        // 1. Archive is produced and readable
+        let archive_base = hcom_dir.join("archive");
+        assert!(archive_base.exists(), "archive directory must exist");
+        let mut archived_sessions = std::fs::read_dir(&archive_base)
+            .expect("must read archive dir")
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .map(|n| n.starts_with("session-"))
+                    .unwrap_or(false)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            archived_sessions.len(),
+            1,
+            "expected exactly one archived session directory"
+        );
+        let session_dir = archived_sessions.pop().unwrap().path();
+        let archived_db_path = session_dir.join("hcom.db");
+        assert!(
+            archived_db_path.exists(),
+            "archived hcom.db file must exist"
+        );
+
+        // 2. Original event exists in archive
+        let archive_conn = rusqlite::Connection::open(&archived_db_path)
+            .expect("archived database must be queryable");
+        let archived_event_count: i64 = archive_conn
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE type = 'message' AND instance = 'test_instance'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("must query archived events");
+        assert_eq!(
+            archived_event_count, 1,
+            "archived database must contain original event"
+        );
+
+        // 3. Fresh active DB can be initialized after reset
+        let fresh_db = HcomDb::open().expect("must open fresh database after reset");
+        let fresh_message_count: i64 = fresh_db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE type = 'message'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("must query fresh events");
+        assert_eq!(
+            fresh_message_count, 0,
+            "fresh database must have cleared previous messages"
+        );
+        let reset_event_count: i64 = fresh_db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE type = 'reset'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("must query reset event");
+        assert_eq!(
+            reset_event_count, 1,
+            "fresh database must contain initial reset event"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[serial_test::serial]
+    fn test_windows_reset_fails_safely_on_external_live_handle() {
+        let (_tmp, hcom_dir, _home, _guard) = crate::hooks::test_helpers::isolated_test_env();
+
+        let db = HcomDb::open().expect("failed to open test database");
+        db.conn()
+            .execute(
+                "INSERT INTO events (timestamp, type, instance, data) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![
+                    "2026-09-04T00:00:00Z",
+                    "message",
+                    "external_instance",
+                    "{\"content\":\"external\"}"
+                ],
+            )
+            .expect("failed to insert test event");
+
+        let db_path = hcom_dir.join("hcom.db");
+
+        // Simulate an uncooperative external process holding an open SQLite connection
+        let external_conn =
+            rusqlite::Connection::open(&db_path).expect("failed to open external connection");
+        let pre_event_count: i64 = external_conn
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE type = 'message'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("external connection must read initial state");
+        assert_eq!(
+            pre_event_count, 1,
+            "external connection must participate in current DB/WAL state"
+        );
+
+        let ctx = crate::shared::CommandContext {
+            explicit_name: None,
+            identity: None,
+            go: true,
+        };
+        let reset_args = crate::commands::reset::ResetArgs { target: None };
+        let exit_code = crate::commands::reset::cmd_reset(db, &reset_args, Some(&ctx));
+        assert_ne!(
+            exit_code, 0,
+            "reset must fail when external process holds open handle"
+        );
+
+        // Verify original database file remains present and queryable through the external handle
+        assert!(
+            db_path.exists(),
+            "original database file must remain present when external handle blocks reset"
+        );
+        let event_count: i64 = external_conn
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE type = 'message'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("original database must remain readable through external connection");
+        assert_eq!(
+            event_count, 1,
+            "original database content must remain intact and not mutated by reset failure"
+        );
+
+        // Also independently verify through a fresh connection that on-disk DB is uncorrupted
+        let fresh_conn = rusqlite::Connection::open(&db_path)
+            .expect("failed to open fresh connection to original db");
+        let fresh_count: i64 = fresh_conn
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE type = 'message'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("fresh connection must read preserved original events");
+        assert_eq!(
+            fresh_count, 1,
+            "original database on disk must remain queryable with message count = 1"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn test_unix_reset_handles_command_owned_connection() {
+        let (_tmp, hcom_dir, _home, _guard) = crate::hooks::test_helpers::isolated_test_env();
+
+        let db = HcomDb::open().expect("failed to open test database");
+        db.conn()
+            .execute(
+                "INSERT INTO events (timestamp, type, instance, data) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![
+                    "2026-09-04T00:00:00Z",
+                    "message",
+                    "test_instance",
+                    "{\"content\":\"test\"}"
+                ],
+            )
+            .expect("failed to insert test event");
+
+        let ctx = crate::shared::CommandContext {
+            explicit_name: None,
+            identity: None,
+            go: true,
+        };
+        let reset_args = crate::commands::reset::ResetArgs { target: None };
+        let exit_code = crate::commands::reset::cmd_reset(db, &reset_args, Some(&ctx));
+        assert_eq!(exit_code, 0);
+
+        let archive_base = hcom_dir.join("archive");
+        assert!(archive_base.exists());
+
+        let fresh_db = HcomDb::open().expect("must open fresh database after reset");
+        let fresh_message_count: i64 = fresh_db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE type = 'message'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(fresh_message_count, 0);
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -862,9 +862,19 @@ fn dispatch_native_command(cmd: &str, args: &[String]) -> i32 {
             &cmd_argv,
             |args| crate::commands::archive::cmd_archive(&db, &args, Some(&ctx))
         ),
-        "reset" => clap_dispatch!(crate::commands::reset::ResetArgs, cmd, &cmd_argv, |args| {
-            crate::commands::reset::cmd_reset(&db, &args, Some(&ctx))
-        }),
+        "reset" => match clap_parse!(crate::commands::reset::ResetArgs, cmd, &cmd_argv) {
+            Ok(args) => return crate::commands::reset::cmd_reset(db, &args, Some(&ctx)),
+            Err(e) => {
+                e.print().ok();
+                let code = if e.use_stderr() { 1 } else { 0 };
+                if let Some(output) =
+                    crate::cli_context::maybe_deliver_pending_messages(&db, &ctx, has_json)
+                {
+                    print!("{output}");
+                }
+                return code;
+            }
+        },
         "hooks" => clap_dispatch!(crate::commands::hooks::HooksArgs, cmd, &cmd_argv, |args| {
             crate::commands::hooks::cmd_hooks(&db, &args, Some(&ctx))
         }),


### PR DESCRIPTION
## Purpose

Fix native-Windows reset/archive failures caused by the reset command retaining its SQLite connection while removing `hcom.db`, `hcom.db-wal`, and `hcom.db-shm`.

Refs #126.

## Root cause and fix

The native command router opened `HcomDb` and retained it while `cmd_reset` called the archive/removal path. Windows rejects removal of SQLite files with live handles.

The reset path now takes ownership of the command DB and explicitly drops it before archive/removal. Archive failure returns immediately, so reset cannot bootstrap a fresh DB or continue destructive cleanup after a failed removal. An independently held external connection still produces an explicit failure and preserved readable data.

## Native RED evidence

Before the production fix, native `windows-latest` run `33840069497`, job `100920386713`, failed exactly at `test_windows_reset_archive_handles_command_owned_live_connection` while removing `hcom.db-wal` with Windows `os error 32`; 2068 other tests passed.

## Coverage

- command-owned Windows handle is released and reset succeeds;
- archived DB is readable and contains the original event;
- fresh active DB contains no old messages and has the reset event;
- independent external Windows handle fails safely, with original data readable through both the live handle and a fresh connection;
- Unix ownership flow remains covered;
- reset parse/help/error retains normal pending-message delivery behavior.

## Local GREEN evidence

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --tests`
- focused reset/reset_ops tests: 3 passed on Linux
- `cargo clippy --all-targets -- -D warnings`

## Native GREEN evidence

- CI run `33842309936` completed successfully at head `faaa8da6db60c8be1a964093364a5ef3a1c24e42`.
- Native `windows-build` passed formatting, clippy, and `cargo test --all-targets --locked`.
- Both Windows reset tests passed.
- Main Windows suite: 2070 passed, 0 failed, 1 ignored; auxiliary suites also passed.

## Remaining lifecycle gates

- Upstream maintainer review and approval.
- Merge by the governing owner.
- Issue closure only after merge/readback.
